### PR TITLE
fix(build): use CARGO_PKG_VERSION as primary version source

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -18,16 +18,16 @@ fn rerun_if_dist_contents(dir: &Path) {
 }
 
 fn main() {
-    // Use DINOTTY_VERSION env var if set, otherwise fall back to latest git tag
-    if let Ok(ver) = std::env::var("DINOTTY_VERSION") {
-        println!("cargo:rustc-env=DINOTTY_VERSION={}", ver);
-    } else if let Ok(output) = std::process::Command::new("git")
-        .args(["describe", "--tags", "--abbrev=0"])
-        .output()
-    {
-        if output.status.success() {
-            let tag = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            println!("cargo:rustc-env=DINOTTY_VERSION={}", tag);
+    // DINOTTY_VERSION env var > CARGO_PKG_VERSION > git tag
+    if std::env::var("DINOTTY_VERSION").is_err() {
+        if let Ok(output) = std::process::Command::new("git")
+            .args(["describe", "--tags", "--abbrev=0"])
+            .output()
+        {
+            if output.status.success() {
+                let tag = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                println!("cargo:rustc-env=DINOTTY_VERSION={}", tag);
+            }
         }
     }
     println!("cargo:rerun-if-changed=.git/refs/tags");


### PR DESCRIPTION
## Summary

- Fix version display showing v0.8.2 instead of v0.9.0
- git describe only finds tags reachable from current branch, causing mismatch when tag is on main
- Use CARGO_PKG_VERSION as fallback when no reachable git tag is found

## Test plan

- [ ] Build and verify About tab shows correct version