### PR TITLE
chore: bump version to v0.9.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["src-tauri"]
 
 [package]
 name = "dinotty-server"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 build = "build.rs"
 repository = "https://github.com/xichan96/dinotty"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dinotty-desktop"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- Update Cargo.toml version from 0.9.0 to 0.9.1