### PR TITLE
fix(TabBar): close plugin dropdown on outside touch on mobile

### DIFF
--- a/frontend/src/components/terminal/TabBar.vue
+++ b/frontend/src/components/terminal/TabBar.vue
@@ -21,7 +21,7 @@
       </div>
     </div>
     <button id="tab-new-btn" title="New Tab (⌘T)" @click="$emit('new')" @touchend.prevent="$emit('new')"><Terminal :size="16" /></button>
-    <div v-if="plugins.length > 0" class="tab-bar-plugin-wrap">
+    <div v-if="plugins.length > 0" class="tab-bar-plugin-wrap" ref="pluginWrapRef">
       <button type="button" class="tab-bar-icon-btn" title="Plugins" @click="pluginMenuOpen = !pluginMenuOpen" @touchend.prevent="pluginMenuOpen = !pluginMenuOpen"><Blocks :size="16" /></button>
       <div v-if="pluginMenuOpen" class="plugin-dropdown" @mouseleave="pluginMenuOpen = false">
         <div
@@ -41,7 +41,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, watch, onBeforeUnmount } from 'vue'
 import { X, Terminal, Blocks } from 'lucide-vue-next'
 
 export interface TabInfo {
@@ -76,6 +76,26 @@ const emit = defineEmits<{
 }>()
 
 const pluginMenuOpen = ref(false)
+const pluginWrapRef = ref<HTMLElement>()
+
+function onDocTouchStart(e: TouchEvent) {
+  if (pluginWrapRef.value && !pluginWrapRef.value.contains(e.target as Node)) {
+    pluginMenuOpen.value = false
+  }
+}
+
+watch(pluginMenuOpen, (open) => {
+  if (open) {
+    document.addEventListener('touchstart', onDocTouchStart, { passive: true })
+  } else {
+    document.removeEventListener('touchstart', onDocTouchStart)
+  }
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('touchstart', onDocTouchStart)
+})
+
 const dragFromId = ref<string | null>(null)
 const dragOverId = ref<string | null>(null)
 


### PR DESCRIPTION
## Summary
- Add document-level `touchstart` listener to dismiss the plugin dropdown when tapping outside the plugin wrap element on mobile
- Listener is lazily attached/removed via `watch` to avoid unnecessary overhead
- Cleaned up in `onBeforeUnmount` to prevent memory leaks

## Test plan
- [ ] Open plugin dropdown on mobile/touch device
- [ ] Tap outside the dropdown — should close
- [ ] Tap inside the dropdown — should stay open
- [ ] Unmount component — verify no listener remains