### PR TITLE
feat: docs restructure, auto-focus fix, and first-time setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,6 +936,7 @@ dependencies = [
  "local-ip-address",
  "mime_guess",
  "portable-pty",
+ "reqwest 0.12.28",
  "rust-embed",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["src-tauri"]
 
 [package]
 name = "dinotty-server"
-version = "0.8.2"
+version = "0.9.0"
 edition = "2021"
 build = "build.rs"
 repository = "https://github.com/xichan96/dinotty"

--- a/README.en.md
+++ b/README.en.md
@@ -30,27 +30,14 @@ A **mobile-first** terminal server purpose-built for **coding agents**. Run Clau
 
 ## Why Dinotty?
 
-Terminal-based coding agents (Claude Code, opencode, Codex, OpenClaw, etc.) are powerful, but they are tethered to your desktop. What if you could:
+Terminal-based coding agents (Claude Code, opencode, Codex, OpenClaw, etc.) are powerful, but they are tethered to your desktop. Dinotty lets you:
 
 - **Kick off a coding task from your phone** while waiting in line, commuting, or walking around
 - **Check on a long-running agent** without pulling out your laptop
-- **Review and verify agent output** — code diffs, rendered pages, generated files — right from the browser on your phone
-- **Never lose your session** — put your phone to sleep, switch apps, lose signal in the subway — come back and everything is exactly where you left it
-
-Dinotty is designed for this. It's a mobile-first web terminal that gives you the **full desktop coding agent experience on any device with a browser**.
-
-### Mobile-First, Desktop-Complete
-
-The interface adapts to your device:
-
-- **Responsive layout** — portrait mode stacks terminal and preview vertically; landscape mode places them side-by-side, just like a desktop IDE
-- **Touch-optimized** — touch scrolling in terminal viewport, touch-friendly buttons, touch-aware pane resizing
-- **Customizable shortcut keyboard** — mobile devices lack Ctrl, Esc, and function keys; Dinotty provides a fully customizable shortcut bar where you can define buttons for any key combination or escape sequence
-- **Same agent experience** — Claude Code, opencode, Codex, OpenClaw all work identically on mobile and desktop; the terminal doesn't know the difference
+- **Review and verify agent output** — code diffs, rendered pages, generated files — right from your phone's browser
+- **Never lose your session** — put your phone to sleep, switch apps, lose signal — come back and everything is exactly where you left it
 
 ### Lightweight — Not a Remote Desktop
-
-You might think: "Why not just VNC / RDP / screen share into my desktop?" You can, but:
 
 | | Dinotty | Remote Desktop (VNC/RDP/Parsec) |
 |---|---|---|
@@ -62,217 +49,39 @@ You might think: "Why not just VNC / RDP / screen share into my desktop?" You ca
 | **Resolution adaptation** | Native text at any size | Scaled bitmap, blurry on phone |
 | **Interaction** | Native touch, custom keyboard | Simulated mouse, tiny desktop UI |
 
-Remote desktop streams the entire screen as video — even when nothing changes. Dinotty only transmits **the text that actually changed**, making it orders of magnitude more efficient. On a spotty mobile connection, the difference between a few KB of JSON and a continuous video stream is the difference between usable and unusable.
+## Key Features
 
-### Virtual Terminal (VT Screen)
-
-The backend maintains a full **virtual terminal emulator** (`vt_screen.rs`, 600+ lines) that parses the PTY output in real time using the VTE state machine. Every character, every escape sequence, every cursor movement is tracked server-side. This means:
-
-- The server always knows the exact screen state — not just raw bytes, but a structured grid of characters with attributes (colors, bold, italic, etc.)
-- Scrollback history is preserved server-side in a ring buffer
-- Screen snapshots can be generated on demand as ANSI-encoded text
-
-### Session Persistence & Auto-Reconnect
-
-Sessions survive network disconnections. When a client reconnects:
-
-1. The PTY process keeps running on the server — nothing is interrupted
-2. The server replays the scrollback history in chunks, then sends the current screen snapshot
-3. The client terminal is restored to the exact state before disconnection
-
-The frontend implements **automatic reconnection** with exponential backoff (1s → 30s cap). Alternatively, simply refreshing the browser page restores the full session — no need to restart processes or recreate terminals.
-
-### Multi-Pane Sync
-
-Multiple panes are managed via `SessionManager` with a `DashMap` of pane-id → PTY. A dedicated `/ws/sync` WebSocket keeps all connected clients in sync on tab state, so you can open the same server from multiple browser windows.
-
-### Customizable Shortcut Keyboard
-
-Mobile devices lack the Ctrl, Esc, Alt, and function keys that terminals depend on. Dinotty provides a **fully customizable shortcut keyboard** that solves this:
-
-- **Action panel** — one-tap buttons for Ctrl+C, Ctrl+D, Escape, Tab, and other terminal essentials out of the box
-- **Fully customizable** — add, remove, and reorder shortcut buttons in Settings; each button has a custom label and can send arbitrary raw escape sequences
-- **Send anything** — configure a button to send any key combination or escape sequence (e.g., `\x03` for Ctrl+C, `\x1b[A` for arrow up), so you can build your own shortcut bar for any workflow
-- **Modifier state tracking** — sticky Ctrl/Alt/Shift modifiers that work with the full keyboard layout
-- Complete key layout with all printable characters, function keys (F1–F12), and a dedicated arrow key cluster
-
-### Built-in File & Web Browser
-
-Coding agents generate code, documents, and web pages — but verifying the output usually means switching to a separate file manager or browser. Dinotty embeds both directly alongside the terminal:
-
-- **File workspace** — tree-view file browser with file listing, upload, rename, and delete. Click any file to preview it instantly
-- **Code editor** — Monaco Editor-based code editor with syntax highlighting and auto-completion
-- **Git change indicators** — gutter decorations show added (green), modified (blue), and deleted (red) lines; click to open an inline diff viewer with Stage/Revert per hunk; file tree displays M/U/A/D badges with color coding
-- **Markdown preview** — live-rendered Markdown with sanitized HTML (marked + DOMPurify)
-- **Office documents** — preview Word, Excel, PowerPoint files directly in the browser (officeparser)
-- **Media playback** — built-in audio/video player with seek, volume, and playback controls
-- **Image preview** — inline image rendering for common formats
-- **Web preview** — enter a URL or local port number and browse it in an embedded iframe; a built-in reverse proxy (`/preview/:port/*`) routes to local dev servers, so you can see your app running without leaving the terminal
-- **Address bar** — type a URL or port to navigate, with auto-detection of web vs. file preview
-
-This means an agent can `npm run dev`, write code, and the user can immediately verify the results — all within a single browser tab.
+- **Server-side virtual terminal** — full VTE parser, server knows exact screen state, enables session recovery & screen snapshots
+- **Session persistence** — PTY processes survive disconnection, auto-reconnect with exponential backoff, refresh page to restore
+- **Responsive layout** — portrait stacks vertically, landscape side-by-side; touch-optimized buttons & pane resizing
+- **Customizable shortcut keyboard** — add Ctrl/Esc/function keys for mobile, supports arbitrary escape sequences
+- **Built-in file browser** — code highlighting, Markdown rendering, Office document preview, audio/video playback
+- **Git change indicators** — gutter marks for added/modified/deleted lines, inline diff, Stage/Revert
+- **Web preview** — built-in reverse proxy to preview local dev servers in iframe
+- **Notification system** — terminal bell/OSC detection, WebSocket push, configurable sound alerts
+- **System monitor** — real-time CPU/memory/network charts
+- **Plugin system** — JS plugins + CLI bridge, hot-reload; ships with CC Switch, JSON Formatter, etc.
+- **Open API** — HTTP endpoint for external device control (Stream Deck, Shortcuts, automation scripts)
+- **Command palette** — quick-access command launcher
+- **Desktop app** — optional Tauri-based native client
 
 ## Comparison with Other Terminals
 
-| Capability | Dinotty | ttyd | gotty | Wetty | Traditional terminal (iTerm2, etc.) |
-|---|---|---|---|---|---|
-| Server-side virtual terminal (VT Screen) | ✅ Full VTE parser, server knows screen state | ❌ | ❌ | ❌ | N/A |
-| Session survives network disconnect | ✅ Auto-reconnect + screen restore | ❌ Session lost | ❌ Session lost | ❌ Session lost | Needs tmux/screen |
-| Refresh page = restore session | ✅ Scrollback + screen snapshot replayed | ❌ New session | ❌ New session | ❌ New session | N/A |
-| Built-in file browser & preview | ✅ Code, Markdown, Office, image, audio/video | ❌ | ❌ | ❌ | ❌ |
-| Git change indicators | ✅ Gutter marks + inline diff + Stage/Revert | ❌ | ❌ | ❌ | ❌ |
-| Built-in web preview (reverse proxy) | ✅ Embed local dev server in iframe | ❌ | ❌ | ❌ | ❌ |
-| File change watching | ✅ Real-time via WebSocket | ❌ | ❌ | ❌ | ❌ |
-| Customizable shortcut keyboard | ✅ User-defined keys with raw escape sequences | ❌ | ❌ | ❌ | N/A |
-| Multi-server management | ✅ Save & switch between servers | ❌ | ❌ | ❌ | N/A |
-| Multi-pane with tab sync | ✅ DashMap sessions + sync WebSocket | ❌ | ❌ | ❌ | ✅ Local only |
-| Terminal notifications (bell / OSC) | ✅ Detection + sound + panel | ❌ | ❌ | ❌ | ✅ Local only |
-| System monitor (CPU/mem/disk/net) | ✅ Real-time charts | ❌ | ❌ | ❌ | ❌ |
-| Command palette | ✅ | ❌ | ❌ | ❌ | ✅ |
-| Token auth | ✅ | ✅ | ❌ | ✅ | N/A |
-| Desktop app | ✅ Tauri | ❌ | ❌ | ❌ | Native |
-| Plugin system | ✅ JS plugins + CLI bridge, hot-reload | ❌ | ❌ | ❌ | ❌ |
-| Open API (external control) | ✅ HTTP endpoint for remote input | ❌ | ❌ | ❌ | ❌ |
-| Terminal link clicking | ✅ Click links to open in preview panel | ❌ | ❌ | ❌ | ❌ |
+| Capability | Dinotty | ttyd | gotty | Wetty |
+|---|---|---|---|---|
+| Server-side virtual terminal (VT Screen) | ✅ | ❌ | ❌ | ❌ |
+| Session survives network disconnect | ✅ | ❌ | ❌ | ❌ |
+| Refresh page = restore session | ✅ | ❌ | ❌ | ❌ |
+| Built-in file browser & preview | ✅ | ❌ | ❌ | ❌ |
+| Git change indicators | ✅ | ❌ | ❌ | ❌ |
+| Built-in web preview (reverse proxy) | ✅ | ❌ | ❌ | ❌ |
+| Customizable shortcut keyboard | ✅ | ❌ | ❌ | ❌ |
+| Plugin system | ✅ | ❌ | ❌ | ❌ |
+| Token auth | ✅ | ✅ | ❌ | ✅ |
 
-**Key differentiator**: Other web terminals (ttyd, gotty, Wetty) are thin WebSocket-to-PTY pipes — they stream raw bytes and have no knowledge of what's on screen. Dinotty runs a **full virtual terminal emulator on the server**, which enables session recovery, screen snapshots, and a level of resilience that other solutions require pairing with tmux/screen to achieve. Combined with the built-in file/web browser, it provides a self-contained environment where coding agents can work and users can verify results — no tool-switching required.
-
-## All Features
-
-- **Virtual terminal emulation** — server-side VT screen with full ANSI/SGR support
-- **Session persistence** — PTY processes survive disconnection, auto-reconnect with state recovery
-- **Multi-pane sessions** — split and manage multiple terminal panes with tab sync
-- **File workspace** — browse, edit, upload, and preview files (code highlighting, Markdown, Office docs)
-- **Git change indicators** — gutter decorations for added/modified/deleted lines, inline diff viewer with Stage and Revert; file tree shows git status badges
-- **Web preview** — built-in reverse proxy to preview local dev servers
-- **Notification system** — terminal bell and OSC notification detection, real-time WebSocket push, configurable sound alerts and notification panel
-- **System monitor** — real-time CPU/memory/network charts via vue-chartjs
-- **Command palette** — quick-access command launcher
-- **Customizable shortcut keyboard** — add Ctrl/Esc/custom escape-sequence buttons for mobile & touch devices
-- **Settings & i18n** — persistent settings with multi-language support
-- **Authentication** — token-based access control
-- **Desktop app** — optional Tauri-based native client
-- **Plugin system** — install third-party plugins to extend UI and functionality; ships with CC Switch, JSON Formatter, Command Bookmarks, and Text Diff
-- **Open API** — HTTP input endpoint for external device control (Stream Deck, Shortcuts, automation scripts)
-- **Terminal link clicking** — clickable links in terminal open directly in the preview panel
-- **Notification command hooks** — execute custom shell commands when notification events fire
-
-## Open API (External Device Control)
-
-The `POST /api/input` endpoint allows external devices (Stream Deck, iOS Shortcuts, automation scripts, etc.) to send input to the terminal for remote control.
-
-Open API must be enabled in Settings.
-
-```bash
-# Send input to the active pane
-curl -X POST http://127.0.0.1:8999/api/input \
-  -H "Content-Type: application/json" \
-  -d '{"data": "ls -la\n"}'
-
-# Send input to a specific pane
-curl -X POST http://127.0.0.1:8999/api/input \
-  -H "Content-Type: application/json" \
-  -d '{"data": "echo hello\n", "pane_id": "pane-1"}'
-```
-
-## Plugin System
-
-Dinotty supports extending functionality through plugins. Plugins run in dedicated tabs, render UI with Vue 3, and have access to built-in APIs for the terminal, notifications, persistent storage, and more.
-
-### Installing Plugins
-
-**Option 1: Upload an archive**
-
-Go to Settings → Plugins and upload a `.tar.gz` package containing a `plugin.json`.
-
-**Option 2: Dev-link a local directory**
-
-```bash
-# Link a local directory as a plugin (development)
-curl -X POST http://127.0.0.1:8999/api/plugins/dev-link \
-  -H "Content-Type: application/json" \
-  -d '{"path": "/your/plugin/dir"}'
-```
-
-**Option 3: Manual placement**
-
-Drop a plugin directory directly into `~/.dinotty/plugins/<plugin-id>/`. The file watcher detects it automatically.
-
-Plugins support **hot-reload** — edit plugin files and the browser picks up changes instantly without restarting the server.
-
-### Plugin Manifest (plugin.json)
-
-| Field | Required | Description |
-|-------|----------|-------------|
-| `id` | ✅ | Unique identifier, lowercase letters + hyphens; must match the directory name |
-| `name` | ✅ | Display name |
-| `version` | ✅ | Semantic version string |
-| `entry` | ❌ | JS entry file, defaults to `./main.js` |
-| `styles` | ❌ | CSS file path |
-| `icon` | ❌ | Icon identifier (e.g., `braces`, `repeat`) |
-| `bin` | ❌ | CLI binary config `{ "mode": "cli", "entry": "./bin/xxx" }` |
-| `commands` | ❌ | Commands to register in the command palette `[{ "id": "...", "title": "..." }]` |
-| `permissions` | ❌ | Permissions the plugin requires (e.g., `["terminal.output"]`) |
-| `description` | ❌ | Plugin description, shown in the dropdown menu |
-
-### Plugin API
-
-A plugin's JS entry exports an `activate(context)` function. The `context` object provides:
-
-| Category | API | Description |
-|----------|-----|-------------|
-| **Vue** | `ref`, `reactive`, `computed`, `watch`, `h`, `onMounted` | Full Vue 3 reactivity and render API |
-| **Terminal** | `terminal.send(paneId, data)` | Send input to a terminal pane |
-| | `terminal.activePaneId()` | Get the currently active pane ID |
-| | `terminal.createTab(command?)` | Create a new terminal tab |
-| | `terminal.listPanes()` | Query all terminal panes |
-| | `terminal.onOutput(paneId, cb)` | Subscribe to terminal output broadcast |
-| **Storage** | `storage.get(key)` | Read a persisted value |
-| | `storage.set(key, value)` | Write a persisted value |
-| | `storage.list()` | List all stored keys |
-| **Commands** | `commands.register(id, handler)` | Register a command palette command, returns `Disposable` |
-| **CLI exec** | `exec.run(args, options?)` | Run the plugin's CLI binary synchronously (`{code, stdout, stderr}`) |
-| | `exec.spawn(args)` | Stream CLI output over WebSocket (returns `ReadableStream`) |
-| **UI** | `ui.notify(message, level?)` | Show a notification (info / warn / error) |
-| | `ui.confirm(message)` | Show a confirm dialog, returns `Promise<boolean>` |
-| **Settings** | `settings.get()` | Read app settings |
-| | `settings.onDidChange(cb)` | Subscribe to settings changes |
-
-The return value of `activate(context)` may include:
-- `component`: A Vue component rendered in the plugin tab
-- `dispose()`: Cleanup called when the plugin is unloaded
-
-### Built-in Plugins
-
-| Plugin | Description |
-|--------|-------------|
-| **CC Switch** | Manage multiple Claude Code API providers and switch between them with one click. Requires the [cc-switch CLI](https://github.com/SaladDay/cc-switch-cli) |
-| **JSON Formatter** | Format, minify, and validate JSON |
-| **Command Bookmarks** | Command bookmarks with batch execution to multiple terminals |
-| **Text Diff** | Text diff comparison tool with line-by-line highlighting |
-
-For the full plugin development guide, see [docs/plugin-development.md](docs/plugin-development.md).
-
-### Plugin Repository
-
-Community plugins are hosted in the [dinotty-plugins](https://github.com/xichan96/dinotty-plugins) repository. Browse and install with one click from Settings → Plugins → Plugin Marketplace. PRs are welcome.
-
-## Tech Stack
-
-| Layer | Technology |
-|-------|-----------|
-| Backend | Rust, Axum 0.7, Tokio, portable-pty, vte |
-| Frontend | Vue 3, TypeScript, Vite, xterm.js 5 |
-| Desktop | Tauri |
+Other web terminals are thin WebSocket-to-PTY pipes. Dinotty runs a **full virtual terminal emulator on the server**, enabling session recovery and screen snapshots. Combined with the built-in file/web browser, it provides a self-contained environment where coding agents work and users verify results.
 
 ## Quick Start
-
-### Prerequisites
-
-- Rust toolchain (stable)
-- Node.js + pnpm (or npm)
-
-### Build & Run
 
 ```bash
 # Build frontend
@@ -284,8 +93,6 @@ cargo run
 
 Open http://127.0.0.1:8999 in your browser.
 
-### Development
-
 ```bash
 # Backend with debug logging
 RUST_LOG=debug cargo run
@@ -293,6 +100,14 @@ RUST_LOG=debug cargo run
 # Frontend type-check
 cd frontend && npx vue-tsc --noEmit
 ```
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Backend | Rust, Axum 0.7, Tokio, portable-pty, vte |
+| Frontend | Vue 3, TypeScript, Vite, xterm.js 5 |
+| Desktop | Tauri |
 
 ## Project Structure
 
@@ -332,74 +147,17 @@ JSON messages over `/ws`:
 | Server → Client | `output` | `data: String` |
 | Server → Client | `shell_info` | `shell_type: String` |
 
+## More Documentation
+
+- [Deployment Guide](docs/deployment.en.md) — systemd, Docker, cross-platform build, configuration
+- [Notification System](docs/notifications.en.md) — HTTP API, Claude Code integration, Open API
+- [Plugin System](docs/plugins.en.md) — installation, manifest, API, built-in plugins
+- [Plugin Development](docs/plugin-development.md) — full plugin development guide
+- [Contributing](docs/contributing.en.md) — branch strategy, commit convention, code style
+
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=xichan96/dinotty&type=Date)](https://star-history.com/#xichan96/dinotty&Date)
-
-## Contributing
-
-PRs are welcome! Please follow these guidelines.
-
-### Branch Strategy
-
-- **PRs must target the `dev` branch** — do not submit PRs directly to `main`
-- `main` is always kept in a stable, releasable state
-- Create your feature branch from `dev`:
-
-```bash
-git checkout dev
-git pull origin dev
-git checkout -b feat/your-feature
-```
-
-### Branch Naming
-
-| Prefix | Purpose | Example |
-|--------|---------|---------|
-| `feat/` | New feature | `feat/plugin-api` |
-| `fix/` | Bug fix | `fix/resize-crash` |
-| `docs/` | Documentation | `docs/contributing` |
-| `refactor/` | Refactor (no behavior change) | `refactor/session-manager` |
-| `chore/` | Build, deps, CI, etc. | `chore/update-deps` |
-
-### Commit Convention
-
-Use [Conventional Commits](https://www.conventionalcommits.org/) format:
-
-```
-<type>: <short description>
-
-[optional body]
-```
-
-Common types: `feat` / `fix` / `docs` / `refactor` / `chore` / `style` / `test`
-
-```
-feat: add plugin hot-reload support
-fix: fix mobile landscape layout crash
-docs: update plugin development guide
-```
-
-### Pre-submission Checklist
-
-Make sure these pass before submitting a PR:
-
-```bash
-# Backend build
-cargo build
-
-# Frontend type check
-cd frontend && npx vue-tsc --noEmit
-```
-
-### Code Style
-
-- **Rust**: Format with `rustfmt` (`cargo fmt`)
-- **Frontend**: Follow the project's existing ESLint / Prettier config
-
-### Issues
-
-Bug reports and feature requests are welcome via GitHub Issues, in either Chinese or English.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -30,27 +30,14 @@
 
 ## 为什么选择 Dinotty？
 
-终端 Coding Agent（Claude Code、opencode、Codex、OpenClaw 等）功能强大，但它们被束缚在桌面上。如果你可以：
+终端 Coding Agent（Claude Code、opencode、Codex、OpenClaw 等）功能强大，但它们被束缚在桌面上。Dinotty 让你：
 
-- **在手机上启动编程任务**——排队、通勤、陪女朋友逛街时，掏出手机就能让 agent 干活
+- **在手机上启动编程任务**——排队、通勤时掏出手机就能让 agent 干活
 - **随时查看长时间运行的 agent**——不用打开笔记本电脑
 - **直接在手机上验证 agent 产出**——代码 diff、渲染的网页、生成的文件，浏览器里一目了然
-- **永远不会丢失会话**——手机息屏、切换 App、地铁里断网——回来后一切都在原处
-
-Dinotty 就是为此而生。它是一个移动优先的 Web 终端，让你在**任何有浏览器的设备上获得完整的桌面级 Coding Agent 体验**。
-
-### 移动优先，桌面同样完美
-
-界面自适应你的设备：
-
-- **响应式布局**——竖屏时终端和预览面板上下排列；横屏时左右并排，和桌面 IDE 一样
-- **触控优化**——终端视口触摸滚动、触控友好的按钮、支持触摸拖拽的面板缩放
-- **可自定义的快捷键盘**——手机没有 Ctrl、Esc、功能键；Dinotty 提供完全自定义的快捷按钮栏，可以为任意按键组合或转义序列定义按钮
-- **一致的 agent 体验**——Claude Code、opencode、Codex、OpenClaw 在手机和电脑上的行为完全相同，终端感知不到区别
+- **永远不会丢失会话**——手机息屏、切换 App、断网——回来后一切都在原处
 
 ### 轻量级——不是远程桌面
-
-你可能会想："为什么不直接用 VNC / RDP / 远程桌面连到电脑上？" 你可以，但：
 
 | | Dinotty | 远程桌面 (VNC/RDP/Parsec) |
 |---|---|---|
@@ -62,271 +49,39 @@ Dinotty 就是为此而生。它是一个移动优先的 Web 终端，让你在*
 | **分辨率适配** | 任意尺寸下原生文本渲染 | 位图缩放，手机上模糊 |
 | **交互方式** | 原生触控 + 自定义键盘 | 模拟鼠标，桌面 UI 在手机上很小 |
 
-远程桌面把整个屏幕当作视频流传输——即使画面没有变化也在持续传输。Dinotty 只传输**实际发生变化的文本**，效率高出几个数量级。在不稳定的移动网络下，几 KB 的 JSON 和持续的视频流之间的差距就是"能用"和"不能用"的差距。
+## 核心特性
 
-### 虚拟终端（VT Screen）
-
-后端维护了一个完整的**服务端虚拟终端仿真器**（`vt_screen.rs`，600+ 行代码），使用 VTE 状态机实时解析 PTY 输出。每个字符、每个转义序列、每次光标移动都在服务端被跟踪。这意味着：
-
-- 服务端始终掌握精确的屏幕状态——不是原始字节，而是带属性（颜色、粗体、斜体等）的结构化字符网格
-- 滚动历史在服务端以环形缓冲区保留
-- 可随时按需生成 ANSI 编码的屏幕快照
-
-### 会话持久化与自动重连
-
-会话在网络断开时不会丢失。当客户端重新连接时：
-
-1. PTY 进程在服务端持续运行——不会被中断
-2. 服务端分块回放滚动历史，然后发送当前屏幕快照
-3. 客户端终端恢复到断开前的精确状态
-
-前端实现了**指数退避自动重连**（1s → 30s 上限）。或者，直接刷新浏览器页面即可恢复完整会话——不需要重启进程或重建终端。
-
-### 多面板同步
-
-多面板通过 `SessionManager` 管理，使用 `DashMap` 映射 pane-id → PTY。专用的 `/ws/sync` WebSocket 保持所有连接客户端的标签页状态同步，你可以从多个浏览器窗口打开同一个服务器。
-
-### 可自定义的快捷键盘
-
-手机没有终端依赖的 Ctrl、Esc、Alt 和功能键。Dinotty 提供了**完全可自定义的快捷键盘**来解决这个问题：
-
-- **快捷面板**——开箱即用的一键按钮：Ctrl+C、Ctrl+D、Escape、Tab 等终端常用操作
-- **完全自定义**——在设置中添加、删除、重新排列快捷按钮；每个按钮可设置自定义标签和发送任意原始转义序列
-- **发送任何内容**——配置按钮发送任意按键组合或转义序列（如 `\x03` 表示 Ctrl+C，`\x1b[A` 表示方向上键），打造专属工作流的快捷按钮栏
-- **修饰键状态跟踪**——粘滞 Ctrl/Alt/Shift 修饰键，配合完整键盘布局使用
-- 完整按键布局，包含所有可打印字符、功能键（F1–F12）和专用方向键区
-
-### 内建文件和网页浏览器
-
-Coding Agent 会生成代码、文档和网页——但验证产出通常需要切换到单独的文件管理器或浏览器。Dinotty 将两者都直接嵌入到终端旁边：
-
-- **文件工作区**——树形文件浏览器，支持文件列表、上传、重命名和删除。点击任意文件即可预览
-- **代码编辑器**——基于 Monaco Editor 的代码编辑器，支持语法高亮、自动补全
-- **Git 变更指示**——编辑器左侧 gutter 显示新增（绿色）、修改（蓝色）、删除（红色）行标记；点击可展开 inline diff 查看器，支持 Stage/Revert 单个 hunk；文件树同步显示 M/U/A/D 徽标和染色
-- **Markdown 预览**——实时渲染 Markdown，带 HTML 净化（marked + DOMPurify）
-- **Office 文档**——直接在浏览器中预览 Word、Excel、PowerPoint 文件（officeparser）
-- **媒体播放**——内建音频/视频播放器，支持进度条、音量和播放控制
-- **图片预览**——支持常见格式的内联图片渲染
-- **网页预览**——输入 URL 或本地端口号，在嵌入式 iframe 中浏览；内建反向代理（`/preview/:port/*`）路由到本地开发服务器，无需离开终端即可查看应用运行效果
-- **地址栏**——输入 URL 或端口进行导航，自动检测网页/文件预览
-
-这意味着 agent 可以执行 `npm run dev`、编写代码，用户可以立即验证结果——全部在一个浏览器标签页内完成。
+- **服务端虚拟终端** — 完整 VTE 解析，服务端掌握精确屏幕状态，支持会话恢复与屏幕快照
+- **会话持久化** — PTY 进程在断网后存活，自动重连 + 指数退避，刷新页面即可恢复
+- **响应式布局** — 竖屏上下排列，横屏左右并排；触控优化的按钮与面板缩放
+- **可自定义快捷键盘** — 为手机补齐 Ctrl/Esc/功能键，支持任意转义序列
+- **内建文件浏览器** — 代码高亮、Markdown 渲染、Office 文档预览、音视频播放
+- **Git 变更指示** — 编辑器 gutter 增/改/删标记，inline diff，Stage/Revert
+- **网页预览** — 内建反向代理，在 iframe 中预览本地开发服务器
+- **通知系统** — 终端 bell/OSC 检测，WebSocket 推送，可配置声音提醒
+- **系统监控** — 实时 CPU/内存/网络图表
+- **插件系统** — JS 插件 + CLI 桥接，热重载，内置 CC Switch、JSON Formatter 等
+- **Open API** — HTTP 端点，支持 Stream Deck、快捷指令等外部设备控制
+- **命令面板** — 快速访问命令启动器
+- **桌面应用** — 可选 Tauri 原生客户端
 
 ## 与其他终端的对比
 
-| 能力 | Dinotty | ttyd | gotty | Wetty | 传统终端（iTerm2 等） |
-|---|---|---|---|---|---|
-| 服务端虚拟终端（VT Screen） | ✅ 完整 VTE 解析，服务端掌握屏幕状态 | ❌ | ❌ | ❌ | N/A |
-| 会话在断网后存活 | ✅ 自动重连 + 屏幕恢复 | ❌ 会话丢失 | ❌ 会话丢失 | ❌ 会话丢失 | 需要 tmux/screen |
-| 刷新页面 = 恢复会话 | ✅ 回放滚动历史 + 屏幕快照 | ❌ 新建会话 | ❌ 新建会话 | ❌ 新建会话 | N/A |
-| 内建文件浏览器和预览 | ✅ 代码、Markdown、Office、图片、音视频 | ❌ | ❌ | ❌ | ❌ |
-| Git 变更指示 | ✅ Gutter 标记 + inline diff + Stage/Revert | ❌ | ❌ | ❌ | ❌ |
-| 内建网页预览（反向代理） | ✅ 在 iframe 中嵌入本地开发服务器 | ❌ | ❌ | ❌ | ❌ |
-| 文件变更监听 | ✅ 通过 WebSocket 实时推送 | ❌ | ❌ | ❌ | ❌ |
-| 可自定义快捷键盘 | ✅ 用户定义按键，支持原始转义序列 | ❌ | ❌ | ❌ | N/A |
-| 多服务器管理 | ✅ 保存并切换服务器 | ❌ | ❌ | ❌ | N/A |
-| 多面板 + 标签页同步 | ✅ DashMap 会话 + 同步 WebSocket | ❌ | ❌ | ❌ | ✅ 仅限本地 |
-| 终端通知（bell / OSC） | ✅ 检测 + 声音 + 面板 | ❌ | ❌ | ❌ | ✅ 仅限本地 |
-| 系统监控（CPU/内存/磁盘/网络） | ✅ 实时图表 | ❌ | ❌ | ❌ | ❌ |
-| 命令面板 | ✅ | ❌ | ❌ | ❌ | ✅ |
-| Token 认证 | ✅ | ✅ | ❌ | ✅ | N/A |
-| 桌面应用 | ✅ Tauri | ❌ | ❌ | ❌ | 原生 |
-| 插件系统 | ✅ JS 插件 + CLI 桥接，热重载 | ❌ | ❌ | ❌ | ❌ |
-| Open API（外部控制） | ✅ HTTP 端点远程输入 | ❌ | ❌ | ❌ | ❌ |
-| 终端链接点击 | ✅ 点击链接在预览面板打开 | ❌ | ❌ | ❌ | ❌ |
+| 能力 | Dinotty | ttyd | gotty | Wetty |
+|---|---|---|---|---|
+| 服务端虚拟终端（VT Screen） | ✅ | ❌ | ❌ | ❌ |
+| 会话在断网后存活 | ✅ | ❌ | ❌ | ❌ |
+| 刷新页面 = 恢复会话 | ✅ | ❌ | ❌ | ❌ |
+| 内建文件浏览器和预览 | ✅ | ❌ | ❌ | ❌ |
+| Git 变更指示 | ✅ | ❌ | ❌ | ❌ |
+| 内建网页预览（反向代理） | ✅ | ❌ | ❌ | ❌ |
+| 可自定义快捷键盘 | ✅ | ❌ | ❌ | ❌ |
+| 插件系统 | ✅ | ❌ | ❌ | ❌ |
+| Token 认证 | ✅ | ✅ | ❌ | ✅ |
 
-**核心差异**：其他 Web 终端（ttyd、gotty、Wetty）只是 WebSocket 到 PTY 的透传管道——它们传输原始字节，对屏幕上显示的内容一无所知。Dinotty 在服务端运行**完整的虚拟终端仿真器**，这使得会话恢复、屏幕快照成为可能，提供了其他方案需要配合 tmux/screen 才能达到的弹性。结合内建的文件/网页浏览器，它提供了一个自包含的环境——Coding Agent 在其中工作，用户在其中验证结果——无需切换工具。
-
-## 全部功能
-
-- **虚拟终端仿真** — 服务端 VT Screen，完整支持 ANSI/SGR
-- **会话持久化** — PTY 进程在断网后存活，自动重连并恢复状态
-- **多面板会话** — 分屏管理多个终端面板，标签页同步
-- **文件工作区** — 浏览、编辑、上传、预览文件（代码高亮、Markdown、Office 文档）
-- **Git 变更指示** — 编辑器 gutter 显示增/改/删行标记，支持 inline diff、Stage 和 Revert；文件树显示 git 状态徽标
-- **网页预览** — 内建反向代理，预览本地开发服务器
-- **通知系统** — 终端 bell 和 OSC 通知检测，WebSocket 实时推送，可配置声音提醒和面板展示
-- **系统监控** — 通过 vue-chartjs 实时展示 CPU/内存/网络图表
-- **命令面板** — 快速访问命令启动器
-- **可自定义快捷键盘** — 为移动端和触屏设备添加 Ctrl/Esc/自定义转义序列按钮
-- **设置与国际化** — 持久化设置，多语言支持
-- **身份认证** — 基于 Token 的访问控制
-- **桌面应用** — 可选的 Tauri 原生客户端
-- **插件系统** — 可安装第三方插件扩展界面与功能；内置 CC Switch、JSON Formatter、Command Bookmarks、Text Diff
-- **Open API** — HTTP 输入端点，支持外部设备（Stream Deck、快捷指令等）远程控制终端
-- **终端链接点击** — 终端中的链接可直接点击，在预览面板中打开
-- **通知命令钩子** — 通知事件触发时自动执行自定义 shell 命令
-
-## 通知系统
-
-dinotty 内建通知系统，支持终端 bell 检测和自定义通知推送，适用于 AI agent 和自动化工具集成。
-
-### HTTP API
-
-通过 `POST /api/notify` 发送通知：
-
-```bash
-curl -s -X POST http://127.0.0.1:8999/api/notify \
-  -H "Content-Type: application/json" \
-  -d '{"body": "任务完成", "title": "My Agent", "notification_type": "info"}'
-```
-
-请求体字段：
-
-| 字段 | 类型 | 必填 | 说明 |
-|------|------|------|------|
-| `body` | string | ✅ | 通知正文 |
-| `title` | string | ❌ | 通知标题 |
-| `pane_id` | string | ❌ | 关联的面板 ID |
-| `notification_type` | string | ❌ | 类型：`info`（默认）/ `warning` / `error` |
-
-### 与 Claude Code 集成
-
-在 dinotty 终端中运行 Claude Code 时，可通过 hook 在关键节点自动发送通知：
-
-```jsonc
-// .claude/settings.json
-{
-  "hooks": {
-    "Notification": [{
-      "matcher": "",
-      "hooks": [{ "type": "command", "command": "curl -s -X POST http://127.0.0.1:8999/api/notify -H 'Content-Type: application/json' -d '{\"body\":\"Claude 需要你的输入\",\"title\":\"Claude Code\",\"notification_type\":\"warning\"}'" }]
-    }],
-    "Stop": [{
-      "matcher": "",
-      "hooks": [{ "type": "command", "command": "curl -s -X POST http://127.0.0.1:8999/api/notify -H 'Content-Type: application/json' -d '{\"body\":\"任务已完成\",\"title\":\"Claude Code\",\"notification_type\":\"info\"}'" }]
-    }]
-  }
-}
-```
-
-| Hook | 用途 |
-|------|------|
-| `Notification` | Claude 需要用户输入或确认权限时通知 |
-| `Stop` | 任务完成时通知 |
-
-其他 AI agent 或自动化脚本同样可以调用 HTTP API 发送通知，无需额外配置。
-
-### 通知命令钩子
-
-可在设置中配置 shell 命令，当通知事件发生时自动执行。适用于触发系统级提醒（如 macOS `osascript`、`notify-send` 等）。
-
-## Open API（外部设备控制）
-
-通过 `POST /api/input` 端点，外部设备（Stream Deck、iOS 快捷指令、自动化脚本等）可以向终端发送输入，实现远程控制。
-
-需要在设置中启用 Open API 功能。
-
-```bash
-# 向活跃面板发送输入
-curl -X POST http://127.0.0.1:8999/api/input \
-  -H "Content-Type: application/json" \
-  -d '{"data": "ls -la\n"}'
-
-# 向指定面板发送输入
-curl -X POST http://127.0.0.1:8999/api/input \
-  -H "Content-Type: application/json" \
-  -d '{"data": "echo hello\n", "pane_id": "pane-1"}'
-```
-
-## 插件系统
-
-Dinotty 支持通过插件扩展功能。插件在独立标签页中运行，使用 Vue 3 渲染 UI，可调用终端、通知、持久化存储等内建 API。
-
-### 安装插件
-
-**方式一：上传安装包**
-
-在 设置 → 插件 中上传 `.tar.gz` 压缩包（包含 `plugin.json`）。
-
-**方式二：开发模式链接**
-
-```bash
-# 将本地目录链接为插件（开发时使用）
-curl -X POST http://127.0.0.1:8999/api/plugins/dev-link \
-  -H "Content-Type: application/json" \
-  -d '{"path": "/your/plugin/dir"}'
-```
-
-**方式三：手动放置**
-
-将插件目录直接放入 `~/.dinotty/plugins/<plugin-id>/`，文件监听器会自动检测。
-
-插件支持**热重载**——修改插件文件后无需重启服务器，浏览器自动加载最新版本。
-
-### 插件清单（plugin.json）
-
-| 字段 | 必填 | 说明 |
-|------|------|------|
-| `id` | ✅ | 唯一标识，小写字母 + 连字符，须与目录名一致 |
-| `name` | ✅ | 显示名称 |
-| `version` | ✅ | 语义化版本 |
-| `entry` | ❌ | JS 入口文件，默认 `./main.js` |
-| `styles` | ❌ | CSS 文件路径 |
-| `icon` | ❌ | 图标标识符（如 `braces`、`repeat`） |
-| `bin` | ❌ | CLI 二进制配置 `{ "mode": "cli", "entry": "./bin/xxx" }` |
-| `commands` | ❌ | 注册到命令面板的命令列表 `[{ "id": "...", "title": "..." }]` |
-| `permissions` | ❌ | 声明插件所需权限（如 `["terminal.output"]`） |
-| `description` | ❌ | 插件描述，显示在下拉菜单中 |
-
-### 插件 API
-
-插件 JS 入口导出 `activate(context)` 函数，`context` 提供以下 API：
-
-| 类别 | API | 说明 |
-|------|-----|------|
-| **Vue** | `ref`, `reactive`, `computed`, `watch`, `h`, `onMounted` | 完整 Vue 3 响应式与渲染 API |
-| **终端** | `terminal.send(paneId, data)` | 向指定终端面板发送输入 |
-| | `terminal.activePaneId()` | 获取当前活跃面板 ID |
-| | `terminal.createTab(command?)` | 创建新终端标签页 |
-| | `terminal.listPanes()` | 查询所有终端面板列表 |
-| | `terminal.onOutput(paneId, cb)` | 监听终端输出广播 |
-| **存储** | `storage.get(key)` | 读取持久化值 |
-| | `storage.set(key, value)` | 写入持久化值 |
-| | `storage.list()` | 列举所有已存储的 key |
-| **命令** | `commands.register(id, handler)` | 注册命令面板命令，返回 `Disposable` |
-| **CLI 执行** | `exec.run(args, options?)` | 调用插件附带的 CLI 二进制（同步，返回 `{code, stdout, stderr}`） |
-| | `exec.spawn(args)` | 流式调用 CLI（WebSocket，返回 `ReadableStream`） |
-| **UI** | `ui.notify(message, level?)` | 显示通知（info / warn / error） |
-| | `ui.confirm(message)` | 显示确认对话框，返回 `Promise<boolean>` |
-| **设置** | `settings.get()` | 读取应用设置 |
-| | `settings.onDidChange(cb)` | 监听设置变更 |
-
-`activate(context)` 返回值可包含：
-- `component`：一个 Vue 组件，将在插件标签页中渲染
-- `dispose()`：插件卸载时的清理函数
-
-### 内置插件
-
-| 插件 | 功能 |
-|------|------|
-| **CC Switch** | 管理多个 Claude Code API Provider，一键切换；依赖 [cc-switch CLI](https://github.com/SaladDay/cc-switch-cli) |
-| **JSON Formatter** | JSON 格式化、压缩与验证工具 |
-| **Command Bookmarks** | 命令收藏夹，支持批量发送到多个终端 |
-| **Text Diff** | 文本差异对比工具，支持逐行对比与高亮显示 |
-
-完整的插件开发文档见 [docs/plugin-development.md](docs/plugin-development.md)。
-
-### 插件仓库
-
-社区插件托管在 [dinotty-plugins](https://github.com/xichan96/dinotty-plugins) 仓库。可在 设置 → 插件 → 插件市场 中浏览和一键安装。欢迎提交 PR 贡献你的插件。
-
-## 技术栈
-
-| 层级 | 技术 |
-|------|------|
-| 后端 | Rust, Axum 0.7, Tokio, portable-pty, vte |
-| 前端 | Vue 3, TypeScript, Vite, xterm.js 5 |
-| 桌面端 | Tauri |
+其他 Web 终端只是 WebSocket 到 PTY 的透传管道。Dinotty 在服务端运行**完整的虚拟终端仿真器**，使得会话恢复、屏幕快照成为可能，结合内建文件/网页浏览器，提供自包含的 Coding Agent 工作环境。
 
 ## 快速开始
-
-### 前置条件
-
-- Rust 工具链（stable）
-- Node.js + pnpm（或 npm）
-
-### 构建与运行
 
 ```bash
 # 构建前端
@@ -338,91 +93,21 @@ cargo run
 
 在浏览器中打开 http://127.0.0.1:8999 。
 
-### 开发
-
 ```bash
-# 带调试日志运行后端
+# 带调试日志运行
 RUST_LOG=debug cargo run
 
 # 前端类型检查
 cd frontend && npx vue-tsc --noEmit
 ```
 
-## 部署
+## 技术栈
 
-### Linux (systemd) 一键部署
-
-```bash
-# 构建二进制
-./build.sh native
-
-# 一键安装为 systemd 服务（支持开机自启 + 进程守护）
-sudo bash deploy/systemd/install.sh --bin target/release/dinotty-server --token your-secret-token
-
-# 管理命令
-systemctl status dinotty       # 查看状态
-systemctl restart dinotty      # 重启
-systemctl stop dinotty         # 停止
-journalctl -u dinotty -f       # 查看实时日志
-
-# 修改配置后重启
-vim /etc/dinotty/env           # 编辑端口、Token、日志级别
-systemctl restart dinotty
-
-# 卸载
-sudo bash deploy/systemd/uninstall.sh
-```
-
-### Docker 部署
-
-```bash
-cd deploy/docker
-
-# 配置环境变量
-cp .env.example .env
-# 编辑 .env 设置 DINOTTY_TOKEN、WORKSPACE_DIR 等
-
-# 构建并启动（支持 amd64 和 arm64）
-docker compose up -d --build
-
-# 管理命令
-docker compose logs -f         # 查看日志
-docker compose restart         # 重启
-docker compose down            # 停止并移除
-
-# 多架构构建并推送
-docker buildx build --platform linux/amd64,linux/arm64 \
-  -t your-registry/dinotty:latest --push \
-  -f deploy/docker/Dockerfile .
-```
-
-### 跨平台构建
-
-```bash
-# 列出支持的目标
-./build.sh list
-
-# 交叉编译 Linux musl（静态链接，无 glibc 依赖）
-./build.sh cross
-
-# 构建所有平台
-./build.sh all
-```
-
-产物输出到 `dist/` 目录：
-- `dinotty-server-x86_64-unknown-linux-musl`
-- `dinotty-server-aarch64-unknown-linux-musl`
-- `dinotty-server-x86_64-apple-darwin`
-- `dinotty-server-aarch64-apple-darwin`
-
-### 配置说明
-
-| 参数 | 方式 | 默认值 | 说明 |
-|------|------|--------|------|
-| 端口 | `--port` 或 `DINOTTY_PORT` | 8999 | 服务监听端口 |
-| Token | `DINOTTY_TOKEN` 环境变量 | 随机生成 | 访问认证令牌，为空时启动日志中打印 |
-| 日志级别 | `RUST_LOG` 环境变量 | info | trace / debug / info / warn / error |
-| Shell | `SHELL` 环境变量 | 自动检测 | 默认终端 Shell |
+| 层级 | 技术 |
+|------|------|
+| 后端 | Rust, Axum 0.7, Tokio, portable-pty, vte |
+| 前端 | Vue 3, TypeScript, Vite, xterm.js 5 |
+| 桌面端 | Tauri |
 
 ## 项目结构
 
@@ -462,76 +147,18 @@ docs/              # 设计文档
 | 服务端 → 客户端 | `output` | `data: String` |
 | 服务端 → 客户端 | `shell_info` | `shell_type: String` |
 
+## 更多文档
+
+- [部署指南](docs/deployment.md) — systemd、Docker、跨平台构建、配置说明
+- [通知系统](docs/notifications.md) — HTTP API、Claude Code 集成、Open API
+- [插件系统](docs/plugins.md) — 安装、清单、API、内置插件
+- [插件开发](docs/plugin-development.md) — 完整的插件开发文档
+- [贡献指南](docs/contributing.md) — 分支策略、Commit 规范、代码风格
+
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=xichan96/dinotty&type=Date)](https://star-history.com/#xichan96/dinotty&Date)
 
-## 贡献指南
-
-欢迎为 Dinotty 提交 PR！请遵循以下规则。
-
-### 分支策略
-
-- **PR 只能提交到 `dev` 分支**，不要直接向 `main` 提交 PR
-- `main` 分支始终保持稳定可发布状态
-- 从 `dev` 分支创建你的功能分支：
-
-```bash
-git checkout dev
-git pull origin dev
-git checkout -b feat/your-feature
-```
-
-### 分支命名
-
-| 前缀 | 用途 | 示例 |
-|------|------|------|
-| `feat/` | 新功能 | `feat/plugin-api` |
-| `fix/` | Bug 修复 | `fix/resize-crash` |
-| `docs/` | 文档更新 | `docs/contributing` |
-| `refactor/` | 重构（不改变功能） | `refactor/session-manager` |
-| `chore/` | 构建、依赖、CI 等 | `chore/update-deps` |
-
-### Commit 规范
-
-使用 [Conventional Commits](https://www.conventionalcommits.org/) 格式：
-
-```
-<type>: <简短描述>
-
-[可选正文]
-```
-
-常用 type：`feat` / `fix` / `docs` / `refactor` / `chore` / `style` / `test`
-
-```
-feat: 添加插件热重载支持
-fix: 修复移动端横屏布局错位
-docs: 更新插件开发文档
-```
-
-### 提交前检查
-
-确保以下两项通过后再提交 PR：
-
-```bash
-# 后端编译
-cargo build
-
-# 前端类型检查
-cd frontend && npx vue-tsc --noEmit
-```
-
-### 代码风格
-
-- **Rust**：使用 `rustfmt` 格式化（`cargo fmt`）
-- **前端**：遵循项目已有的 ESLint / Prettier 配置
-
-### Issue
-
-Bug 报告和功能建议请使用 GitHub Issue，中文或英文均可。
-
 ## 许可证
 
 MIT
-

--- a/docs/contributing.en.md
+++ b/docs/contributing.en.md
@@ -1,0 +1,64 @@
+# Contributing
+
+PRs are welcome! Please follow these guidelines.
+
+## Branch Strategy
+
+- **PRs must target the `dev` branch** — do not submit PRs directly to `main`
+- `main` is always kept in a stable, releasable state
+- Create your feature branch from `dev`:
+
+```bash
+git checkout dev
+git pull origin dev
+git checkout -b feat/your-feature
+```
+
+## Branch Naming
+
+| Prefix | Purpose | Example |
+|--------|---------|---------|
+| `feat/` | New feature | `feat/plugin-api` |
+| `fix/` | Bug fix | `fix/resize-crash` |
+| `docs/` | Documentation | `docs/contributing` |
+| `refactor/` | Refactor (no behavior change) | `refactor/session-manager` |
+| `chore/` | Build, deps, CI, etc. | `chore/update-deps` |
+
+## Commit Convention
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) format:
+
+```
+<type>: <short description>
+
+[optional body]
+```
+
+Common types: `feat` / `fix` / `docs` / `refactor` / `chore` / `style` / `test`
+
+```
+feat: add plugin hot-reload support
+fix: fix mobile landscape layout crash
+docs: update plugin development guide
+```
+
+## Pre-submission Checklist
+
+Make sure these pass before submitting a PR:
+
+```bash
+# Backend build
+cargo build
+
+# Frontend type check
+cd frontend && npx vue-tsc --noEmit
+```
+
+## Code Style
+
+- **Rust**: Format with `rustfmt` (`cargo fmt`)
+- **Frontend**: Follow the project's existing ESLint / Prettier config
+
+## Issues
+
+Bug reports and feature requests are welcome via GitHub Issues, in either Chinese or English.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,64 @@
+# 贡献指南
+
+欢迎为 Dinotty 提交 PR！请遵循以下规则。
+
+## 分支策略
+
+- **PR 只能提交到 `dev` 分支**，不要直接向 `main` 提交 PR
+- `main` 分支始终保持稳定可发布状态
+- 从 `dev` 分支创建你的功能分支：
+
+```bash
+git checkout dev
+git pull origin dev
+git checkout -b feat/your-feature
+```
+
+## 分支命名
+
+| 前缀 | 用途 | 示例 |
+|------|------|------|
+| `feat/` | 新功能 | `feat/plugin-api` |
+| `fix/` | Bug 修复 | `fix/resize-crash` |
+| `docs/` | 文档更新 | `docs/contributing` |
+| `refactor/` | 重构（不改变功能） | `refactor/session-manager` |
+| `chore/` | 构建、依赖、CI 等 | `chore/update-deps` |
+
+## Commit 规范
+
+使用 [Conventional Commits](https://www.conventionalcommits.org/) 格式：
+
+```
+<type>: <简短描述>
+
+[可选正文]
+```
+
+常用 type：`feat` / `fix` / `docs` / `refactor` / `chore` / `style` / `test`
+
+```
+feat: 添加插件热重载支持
+fix: 修复移动端横屏布局错位
+docs: 更新插件开发文档
+```
+
+## 提交前检查
+
+确保以下两项通过后再提交 PR：
+
+```bash
+# 后端编译
+cargo build
+
+# 前端类型检查
+cd frontend && npx vue-tsc --noEmit
+```
+
+## 代码风格
+
+- **Rust**：使用 `rustfmt` 格式化（`cargo fmt`）
+- **前端**：遵循项目已有的 ESLint / Prettier 配置
+
+## Issue
+
+Bug 报告和功能建议请使用 GitHub Issue，中文或英文均可。

--- a/docs/deployment.en.md
+++ b/docs/deployment.en.md
@@ -1,0 +1,75 @@
+# Deployment Guide
+
+## Linux (systemd) One-Click Deploy
+
+```bash
+# Build binary
+./build.sh native
+
+# One-click install as systemd service (auto-start + process supervision)
+sudo bash deploy/systemd/install.sh --bin target/release/dinotty-server --token your-secret-token
+
+# Management commands
+systemctl status dinotty       # Check status
+systemctl restart dinotty      # Restart
+systemctl stop dinotty         # Stop
+journalctl -u dinotty -f       # View live logs
+
+# Update config and restart
+vim /etc/dinotty/env           # Edit port, token, log level
+systemctl restart dinotty
+
+# Uninstall
+sudo bash deploy/systemd/uninstall.sh
+```
+
+## Docker Deploy
+
+```bash
+cd deploy/docker
+
+# Configure environment variables
+cp .env.example .env
+# Edit .env to set DINOTTY_TOKEN, WORKSPACE_DIR, etc.
+
+# Build and start (supports amd64 and arm64)
+docker compose up -d --build
+
+# Management commands
+docker compose logs -f         # View logs
+docker compose restart         # Restart
+docker compose down            # Stop and remove
+
+# Multi-arch build and push
+docker buildx build --platform linux/amd64,linux/arm64 \
+  -t your-registry/dinotty:latest --push \
+  -f deploy/docker/Dockerfile .
+```
+
+## Cross-Platform Build
+
+```bash
+# List supported targets
+./build.sh list
+
+# Cross-compile for Linux musl (static linking, no glibc dependency)
+./build.sh cross
+
+# Build for all platforms
+./build.sh all
+```
+
+Output in `dist/` directory:
+- `dinotty-server-x86_64-unknown-linux-musl`
+- `dinotty-server-aarch64-unknown-linux-musl`
+- `dinotty-server-x86_64-apple-darwin`
+- `dinotty-server-aarch64-apple-darwin`
+
+## Configuration
+
+| Parameter | Method | Default | Description |
+|-----------|--------|---------|-------------|
+| Port | `--port` or `DINOTTY_PORT` | 8999 | Server listen port |
+| Token | `DINOTTY_TOKEN` env var | Random | Access auth token; printed in startup log when empty |
+| Log level | `RUST_LOG` env var | info | trace / debug / info / warn / error |
+| Shell | `SHELL` env var | Auto-detect | Default terminal shell |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,75 @@
+# 部署指南
+
+## Linux (systemd) 一键部署
+
+```bash
+# 构建二进制
+./build.sh native
+
+# 一键安装为 systemd 服务（支持开机自启 + 进程守护）
+sudo bash deploy/systemd/install.sh --bin target/release/dinotty-server --token your-secret-token
+
+# 管理命令
+systemctl status dinotty       # 查看状态
+systemctl restart dinotty      # 重启
+systemctl stop dinotty         # 停止
+journalctl -u dinotty -f       # 查看实时日志
+
+# 修改配置后重启
+vim /etc/dinotty/env           # 编辑端口、Token、日志级别
+systemctl restart dinotty
+
+# 卸载
+sudo bash deploy/systemd/uninstall.sh
+```
+
+## Docker 部署
+
+```bash
+cd deploy/docker
+
+# 配置环境变量
+cp .env.example .env
+# 编辑 .env 设置 DINOTTY_TOKEN、WORKSPACE_DIR 等
+
+# 构建并启动（支持 amd64 和 arm64）
+docker compose up -d --build
+
+# 管理命令
+docker compose logs -f         # 查看日志
+docker compose restart         # 重启
+docker compose down            # 停止并移除
+
+# 多架构构建并推送
+docker buildx build --platform linux/amd64,linux/arm64 \
+  -t your-registry/dinotty:latest --push \
+  -f deploy/docker/Dockerfile .
+```
+
+## 跨平台构建
+
+```bash
+# 列出支持的目标
+./build.sh list
+
+# 交叉编译 Linux musl（静态链接，无 glibc 依赖）
+./build.sh cross
+
+# 构建所有平台
+./build.sh all
+```
+
+产物输出到 `dist/` 目录：
+- `dinotty-server-x86_64-unknown-linux-musl`
+- `dinotty-server-aarch64-unknown-linux-musl`
+- `dinotty-server-x86_64-apple-darwin`
+- `dinotty-server-aarch64-apple-darwin`
+
+## 配置说明
+
+| 参数 | 方式 | 默认值 | 说明 |
+|------|------|--------|------|
+| 端口 | `--port` 或 `DINOTTY_PORT` | 8999 | 服务监听端口 |
+| Token | `DINOTTY_TOKEN` 环境变量 | 随机生成 | 访问认证令牌，为空时启动日志中打印 |
+| 日志级别 | `RUST_LOG` 环境变量 | info | trace / debug / info / warn / error |
+| Shell | `SHELL` 环境变量 | 自动检测 | 默认终端 Shell |

--- a/docs/notifications.en.md
+++ b/docs/notifications.en.md
@@ -1,0 +1,71 @@
+# Notification System
+
+Dinotty has a built-in notification system supporting terminal bell detection and custom notification push, designed for AI agent and automation tool integration.
+
+## HTTP API
+
+Send notifications via `POST /api/notify`:
+
+```bash
+curl -s -X POST http://127.0.0.1:8999/api/notify \
+  -H "Content-Type: application/json" \
+  -d '{"body": "Task completed", "title": "My Agent", "notification_type": "info"}'
+```
+
+Request body fields:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `body` | string | ✅ | Notification body |
+| `title` | string | ❌ | Notification title |
+| `pane_id` | string | ❌ | Associated pane ID |
+| `notification_type` | string | ❌ | Type: `info` (default) / `warning` / `error` |
+
+## Claude Code Integration
+
+When running Claude Code in a dinotty terminal, you can use hooks to automatically send notifications at key moments:
+
+```jsonc
+// .claude/settings.json
+{
+  "hooks": {
+    "Notification": [{
+      "matcher": "",
+      "hooks": [{ "type": "command", "command": "curl -s -X POST http://127.0.0.1:8999/api/notify -H 'Content-Type: application/json' -d '{\"body\":\"Claude needs your input\",\"title\":\"Claude Code\",\"notification_type\":\"warning\"}'" }]
+    }],
+    "Stop": [{
+      "matcher": "",
+      "hooks": [{ "type": "command", "command": "curl -s -X POST http://127.0.0.1:8999/api/notify -H 'Content-Type: application/json' -d '{\"body\":\"Task completed\",\"title\":\"Claude Code\",\"notification_type\":\"info\"}'" }]
+    }]
+  }
+}
+```
+
+| Hook | Purpose |
+|------|---------|
+| `Notification` | Alert when Claude needs user input or permission confirmation |
+| `Stop` | Alert when a task completes |
+
+Other AI agents and automation scripts can also call the HTTP API to send notifications without additional configuration.
+
+## Notification Command Hooks
+
+You can configure shell commands in Settings that execute automatically when notification events fire. Useful for triggering system-level alerts (e.g., macOS `osascript`, `notify-send`, etc.).
+
+## Open API (External Device Control)
+
+The `POST /api/input` endpoint allows external devices (Stream Deck, iOS Shortcuts, automation scripts, etc.) to send input to the terminal for remote control.
+
+Open API must be enabled in Settings.
+
+```bash
+# Send input to the active pane
+curl -X POST http://127.0.0.1:8999/api/input \
+  -H "Content-Type: application/json" \
+  -d '{"data": "ls -la\n"}'
+
+# Send input to a specific pane
+curl -X POST http://127.0.0.1:8999/api/input \
+  -H "Content-Type: application/json" \
+  -d '{"data": "echo hello\n", "pane_id": "pane-1"}'
+```

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,0 +1,71 @@
+# 通知系统
+
+dinotty 内建通知系统，支持终端 bell 检测和自定义通知推送，适用于 AI agent 和自动化工具集成。
+
+## HTTP API
+
+通过 `POST /api/notify` 发送通知：
+
+```bash
+curl -s -X POST http://127.0.0.1:8999/api/notify \
+  -H "Content-Type: application/json" \
+  -d '{"body": "任务完成", "title": "My Agent", "notification_type": "info"}'
+```
+
+请求体字段：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `body` | string | ✅ | 通知正文 |
+| `title` | string | ❌ | 通知标题 |
+| `pane_id` | string | ❌ | 关联的面板 ID |
+| `notification_type` | string | ❌ | 类型：`info`（默认）/ `warning` / `error` |
+
+## 与 Claude Code 集成
+
+在 dinotty 终端中运行 Claude Code 时，可通过 hook 在关键节点自动发送通知：
+
+```jsonc
+// .claude/settings.json
+{
+  "hooks": {
+    "Notification": [{
+      "matcher": "",
+      "hooks": [{ "type": "command", "command": "curl -s -X POST http://127.0.0.1:8999/api/notify -H 'Content-Type: application/json' -d '{\"body\":\"Claude 需要你的输入\",\"title\":\"Claude Code\",\"notification_type\":\"warning\"}'" }]
+    }],
+    "Stop": [{
+      "matcher": "",
+      "hooks": [{ "type": "command", "command": "curl -s -X POST http://127.0.0.1:8999/api/notify -H 'Content-Type: application/json' -d '{\"body\":\"任务已完成\",\"title\":\"Claude Code\",\"notification_type\":\"info\"}'" }]
+    }]
+  }
+}
+```
+
+| Hook | 用途 |
+|------|------|
+| `Notification` | Claude 需要用户输入或确认权限时通知 |
+| `Stop` | 任务完成时通知 |
+
+其他 AI agent 或自动化脚本同样可以调用 HTTP API 发送通知，无需额外配置。
+
+## 通知命令钩子
+
+可在设置中配置 shell 命令，当通知事件发生时自动执行。适用于触发系统级提醒（如 macOS `osascript`、`notify-send` 等）。
+
+## Open API（外部设备控制）
+
+通过 `POST /api/input` 端点，外部设备（Stream Deck、iOS 快捷指令、自动化脚本等）可以向终端发送输入，实现远程控制。
+
+需要在设置中启用 Open API 功能。
+
+```bash
+# 向活跃面板发送输入
+curl -X POST http://127.0.0.1:8999/api/input \
+  -H "Content-Type: application/json" \
+  -d '{"data": "ls -la\n"}'
+
+# 向指定面板发送输入
+curl -X POST http://127.0.0.1:8999/api/input \
+  -H "Content-Type: application/json" \
+  -d '{"data": "echo hello\n", "pane_id": "pane-1"}'
+```

--- a/docs/plugins.en.md
+++ b/docs/plugins.en.md
@@ -1,0 +1,81 @@
+# Plugin System
+
+Dinotty supports extending functionality through plugins. Plugins run in dedicated tabs, render UI with Vue 3, and have access to built-in APIs for the terminal, notifications, persistent storage, and more.
+
+## Installing Plugins
+
+**Option 1: Upload an archive**
+
+Go to Settings → Plugins and upload a `.tar.gz` package containing a `plugin.json`.
+
+**Option 2: Dev-link a local directory**
+
+```bash
+# Link a local directory as a plugin (development)
+curl -X POST http://127.0.0.1:8999/api/plugins/dev-link \
+  -H "Content-Type: application/json" \
+  -d '{"path": "/your/plugin/dir"}'
+```
+
+**Option 3: Manual placement**
+
+Drop a plugin directory directly into `~/.dinotty/plugins/<plugin-id>/`. The file watcher detects it automatically.
+
+Plugins support **hot-reload** — edit plugin files and the browser picks up changes instantly without restarting the server.
+
+## Plugin Manifest (plugin.json)
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `id` | ✅ | Unique identifier, lowercase letters + hyphens; must match the directory name |
+| `name` | ✅ | Display name |
+| `version` | ✅ | Semantic version string |
+| `entry` | ❌ | JS entry file, defaults to `./main.js` |
+| `styles` | ❌ | CSS file path |
+| `icon` | ❌ | Icon identifier (e.g., `braces`, `repeat`) |
+| `bin` | ❌ | CLI binary config `{ "mode": "cli", "entry": "./bin/xxx" }` |
+| `commands` | ❌ | Commands to register in the command palette `[{ "id": "...", "title": "..." }]` |
+| `permissions` | ❌ | Permissions the plugin requires (e.g., `["terminal.output"]`) |
+| `description` | ❌ | Plugin description, shown in the dropdown menu |
+
+## Plugin API
+
+A plugin's JS entry exports an `activate(context)` function. The `context` object provides:
+
+| Category | API | Description |
+|----------|-----|-------------|
+| **Vue** | `ref`, `reactive`, `computed`, `watch`, `h`, `onMounted` | Full Vue 3 reactivity and render API |
+| **Terminal** | `terminal.send(paneId, data)` | Send input to a terminal pane |
+| | `terminal.activePaneId()` | Get the currently active pane ID |
+| | `terminal.createTab(command?)` | Create a new terminal tab |
+| | `terminal.listPanes()` | Query all terminal panes |
+| | `terminal.onOutput(paneId, cb)` | Subscribe to terminal output broadcast |
+| **Storage** | `storage.get(key)` | Read a persisted value |
+| | `storage.set(key, value)` | Write a persisted value |
+| | `storage.list()` | List all stored keys |
+| **Commands** | `commands.register(id, handler)` | Register a command palette command, returns `Disposable` |
+| **CLI exec** | `exec.run(args, options?)` | Run the plugin's CLI binary synchronously (`{code, stdout, stderr}`) |
+| | `exec.spawn(args)` | Stream CLI output over WebSocket (returns `ReadableStream`) |
+| **UI** | `ui.notify(message, level?)` | Show a notification (info / warn / error) |
+| | `ui.confirm(message)` | Show a confirm dialog, returns `Promise<boolean>` |
+| **Settings** | `settings.get()` | Read app settings |
+| | `settings.onDidChange(cb)` | Subscribe to settings changes |
+
+The return value of `activate(context)` may include:
+- `component`: A Vue component rendered in the plugin tab
+- `dispose()`: Cleanup called when the plugin is unloaded
+
+## Built-in Plugins
+
+| Plugin | Description |
+|--------|-------------|
+| **CC Switch** | Manage multiple Claude Code API providers and switch between them with one click. Requires the [cc-switch CLI](https://github.com/SaladDay/cc-switch-cli) |
+| **JSON Formatter** | Format, minify, and validate JSON |
+| **Command Bookmarks** | Command bookmarks with batch execution to multiple terminals |
+| **Text Diff** | Text diff comparison tool with line-by-line highlighting |
+
+For the full plugin development guide, see [plugin-development.md](plugin-development.md).
+
+## Plugin Repository
+
+Community plugins are hosted in the [dinotty-plugins](https://github.com/xichan96/dinotty-plugins) repository. Browse and install with one click from Settings → Plugins → Plugin Marketplace. PRs are welcome.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,81 @@
+# 插件系统
+
+Dinotty 支持通过插件扩展功能。插件在独立标签页中运行，使用 Vue 3 渲染 UI，可调用终端、通知、持久化存储等内建 API。
+
+## 安装插件
+
+**方式一：上传安装包**
+
+在 设置 → 插件 中上传 `.tar.gz` 压缩包（包含 `plugin.json`）。
+
+**方式二：开发模式链接**
+
+```bash
+# 将本地目录链接为插件（开发时使用）
+curl -X POST http://127.0.0.1:8999/api/plugins/dev-link \
+  -H "Content-Type: application/json" \
+  -d '{"path": "/your/plugin/dir"}'
+```
+
+**方式三：手动放置**
+
+将插件目录直接放入 `~/.dinotty/plugins/<plugin-id>/`，文件监听器会自动检测。
+
+插件支持**热重载**——修改插件文件后无需重启服务器，浏览器自动加载最新版本。
+
+## 插件清单（plugin.json）
+
+| 字段 | 必填 | 说明 |
+|------|------|------|
+| `id` | ✅ | 唯一标识，小写字母 + 连字符，须与目录名一致 |
+| `name` | ✅ | 显示名称 |
+| `version` | ✅ | 语义化版本 |
+| `entry` | ❌ | JS 入口文件，默认 `./main.js` |
+| `styles` | ❌ | CSS 文件路径 |
+| `icon` | ❌ | 图标标识符（如 `braces`、`repeat`） |
+| `bin` | ❌ | CLI 二进制配置 `{ "mode": "cli", "entry": "./bin/xxx" }` |
+| `commands` | ❌ | 注册到命令面板的命令列表 `[{ "id": "...", "title": "..." }]` |
+| `permissions` | ❌ | 声明插件所需权限（如 `["terminal.output"]`） |
+| `description` | ❌ | 插件描述，显示在下拉菜单中 |
+
+## 插件 API
+
+插件 JS 入口导出 `activate(context)` 函数，`context` 提供以下 API：
+
+| 类别 | API | 说明 |
+|------|-----|------|
+| **Vue** | `ref`, `reactive`, `computed`, `watch`, `h`, `onMounted` | 完整 Vue 3 响应式与渲染 API |
+| **终端** | `terminal.send(paneId, data)` | 向指定终端面板发送输入 |
+| | `terminal.activePaneId()` | 获取当前活跃面板 ID |
+| | `terminal.createTab(command?)` | 创建新终端标签页 |
+| | `terminal.listPanes()` | 查询所有终端面板列表 |
+| | `terminal.onOutput(paneId, cb)` | 监听终端输出广播 |
+| **存储** | `storage.get(key)` | 读取持久化值 |
+| | `storage.set(key, value)` | 写入持久化值 |
+| | `storage.list()` | 列举所有已存储的 key |
+| **命令** | `commands.register(id, handler)` | 注册命令面板命令，返回 `Disposable` |
+| **CLI 执行** | `exec.run(args, options?)` | 调用插件附带的 CLI 二进制（同步，返回 `{code, stdout, stderr}`） |
+| | `exec.spawn(args)` | 流式调用 CLI（WebSocket，返回 `ReadableStream`） |
+| **UI** | `ui.notify(message, level?)` | 显示通知（info / warn / error） |
+| | `ui.confirm(message)` | 显示确认对话框，返回 `Promise<boolean>` |
+| **设置** | `settings.get()` | 读取应用设置 |
+| | `settings.onDidChange(cb)` | 监听设置变更 |
+
+`activate(context)` 返回值可包含：
+- `component`：一个 Vue 组件，将在插件标签页中渲染
+- `dispose()`：插件卸载时的清理函数
+
+## 内置插件
+
+| 插件 | 功能 |
+|------|------|
+| **CC Switch** | 管理多个 Claude Code API Provider，一键切换；依赖 [cc-switch CLI](https://github.com/SaladDay/cc-switch-cli) |
+| **JSON Formatter** | JSON 格式化、压缩与验证工具 |
+| **Command Bookmarks** | 命令收藏夹，支持批量发送到多个终端 |
+| **Text Diff** | 文本差异对比工具，支持逐行对比与高亮显示 |
+
+完整的插件开发文档见 [plugin-development.md](plugin-development.md)。
+
+## 插件仓库
+
+社区插件托管在 [dinotty-plugins](https://github.com/xichan96/dinotty-plugins) 仓库。可在 设置 → 插件 → 插件市场 中浏览和一键安装。欢迎提交 PR 贡献你的插件。

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -105,7 +105,7 @@ import ServerList from './components/ServerList.vue'
 import StatusBar from './components/terminal/StatusBar.vue'
 import type { SyncServerMsg, SyncClientMsg } from './types/protocol'
 import { useSettings } from './composables/useSettings'
-import { getApiBase, wsUrlWithToken, hasAuthToken } from './composables/apiBase'
+import { getApiBase, wsUrlWithToken, hasAuthToken, checkTokenConfigured, setAuthToken } from './composables/apiBase'
 import { isTauri } from './composables/useTransport'
 import { isTouchDevice } from './composables/useTerminal'
 import { useI18n } from './composables/useI18n'
@@ -789,6 +789,16 @@ onMounted(async () => {
     void connectSyncWS()
     initMonitorHistory()
     void loadAll()
+  } else {
+    // No local token — check if server has one configured
+    await getApiBase()
+    const configured = await checkTokenConfigured()
+    if (!configured) {
+      // First-time setup: skip login, open settings
+      authenticated.value = true
+      settingsOpen.value = true
+      void loadAll()
+    }
   }
 })
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -776,8 +776,13 @@ function onOrientationChange() {
   isLandscape.value = window.innerWidth > window.innerHeight
 }
 
+const _focusHandler = () => {
+  nextTick(() => focusActive())
+}
+
 onMounted(async () => {
   document.addEventListener('keydown', onGlobalKeydown)
+  window.addEventListener('focus', _focusHandler)
   window.addEventListener('resize', onOrientationChange)
   window.addEventListener('terminal-insert-path', onTerminalInsertPath)
   window.addEventListener('terminal-insert-text', onTerminalInsertText)
@@ -804,6 +809,7 @@ onMounted(async () => {
 
 onBeforeUnmount(() => {
   document.removeEventListener('keydown', onGlobalKeydown)
+  window.removeEventListener('focus', _focusHandler)
   window.removeEventListener('resize', onOrientationChange)
   window.removeEventListener('terminal-insert-path', onTerminalInsertPath)
   window.removeEventListener('terminal-insert-text', onTerminalInsertText)

--- a/frontend/src/composables/apiBase.ts
+++ b/frontend/src/composables/apiBase.ts
@@ -48,6 +48,18 @@ export async function validateToken(token: string): Promise<boolean> {
   }
 }
 
+export async function checkTokenConfigured(): Promise<boolean> {
+  try {
+    await getApiBase()
+    const res = await fetch(apiUrl('/api/token-configured'))
+    if (!res.ok) return true // assume configured on error
+    const data = await res.json()
+    return !!data.configured
+  } catch {
+    return true // assume configured on error
+  }
+}
+
 export async function getApiBase(): Promise<string> {
   if (!isTauri()) {
     cached = ''
@@ -73,7 +85,26 @@ export function apiUrl(path: string): string {
   return cached ? `${cached}${p}` : p
 }
 
-export function authFetch(url: string, init?: RequestInit): Promise<Response> {
+export async function authFetch(url: string, init?: RequestInit): Promise<Response> {
+  if (isTauri()) {
+    const token = getAuthToken()
+    const headers: [string, string][] = []
+    if (token) headers.push(['Authorization', `Bearer ${token}`])
+    if (init?.headers) {
+      const h = new Headers(init.headers)
+      h.forEach((v, k) => headers.push([k, v]))
+    }
+    const resp = (await tauriInvoke('tauri_fetch', {
+      url,
+      method: init?.method || 'GET',
+      headers,
+      body: typeof init?.body === 'string' ? init.body : null,
+    })) as { status: number; headers: [string, string][]; body: string }
+    return new Response(resp.body, {
+      status: resp.status,
+      headers: resp.headers,
+    })
+  }
   const token = getAuthToken()
   const headers = new Headers(init?.headers)
   if (token) headers.set('Authorization', `Bearer ${token}`)

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dinotty-desktop"
-version = "0.8.2"
+version = "0.9.0"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ tower-http = { version = "0.5", features = ["fs", "cors"] }
 rust-embed = { version = "8", features = ["axum"] }
 mime_guess = "2"
 local-ip-address = "0.6"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/src-tauri/src/embedded_server.rs
+++ b/src-tauri/src/embedded_server.rs
@@ -191,6 +191,19 @@ async fn server_info(AxumState(state): AxumState<AppState>) -> Json<serde_json::
     }))
 }
 
+// Desktop client doesn't need auth — stubs for frontend compatibility
+async fn check_auth() -> StatusCode {
+    StatusCode::OK
+}
+
+async fn token_configured() -> Json<serde_json::Value> {
+    Json(serde_json::json!({ "configured": false }))
+}
+
+async fn update_token(Json(_body): Json<serde_json::Value>) -> StatusCode {
+    StatusCode::OK
+}
+
 pub async fn run_server(port: u16, manager: Arc<SessionManager>) {
     let monitor_state = MonitorState::new();
     monitor_state.clone().start_collector();
@@ -243,6 +256,9 @@ pub async fn run_server(port: u16, manager: Arc<SessionManager>) {
         .route("/api/notify", post(notification::post_notify))
         .route("/api/history", get(history::get_history).delete(history::delete_history))
         .route("/api/info", get(server_info))
+        .route("/api/auth", post(check_auth))
+        .route("/api/token-configured", get(token_configured))
+        .route("/api/token", put(update_token))
         .route("/api/plugins", get(plugin::list_plugins))
         .route("/api/plugins/market", get(plugin::get_market_registry))
         .route("/api/plugins/market/:id/readme", get(plugin::get_market_readme))

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, OnceLock};
 use tauri::{AppHandle, Emitter, State};
 use dinotty_server::pty;
 use dinotty_server::session::{SessionManager, SessionStatus, SyncMsg};
+use reqwest::Method;
 
 mod embedded_server;
 
@@ -146,6 +147,40 @@ fn embedded_http_origin() -> String {
     format!("http://127.0.0.1:{port}")
 }
 
+#[derive(Serialize)]
+struct FetchResponse {
+    status: u16,
+    headers: Vec<(String, String)>,
+    body: String,
+}
+
+#[tauri::command]
+async fn tauri_fetch(
+    url: String,
+    method: String,
+    headers: Vec<(String, String)>,
+    body: Option<String>,
+) -> Result<FetchResponse, String> {
+    let client = reqwest::Client::new();
+    let method: Method = method.parse().map_err(|_| "invalid method")?;
+    let mut req = client.request(method, &url);
+    for (k, v) in headers {
+        req = req.header(k, v);
+    }
+    if let Some(b) = body {
+        req = req.body(b);
+    }
+    let resp = req.send().await.map_err(|e| e.to_string())?;
+    let status = resp.status().as_u16();
+    let headers: Vec<(String, String)> = resp
+        .headers()
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_string()))
+        .collect();
+    let body = resp.text().await.map_err(|e| e.to_string())?;
+    Ok(FetchResponse { status, headers, body })
+}
+
 fn main() {
     tracing_subscriber::fmt()
         .with_env_filter(
@@ -200,6 +235,7 @@ fn main() {
             pty_resize,
             pty_kill,
             embedded_http_origin,
+            tauri_fetch,
         ])
         .run(tauri::generate_context!())
         .expect("error running tauri application");

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nickelpack/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "Dinotty",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "identifier": "com.dinotty.terminal",
   "build": {
     "frontendDist": "../frontend/dist",

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -36,6 +36,11 @@ pub async fn auth_middleware(
 ) -> Response {
     let path = request.uri().path();
 
+    // No token configured — first-time setup, allow all requests
+    if token.is_empty() {
+        return next.run(request).await;
+    }
+
     if path == "/" || path == "/api/notify" || path == "/manifest.json" || path == "/logo.png"
         || path.starts_with("/assets/") || path.starts_with("/preview/") || path.starts_with("/icons/")
     {

--- a/src/main.rs
+++ b/src/main.rs
@@ -302,6 +302,11 @@ async fn check_auth(State(state): State<AppState>) -> impl IntoResponse {
     StatusCode::OK
 }
 
+async fn token_configured(State(state): State<AppState>) -> impl IntoResponse {
+    let token = state.auth_token.read().await;
+    Json(serde_json::json!({ "configured": !token.is_empty() }))
+}
+
 async fn update_token(
     State(state): State<AppState>,
     Json(body): Json<UpdateTokenRequest>,
@@ -341,20 +346,15 @@ async fn main() {
     notifier.set_settings(settings_state.clone());
     let history_state = HistoryState::new();
 
-    // Load token from dedicated file, fall back to env var, then generate
+    // Load token from dedicated file or env var; empty means first-time setup
     let initial_token = settings::load_token()
         .or_else(|| std::env::var("DINOTTY_TOKEN").ok())
-        .unwrap_or_else(|| {
-            let mut buf = [0u8; 32];
-            rand::fill(&mut buf);
-            buf.iter().map(|b| format!("{:02x}", b)).collect()
-        });
-    if settings::load_token().is_none() {
-        if let Err(e) = settings::save_token(&initial_token) {
-            tracing::warn!("Failed to persist auth token: {}", e);
-        }
+        .unwrap_or_default();
+    if initial_token.is_empty() {
+        tracing::info!("No auth token configured — first-time setup required");
+    } else {
+        tracing::info!("Auth token loaded (length={})", initial_token.len());
     }
-    tracing::info!("Auth token loaded (length={})", initial_token.len());
     let auth_token = Arc::new(tokio::sync::RwLock::new(initial_token));
 
     let plugins = Arc::new(plugin::PluginManager::new());
@@ -411,6 +411,7 @@ async fn main() {
         .route("/api/notify", post(notification::post_notify))
         .route("/api/input", post(ws::post_input))
         .route("/api/auth", post(check_auth))
+        .route("/api/token-configured", get(token_configured))
         .route("/api/settings", get(settings::get_settings).put(settings::put_settings))
         .route("/api/settings/background", post(settings::upload_background).get(settings::get_background))
         .route("/api/workspace/resolve", get(workspace::workspace_resolve))


### PR DESCRIPTION
## Summary
- Simplify README and extract detailed docs into separate files
- Add Chinese/English docs for contributing, deployment, notifications, plugins
- Auto-focus terminal when switching back to browser tab
- Support first-time setup without pre-configured token
- Bump version to v0.9.0

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Check all new docs links work
- [ ] Test terminal focus restoration on tab switch
- [ ] Test fresh install flow without pre-set token