### PR TITLE
fix(auth): add dedicated auth endpoint and fix init/brute-force issues

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -417,6 +417,9 @@ function getSendFn(): ((data: string) => void) | null {
 
 function onLoginSuccess() {
   authenticated.value = true
+  void loadAll()
+  void connectSyncWS()
+  initMonitorHistory()
 }
 
 function shellEscapePath(path: string): string {
@@ -752,9 +755,11 @@ onMounted(() => {
   if (window.visualViewport) {
     window.visualViewport.addEventListener('resize', onViewportResize)
   }
-  void connectSyncWS()
-  initMonitorHistory()
-  void loadAll()
+  if (authenticated.value) {
+    void connectSyncWS()
+    initMonitorHistory()
+    void loadAll()
+  }
 })
 
 onBeforeUnmount(() => {

--- a/frontend/src/components/settings/GeneralTab.vue
+++ b/frontend/src/components/settings/GeneralTab.vue
@@ -125,7 +125,7 @@ import { useSettings } from '../../composables/useSettings'
 import { useI18n } from '../../composables/useI18n'
 import { themes } from '../../themes'
 import { copyToClipboard } from '../../utils/clipboard'
-import { apiUrl, authFetch, getAuthToken, clearAuthToken } from '../../composables/apiBase'
+import { apiUrl, authFetch, getAuthToken, setAuthToken } from '../../composables/apiBase'
 
 const { settings, applyCurrentTheme } = useSettings()
 const { t, themeLabel } = useI18n()
@@ -212,7 +212,7 @@ async function applyNewToken(token: string) {
       body: JSON.stringify({ token }),
     })
     if (res.ok) {
-      clearAuthToken()
+      setAuthToken(token)
       window.location.reload()
     } else {
       tokenError.value = t('settings.token.saveFailed')

--- a/frontend/src/composables/apiBase.ts
+++ b/frontend/src/composables/apiBase.ts
@@ -38,7 +38,8 @@ export function hasAuthToken(): boolean {
 export async function validateToken(token: string): Promise<boolean> {
   try {
     await getApiBase()
-    const res = await fetch(apiUrl('/api/settings'), {
+    const res = await fetch(apiUrl('/api/auth'), {
+      method: 'POST',
       headers: { Authorization: `Bearer ${token}` },
     })
     return res.ok

--- a/frontend/src/composables/useSettings.ts
+++ b/frontend/src/composables/useSettings.ts
@@ -1,6 +1,6 @@
 import { reactive } from 'vue'
 import { getThemeByName, applyThemeToDOM, getXtermTheme } from '../themes'
-import { getApiBase, apiUrl, authFetch } from './apiBase'
+import { getApiBase, apiUrl, authFetch, hasAuthToken } from './apiBase'
 export interface SettingsData {
   theme: {
     preset: string
@@ -183,6 +183,7 @@ export function useSettings() {
 }
 
 async function loadSettings() {
+  if (!hasAuthToken()) return
   try {
     await getApiBase()
     const res = await authFetch(apiUrl('/api/settings'))

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -42,12 +42,14 @@ pub async fn auth_middleware(
         return next.run(request).await;
     }
 
-    // IP whitelist check
-    {
+    // IP whitelist check — drop the lock before calling next.run() to avoid
+    // deadlocking when a write lock is requested later in the same task chain.
+    let whitelisted = {
         let s = settings.read().await;
-        if is_ip_whitelisted(client_ip, &s.ip_whitelist) {
-            return next.run(request).await;
-        }
+        is_ip_whitelisted(client_ip, &s.ip_whitelist)
+    };
+    if whitelisted {
+        return next.run(request).await;
     }
 
     // Brute-force lockout check
@@ -74,10 +76,14 @@ pub async fn auth_middleware(
         return next.run(request).await;
     }
 
-    // Record failure
-    let mut rec = map.entry(client_ip).or_insert(FailRecord { count: 0, last_fail: Instant::now() });
-    rec.count += 1;
-    rec.last_fail = Instant::now();
+    // Only count failures from the login endpoint — other endpoints return 401
+    // without incrementing the counter, so normal pre-auth API calls (settings,
+    // plugins, etc.) don't accidentally trigger the lockout.
+    if path == "/api/auth" {
+        let mut rec = map.entry(client_ip).or_insert(FailRecord { count: 0, last_fail: Instant::now() });
+        rec.count += 1;
+        rec.last_fail = Instant::now();
+    }
 
     Response::builder()
         .status(StatusCode::UNAUTHORIZED)

--- a/src/main.rs
+++ b/src/main.rs
@@ -198,6 +198,11 @@ struct UpdateTokenRequest {
     token: String,
 }
 
+async fn check_auth(State(state): State<AppState>) -> impl IntoResponse {
+    let _ = state;
+    StatusCode::OK
+}
+
 async fn update_token(
     State(state): State<AppState>,
     Json(body): Json<UpdateTokenRequest>,
@@ -279,6 +284,7 @@ async fn main() {
         .route("/ws/notify", get(ws::notification_ws_handler))
         .route("/api/notify", post(notification::post_notify))
         .route("/api/input", post(ws::post_input))
+        .route("/api/auth", post(check_auth))
         .route("/api/settings", get(settings::get_settings).put(settings::put_settings))
         .route("/api/settings/background", post(settings::upload_background).get(settings::get_background))
         .route("/api/workspace/resolve", get(workspace::workspace_resolve))


### PR DESCRIPTION
## Summary

- Add `POST /api/auth` endpoint for token validation
- Defer app initialization (`loadAll`, `connectSyncWS`, etc.) until after authentication
- Fix token update flow: store new token locally instead of clearing it
- Guard `loadSettings()` with `hasAuthToken()` to prevent unauthenticated requests
- Release settings read lock before `next.run()` to avoid potential deadlock
- Only increment brute-force counter on `/api/auth`, not all 401 responses

## Test plan

- [ ] Login with valid token → app initializes correctly
- [ ] Login with invalid token → brute-force counter increments only on `/api/auth`
- [ ] Update token in settings → new token persisted, page reloads with new auth
- [ ] IP whitelisted client → no deadlock under concurrent requests