### PR TITLE
feat: split pane system, first-time setup, and misc fixes

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -155,6 +155,14 @@ JSON messages over `/ws`:
 - [Plugin Development](docs/plugin-development.md) — full plugin development guide
 - [Contributing](docs/contributing.en.md) — branch strategy, commit convention, code style
 
+## Contributors
+
+Thanks to all the people who have contributed to Dinotty!
+
+<a href="https://github.com/xichan96/dinotty/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=xichan96/dinotty" />
+</a>
+
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=xichan96/dinotty&type=Date)](https://star-history.com/#xichan96/dinotty&Date)

--- a/README.md
+++ b/README.md
@@ -155,6 +155,14 @@ docs/              # 设计文档
 - [插件开发](docs/plugin-development.md) — 完整的插件开发文档
 - [贡献指南](docs/contributing.md) — 分支策略、Commit 规范、代码风格
 
+## 贡献者
+
+感谢所有为 Dinotty 做出贡献的人！
+
+<a href="https://github.com/xichan96/dinotty/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=xichan96/dinotty" />
+</a>
+
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=xichan96/dinotty&type=Date)](https://star-history.com/#xichan96/dinotty&Date)

--- a/frontend/src/composables/useSplitPane.ts
+++ b/frontend/src/composables/useSplitPane.ts
@@ -87,21 +87,17 @@ export function useSplitPane(opts: {
       return false
     }
 
+    // If this is the last child in a single-child split, close the tab
+    if (parent.children.length <= 1) {
+      return false
+    }
+
     const idx = parent.children.findIndex(c => c.type === 'leaf' && c.paneId === paneId)
     if (idx === -1) return false
 
     parent.children.splice(idx, 1)
     parent.ratios.splice(idx, 1)
     redistributeRatios(parent)
-
-    if (parent.children.length === 1) {
-      const remaining = parent.children[0]
-      if (parent === tab.layout) {
-        tab.layout = remaining
-      } else {
-        replaceNode(tab.layout, parent, remaining)
-      }
-    }
 
     if (tab.activePaneId === paneId) {
       tab.activePaneId = findFirstLeaf(tab.layout).paneId

--- a/frontend/src/composables/useSplitPane.ts
+++ b/frontend/src/composables/useSplitPane.ts
@@ -87,17 +87,21 @@ export function useSplitPane(opts: {
       return false
     }
 
-    // If this is the last child in a single-child split, close the tab
-    if (parent.children.length <= 1) {
-      return false
-    }
-
     const idx = parent.children.findIndex(c => c.type === 'leaf' && c.paneId === paneId)
     if (idx === -1) return false
 
     parent.children.splice(idx, 1)
     parent.ratios.splice(idx, 1)
     redistributeRatios(parent)
+
+    if (parent.children.length === 1) {
+      const remaining = parent.children[0]
+      if (parent === tab.layout) {
+        tab.layout = remaining
+      } else {
+        replaceNode(tab.layout, parent, remaining)
+      }
+    }
 
     if (tab.activePaneId === paneId) {
       tab.activePaneId = findFirstLeaf(tab.layout).paneId

--- a/frontend/src/types/pane.ts
+++ b/frontend/src/types/pane.ts
@@ -84,6 +84,11 @@ export function findParentSplit(node: PaneLayout, paneId: string): SplitPane | n
   return null
 }
 
+/** Check if a node is a split with only one child (collapsed split) */
+export function isSingleChildSplit(node: PaneLayout): boolean {
+  return node.type === 'split' && node.children.length === 1
+}
+
 /** Get all leaf nodes in order */
 export function getAllLeaves(node: PaneLayout): LeafPane[] {
   if (node.type === 'leaf') return [node]


### PR DESCRIPTION
## Summary
- feat(frontend): add split pane system for terminal
- feat: add iTerm2-style drag-and-drop with server-side layout sync
- feat(frontend): add first-time setup page
- feat(frontend): add action dropdown menu to TabBar new-tab button
- feat(frontend): replace broadcast badge with icon and move to left slot
- feat(frontend): add touch event support for split pane drag and resize
- feat(workspace): add git operations and move endpoint
- feat(server): add /api/info endpoint with LAN IP, version and repo URL
- feat(plugins): add marketplace, git install and process management
- feat(server): add syntax-check and static asset routes
- feat(auth): support first-time setup without pre-configured token
- fix(frontend): collapse split container when reduced to single child
- fix(frontend): prevent closing last pane in a split
- fix(frontend): fix split pane collapse and resize after closing panes
- fix(session): reap child process on drop and purge closed pane from layouts
- fix(frontend): auto-focus terminal on window focus
- fix(build): use CARGO_PKG_VERSION as primary version source
- docs: add contributors wall to README
- docs: restructure README and extract detailed docs

## Test plan
- [ ] Split terminal panes and verify drag/resize works on desktop and mobile
- [ ] Close one of two split panes and verify the remaining pane unwraps correctly
- [ ] First-time setup page appears when no token is configured
- [ ] Plugin marketplace installs and manages processes correctly
- [ ] File workspace git operations function as expected