### PR TITLE
fix: reconnect stability, split-pane correctness, and mobile UX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "dinotty-desktop"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "axum 0.7.9",
  "dinotty-server",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "dinotty-server"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "axum 0.7.9",
  "axum-extra",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -982,6 +982,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-tungstenite",
+ "tokio-util",
  "tower-http 0.5.2",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["src-tauri"]
 
 [package]
 name = "dinotty-server"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 build = "build.rs"
 repository = "https://github.com/xichan96/dinotty"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ image = { version = "0.25", default-features = false, features = ["jpeg", "png",
 dirs = "5"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream", "gzip", "brotli", "blocking", "json"] }
 tokio-tungstenite = "0.24"
+tokio-util = { version = "0.7", features = ["io"] }
 bytes = "1"
 regex = "1.12.3"
 unicode-width = "0.2"

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1005,8 +1005,15 @@ async function connectSyncWS() {
         }
       }
     } else if (msg.type === 'layout_updated') {
-      // Find the tab by its pane_id (tab-level id)
-      const targetTab = tabs.value.find(t => t.paneId === msg.pane_id) as TerminalTab | undefined
+      // Find the tab by tab-level paneId OR by shared leaf paneIds
+      // (tab-level paneIds are client-local, so fall back to leaf matching)
+      const targetTab = tabs.value.find(t => {
+        if (t.type !== 'terminal') return false
+        if (t.paneId === msg.pane_id) return true
+        const incomingLeafIds = getAllLeaves(msg.layout).map((l: any) => l.paneId)
+        const localLeafIds = getAllLeaves(t.layout).map(l => l.paneId)
+        return incomingLeafIds.some((id: string) => localLeafIds.includes(id))
+      }) as TerminalTab | undefined
       if (targetTab) {
         suppressSync = true
         targetTab.layout = ensureSplitRoot(msg.layout)

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -43,7 +43,7 @@
             :active-pane-id="tab.activePaneId"
             :broadcast-mode="tab.broadcastMode"
             :broadcast-activity="tab.broadcastActivity"
-            :allow-close="tab.layout.type === 'split'"
+            :allow-close="getAllLeaves(tab.layout).length > 1"
             @register="registerTermRef"
             @title-change="onTitleChange"
             @focus="(id: string) => splitPane.focusPane(id)"
@@ -123,7 +123,7 @@ import ServerList from './components/ServerList.vue'
 import StatusBar from './components/terminal/StatusBar.vue'
 import type { SyncServerMsg, SyncClientMsg } from './types/protocol'
 import type { Tab, TerminalTab, PluginTab, PaneLayout } from './types/pane'
-import { migrateTab, getAllLeaves, findLeaf, findFirstLeaf } from './types/pane'
+import { migrateTab, getAllLeaves, findLeaf, findFirstLeaf, ensureSplitRoot } from './types/pane'
 import { useSettings } from './composables/useSettings'
 import { getApiBase, wsUrlWithToken, hasAuthToken, checkTokenConfigured, setAuthToken } from './composables/apiBase'
 import { isTauri } from './composables/useTransport'
@@ -346,7 +346,7 @@ function newTab() {
   tabs.value.push({
     type: 'terminal',
     paneId: tabId,
-    layout: { type: 'leaf', paneId, title: 'Terminal', ratio: 1, zoomed: false },
+    layout: ensureSplitRoot({ type: 'leaf', paneId, title: 'Terminal', ratio: 1, zoomed: false }),
     activePaneId: paneId,
     broadcastMode: false,
     broadcastActivity: 0,
@@ -402,11 +402,13 @@ function closeTab(tabId: string) {
   if (!tab) return
 
   if (tab.type === 'terminal') {
-    // Clean up all leaf pane refs and send close for each
+    // Clean up all leaf pane refs and close their sessions
     for (const leaf of getAllLeaves(tab.layout)) {
       delete termRefs[leaf.paneId]
-      sendSync({ type: 'close_tab', pane_id: leaf.paneId })
+      sendSync({ type: 'close_pane', pane_id: leaf.paneId })
     }
+    // Remove the tab layout entry and broadcast tab_closed
+    sendSync({ type: 'close_tab', pane_id: tab.paneId })
   }
 
   if (tabs.value.length === 1) {
@@ -415,7 +417,7 @@ function closeTab(tabId: string) {
     tabs.value[0] = {
       type: 'terminal',
       paneId: newTabId,
-      layout: { type: 'leaf', paneId: newPaneId, title: 'Terminal', ratio: 1, zoomed: false },
+      layout: ensureSplitRoot({ type: 'leaf', paneId: newPaneId, title: 'Terminal', ratio: 1, zoomed: false }),
       activePaneId: newPaneId,
       broadcastMode: false,
       broadcastActivity: 0,
@@ -887,7 +889,7 @@ async function connectSyncWS() {
           tabs.value.push({
             type: 'terminal',
             paneId: tabId,
-            layout: serverLayout ?? migrated?.layout ?? { type: 'leaf', paneId: tab.pane_id, title: 'Terminal', ratio: 1, zoomed: false },
+            layout: ensureSplitRoot(serverLayout ?? migrated?.layout ?? { type: 'leaf', paneId: tab.pane_id, title: 'Terminal', ratio: 1, zoomed: false }),
             activePaneId: tab.active_pane_id ?? migrated?.activePaneId ?? tab.pane_id,
             broadcastMode: false,
             broadcastActivity: 0,
@@ -959,7 +961,7 @@ async function connectSyncWS() {
         tabs.value.push({
           type: 'terminal',
           paneId: tabId,
-          layout: { type: 'leaf', paneId: msg.pane_id, title: 'Terminal', ratio: 1, zoomed: false },
+          layout: ensureSplitRoot({ type: 'leaf', paneId: msg.pane_id, title: 'Terminal', ratio: 1, zoomed: false }),
           activePaneId: msg.pane_id,
           broadcastMode: false,
       broadcastActivity: 0,
@@ -970,26 +972,22 @@ async function connectSyncWS() {
         })
       }
     } else if (msg.type === 'tab_closed') {
-      // Find which tab contains this leaf paneId
-      const tabIdx = tabs.value.findIndex(t => {
-        if (t.type !== 'terminal') return false
-        return !!findLeaf(t.layout, msg.pane_id)
-      })
+      // Tab-level close: find the tab by its paneId
+      const tabIdx = tabs.value.findIndex(t =>
+        t.type === 'terminal' && t.paneId === msg.pane_id,
+      )
       if (tabIdx !== -1) {
         const tab = tabs.value[tabIdx] as TerminalTab
-        const leaves = getAllLeaves(tab.layout)
-        if (leaves.length <= 1) {
-          // Last leaf, remove the tab
-          if (tabs.value.length > 1) {
-            delete termRefs[msg.pane_id]
-            tabs.value.splice(tabIdx, 1)
-            if (activePaneId.value === tab.paneId) {
-              activePaneId.value = tabs.value[Math.min(tabIdx, tabs.value.length - 1)].paneId
-            }
-            persist()
+        if (tabs.value.length > 1) {
+          for (const leaf of getAllLeaves(tab.layout)) {
+            delete termRefs[leaf.paneId]
           }
+          tabs.value.splice(tabIdx, 1)
+          if (activePaneId.value === tab.paneId) {
+            activePaneId.value = tabs.value[Math.min(tabIdx, tabs.value.length - 1)].paneId
+          }
+          persist()
         }
-        // Multi-leaf: the backend only closes individual panes, which we handle via closePane
       }
     } else if (msg.type === 'tab_activated') {
       const cur = tabs.value.find(t => t.paneId === activePaneId.value)
@@ -1011,7 +1009,7 @@ async function connectSyncWS() {
       const targetTab = tabs.value.find(t => t.paneId === msg.pane_id) as TerminalTab | undefined
       if (targetTab) {
         suppressSync = true
-        targetTab.layout = msg.layout
+        targetTab.layout = ensureSplitRoot(msg.layout)
         targetTab.activePaneId = msg.active_pane_id
         suppressSync = false
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -452,7 +452,9 @@ function focusActive() {
   if (!tab) return
   if (tab.type === 'terminal') {
     const paneId = tab.activePaneId
-    termRefs[paneId]?.focus()
+    if (!(isTouchDevice() && kbVisible.value)) {
+      termRefs[paneId]?.focus()
+    }
     termRefs[paneId]?.fit()
   }
 }

--- a/frontend/src/components/split/SplitContainer.vue
+++ b/frontend/src/components/split/SplitContainer.vue
@@ -49,14 +49,14 @@
     ref="containerRef"
     :class="['split-container', split.direction]"
   >
-    <template v-for="(child, idx) in split.children" :key="child.type === 'leaf' ? child.paneId : idx">
+    <template v-for="(child, idx) in split.children" :key="child.type === 'leaf' ? child.paneId : child.id">
       <SplitContainer
         :layout="child"
         :active-pane-id="activePaneId"
         :broadcast-mode="broadcastMode"
         :broadcast-activity="broadcastActivity"
-        :show-header="true"
-        :allow-close="true"
+        :show-header="allowClose"
+        :allow-close="allowClose"
         :parent-direction="split!.direction"
         :style="getChildStyle(idx)"
         @register="(id: string, el: any) => emit('register', id, el)"

--- a/frontend/src/composables/useSplitPane.ts
+++ b/frontend/src/composables/useSplitPane.ts
@@ -75,7 +75,6 @@ export function useSplitPane(opts: {
     }
 
     tab.activePaneId = newPaneId
-    sendSync({ type: 'create_tab', pane_id: newPaneId })
     persist()
     syncTabLayout(tab)
     nextTick(() => termRefs[newPaneId]?.focus())
@@ -113,7 +112,11 @@ export function useSplitPane(opts: {
         if (remaining.type === 'split') {
           tab.layout = remaining
         }
-      } else if (remaining.type === 'split') {
+      } else {
+        // Nested split: always collapse regardless of remaining child type.
+        // A single-child non-root split is degenerate — leaving it causes
+        // findParentSplit to return the degenerate split on next closePane,
+        // which then returns false and triggers closeTab (closing the whole tab).
         replaceNode(tab.layout, parent, remaining)
       }
     }

--- a/frontend/src/composables/useSplitPane.ts
+++ b/frontend/src/composables/useSplitPane.ts
@@ -3,7 +3,7 @@ import type { Tab, TerminalTab, PaneLayout, LeafPane, SplitPane, DropPosition } 
 import {
   findLeaf, findParentSplit, getAllLeaves, findFirstLeaf,
   replaceLeaf, replaceNode, redistributeRatios, clearAllZoom, equalizeRecursive,
-  removeLeaf,
+  removeLeaf, genSplitId,
 } from '../types/pane'
 import type TerminalPane from '../components/terminal/TerminalPane.vue'
 import type { SyncClientMsg } from '../types/protocol'
@@ -58,6 +58,7 @@ export function useSplitPane(opts: {
 
     const split: SplitPane = {
       type: 'split',
+      id: genSplitId(),
       direction,
       children: [{ ...currentLeaf, ratio: 0.5 }, newLeaf],
       ratios: [0.5, 0.5],
@@ -65,6 +66,10 @@ export function useSplitPane(opts: {
 
     if (tab.layout.type === 'leaf') {
       tab.layout = split
+    } else if (tab.layout.type === 'split' && tab.layout.children.length === 1 && tab.layout.direction === direction) {
+      // Single-child root split with same direction — add sibling directly
+      tab.layout.children.push(newLeaf)
+      redistributeRatios(tab.layout)
     } else {
       replaceLeaf(tab.layout, tab.activePaneId, split)
     }
@@ -90,6 +95,11 @@ export function useSplitPane(opts: {
     const idx = parent.children.findIndex(c => c.type === 'leaf' && c.paneId === paneId)
     if (idx === -1) return false
 
+    // If removing this leaf would leave the parent with 0 children, signal to close the tab
+    if (parent.children.length <= 1) {
+      return false
+    }
+
     parent.children.splice(idx, 1)
     parent.ratios.splice(idx, 1)
     redistributeRatios(parent)
@@ -97,8 +107,13 @@ export function useSplitPane(opts: {
     if (parent.children.length === 1) {
       const remaining = parent.children[0]
       if (parent === tab.layout) {
-        tab.layout = remaining
-      } else {
+        // Root-level: only collapse if the remaining child is a split
+        // (collapsing split→leaf destroys and recreates all TerminalPane components,
+        // breaking active sessions — e.g. htop loses its PTY)
+        if (remaining.type === 'split') {
+          tab.layout = remaining
+        }
+      } else if (remaining.type === 'split') {
         replaceNode(tab.layout, parent, remaining)
       }
     }
@@ -111,10 +126,10 @@ export function useSplitPane(opts: {
       tab.broadcastMode = false
     }
 
-    sendSync({ type: 'close_tab', pane_id: paneId })
     delete termRefs[paneId]
     persist()
     syncTabLayout(tab)
+    sendSync({ type: 'close_pane', pane_id: paneId })
     nextTick(() => {
       getAllLeaves(tab.layout).forEach(l => termRefs[l.paneId]?.fit())
       termRefs[tab.activePaneId]?.focus()
@@ -342,6 +357,7 @@ export function useSplitPane(opts: {
     if (sameParent && sourceParent.children.length === 2) {
       const newSplit: SplitPane = {
         type: 'split',
+        id: genSplitId(),
         direction,
         children: before
           ? [sourceParent.children.find(c => c.type === 'leaf' && c.paneId === sourcePaneId)!, sourceParent.children.find(c => c.type === 'leaf' && c.paneId === targetPaneId)!]
@@ -366,15 +382,11 @@ export function useSplitPane(opts: {
     const removed = removeLeaf(tab.layout, sourcePaneId)
     if (!removed) return
 
-    // Collapse single-child root split (removeLeaf can't reassign caller's variable)
-    if (tab.layout.type === 'split' && tab.layout.children.length === 1) {
-      tab.layout = tab.layout.children[0]
-    }
-
     // After removal, target may have become the root leaf (parent collapsed)
     if (tab.layout.type === 'leaf' && tab.layout.paneId === targetPaneId) {
       const newSplit: SplitPane = {
         type: 'split',
+        id: genSplitId(),
         direction,
         children: before ? [removed, tab.layout] : [tab.layout, removed],
         ratios: [0.5, 0.5],
@@ -407,6 +419,7 @@ export function useSplitPane(opts: {
         // Different direction: wrap target in a new split
         const newSplit: SplitPane = {
           type: 'split',
+          id: genSplitId(),
           direction,
           children: before ? [removed, effectiveTargetParent.children[targetIdx]] : [effectiveTargetParent.children[targetIdx], removed],
           ratios: [0.5, 0.5],
@@ -430,6 +443,7 @@ export function useSplitPane(opts: {
           // Different direction: wrap the split in a new split
           const newSplit: SplitPane = {
             type: 'split',
+            id: genSplitId(),
             direction,
             children: before ? [removed, targetNode] : [targetNode, removed],
             ratios: [0.5, 0.5],

--- a/frontend/src/composables/useTerminal.ts
+++ b/frontend/src/composables/useTerminal.ts
@@ -330,11 +330,14 @@ export class TerminalInstance {
       this.onDisconnect?.()
     })
 
-    this.xterm!.onData((data) => {
-      if (this._compositionGuard && !this._compositionGuard(data)) return
-      this.onInput?.(data)
-      this._transport?.send({ type: 'input', data })
-    })
+    if (!this._onDataRegistered) {
+      this._onDataRegistered = true
+      this.xterm!.onData((data) => {
+        if (this._compositionGuard && !this._compositionGuard(data)) return
+        this.onInput?.(data)
+        this._transport?.send({ type: 'input', data })
+      })
+    }
   }
 
   // ── Private ──────────────────────────────────────────────

--- a/frontend/src/composables/useTransport.ts
+++ b/frontend/src/composables/useTransport.ts
@@ -176,7 +176,7 @@ export class TauriIpcTransport implements Transport {
   }
 
   disconnect() {
-    this._invoke('pty_kill')
+    this._invoke('pty_detach')
     for (const u of this._unlistenFns) {
       u()
     }

--- a/frontend/src/types/pane.ts
+++ b/frontend/src/types/pane.ts
@@ -10,6 +10,7 @@ export interface LeafPane {
 /** 分割容器：水平或垂直排列子节点 */
 export interface SplitPane {
   type: 'split'
+  id: string             // Stable identifier for Vue key (survives reorder)
   direction: 'horizontal' | 'vertical'
   children: PaneLayout[]
   ratios: number[]
@@ -50,7 +51,7 @@ export function migrateTab(raw: any): TerminalTab {
     return {
       type: 'terminal',
       paneId: raw.paneId,
-      layout: { type: 'leaf', paneId: raw.paneId, title: raw.title ?? 'Terminal', ratio: 1, zoomed: false },
+      layout: ensureSplitRoot({ type: 'leaf', paneId: raw.paneId, title: raw.title ?? 'Terminal', ratio: 1, zoomed: false }),
       activePaneId: raw.paneId,
       broadcastMode: false,
       broadcastActivity: 0,
@@ -190,4 +191,27 @@ export function removeLeaf(root: PaneLayout, paneId: string): LeafPane | null {
   }
 
   return removed
+}
+
+/** Generate a stable ID for a SplitPane */
+export function genSplitId(): string {
+  return 's-' + crypto.randomUUID()
+}
+
+/** Ensure a SplitPane has an id (for deserialized/migrated data) */
+export function ensureSplitId(split: SplitPane): SplitPane {
+  if (!split.id) split.id = genSplitId()
+  return split
+}
+
+/** Wrap a leaf layout in a single-child split so the root is always a SplitPane */
+export function ensureSplitRoot(layout: PaneLayout): SplitPane {
+  if (layout.type === 'split') return ensureSplitId(layout)
+  return {
+    type: 'split',
+    id: genSplitId(),
+    direction: 'horizontal',
+    children: [layout],
+    ratios: [1.0],
+  }
 }

--- a/frontend/src/types/protocol.ts
+++ b/frontend/src/types/protocol.ts
@@ -76,6 +76,11 @@ export interface SyncCloseTab {
   pane_id: string
 }
 
+export interface SyncClosePane {
+  type: 'close_pane'
+  pane_id: string
+}
+
 export interface SyncActivateTab {
   type: 'activate_tab'
   pane_id: string
@@ -88,4 +93,4 @@ export interface SyncUpdateLayout {
   active_pane_id: string
 }
 
-export type SyncClientMsg = SyncCreateTab | SyncCloseTab | SyncActivateTab | SyncUpdateLayout
+export type SyncClientMsg = SyncCreateTab | SyncCloseTab | SyncClosePane | SyncActivateTab | SyncUpdateLayout

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dinotty-desktop"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -77,6 +77,7 @@ fn pty_spawn(
                 *g = Some(Arc::clone(&exit_cb));
             }
         }
+        session.clear_clients();
         emit_join_sync(&app, &pane_id, &session);
         spawn_tauri_output_forwarder(app.clone(), pane_id.clone(), Arc::clone(&session));
         return Ok(session.shell_type.clone());

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -142,6 +142,19 @@ fn pty_kill(pane_id: String, state: State<'_, Arc<SessionManager>>) -> Result<()
 }
 
 #[tauri::command]
+fn pty_detach(pane_id: String, state: State<'_, Arc<SessionManager>>) -> Result<(), String> {
+    if let Some(entry) = state.sessions.get(&pane_id) {
+        let session = Arc::clone(entry.value());
+        if !session.has_clients() {
+            *session.status.lock().unwrap() = SessionStatus::Detached {
+                since: std::time::Instant::now(),
+            };
+        }
+    }
+    Ok(())
+}
+
+#[tauri::command]
 fn embedded_http_origin() -> String {
     let port = EMBEDDED_HTTP_PORT.get().copied().unwrap_or(8999);
     format!("http://127.0.0.1:{port}")
@@ -234,6 +247,7 @@ fn main() {
             pty_write,
             pty_resize,
             pty_kill,
+            pty_detach,
             embedded_http_origin,
             tauri_fetch,
         ])

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nickelpack/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "Dinotty",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "identifier": "com.dinotty.terminal",
   "build": {
     "frontendDist": "../frontend/dist",

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -41,7 +41,8 @@ pub async fn auth_middleware(
         return next.run(request).await;
     }
 
-    if path == "/" || path == "/api/notify" || path == "/manifest.json" || path == "/logo.png"
+    if path == "/" || path == "/api/notify" || path == "/api/token-configured"
+        || path == "/manifest.json" || path == "/logo.png"
         || path.starts_with("/assets/") || path.starts_with("/preview/") || path.starts_with("/icons/")
     {
         return next.run(request).await;

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -69,6 +69,7 @@ pub fn create_session(
         child: std::sync::Mutex::new(child),
         screen: std::sync::Mutex::new(VirtualScreen::new(80, 24)),
         clients: std::sync::Mutex::new(Vec::new()),
+        input_tx: std::sync::Mutex::new(None),
         status: std::sync::Mutex::new(SessionStatus::Connected),
         size: std::sync::Mutex::new((80, 24)),
         shell_type: shell_type.clone(),
@@ -79,9 +80,6 @@ pub fn create_session(
         }),
     });
     manager.sessions.insert(pane_id.clone(), Arc::clone(&session));
-    manager.broadcast_sync(&SyncMsg::TabCreated {
-        pane_id: pane_id.clone(),
-    });
 
     let session_clone = Arc::clone(&session);
     let pane_id_clone = pane_id.clone();

--- a/src/session.rs
+++ b/src/session.rs
@@ -27,6 +27,7 @@ pub struct Session {
     pub child: Mutex<Box<dyn Child + Send + Sync>>,
     pub screen: Mutex<VirtualScreen>,
     pub clients: Mutex<Vec<mpsc::UnboundedSender<String>>>,
+    pub input_tx: Mutex<Option<mpsc::UnboundedSender<String>>>,
     pub status: Mutex<SessionStatus>,
     pub size: Mutex<(u16, u16)>,
     #[allow(dead_code)]
@@ -45,10 +46,27 @@ impl Session {
         sniff_cwd_from_title_osc(sniff_buf, data, &home, cwd);
     }
 
+    /// Replace the input channel, closing the old one (if any) so the previous
+    /// PTY write task exits. Returns the new receiver for the caller to spawn
+    /// a write task on.
+    pub fn replace_input_channel(&self) -> mpsc::UnboundedReceiver<String> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let old = self.input_tx.lock().unwrap().replace(tx);
+        drop(old); // close old sender → old write task's recv() returns None
+        rx
+    }
+
     pub fn add_client(&self) -> mpsc::UnboundedReceiver<String> {
         let (tx, rx) = mpsc::unbounded_channel();
         self.clients.lock().unwrap().push(tx);
         rx
+    }
+
+    /// Remove all existing clients so old forwarder tasks exit cleanly.
+    /// Must be called before `add_client` on reconnection to prevent
+    /// duplicate output delivery.
+    pub fn clear_clients(&self) {
+        self.clients.lock().unwrap().clear();
     }
 
     pub fn broadcast(&self, msg: &str) {
@@ -138,6 +156,10 @@ fn remove_pane_from_layout(node: &serde_json::Value, pane_id: &str) -> Option<se
             match new_children.len() {
                 0 => None,
                 _ if new_children.len() == children.len() => Some(node.clone()),
+                1 => {
+                    // Single-child split is degenerate — collapse by returning the child directly
+                    Some(new_children.into_iter().next().unwrap())
+                }
                 _ => {
                     let mut result = node.clone();
                     result["children"] = serde_json::Value::Array(new_children);
@@ -258,10 +280,12 @@ impl SessionManager {
             if new_layout == *layout {
                 return None;
             }
-            let active = val.get("active_pane_id").cloned();
+            let active = val.get("active_pane_id").and_then(|v| v.as_str());
+            let new_leaf_ids = collect_leaf_pane_ids(&new_layout);
+            let active_pane_id = active.filter(|id| new_leaf_ids.iter().any(|lid| lid == *id));
             let mut new_val = serde_json::json!({ "layout": new_layout });
-            if let Some(a) = active {
-                new_val["active_pane_id"] = a;
+            if let Some(a) = active_pane_id {
+                new_val["active_pane_id"] = serde_json::Value::String(a.to_string());
             }
             Some((tab_pane_id.clone(), new_val))
         }).collect();

--- a/src/session.rs
+++ b/src/session.rs
@@ -137,7 +137,7 @@ fn remove_pane_from_layout(node: &serde_json::Value, pane_id: &str) -> Option<se
                 .collect();
             match new_children.len() {
                 0 => None,
-                1 => Some(new_children.into_iter().next().unwrap()),
+                _ if new_children.len() == children.len() => Some(node.clone()),
                 _ => {
                     let mut result = node.clone();
                     result["children"] = serde_json::Value::Array(new_children);

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -526,16 +526,17 @@ pub async fn workspace_raw(
             (StatusCode::RANGE_NOT_SATISFIABLE, headers, Body::empty()).into_response()
         }
         ByteRangeResult::Full => {
-            let bytes = match tokio::fs::read(&target).await {
-                Ok(b) => b,
+            let file = match tokio::fs::File::open(&target).await {
+                Ok(f) => f,
                 Err(e) => return json_err(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
             };
+            let stream = tokio_util::io::ReaderStream::new(file);
             headers.insert(
                 header::CONTENT_LENGTH,
                 HeaderValue::from_str(&len.to_string())
                     .unwrap_or_else(|_| HeaderValue::from_static("0")),
             );
-            (StatusCode::OK, headers, Body::from(bytes)).into_response()
+            (StatusCode::OK, headers, Body::from_stream(stream)).into_response()
         }
     }
 }

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -175,6 +175,16 @@ async fn handle_socket(socket: WebSocket, pane_id: String, manager: Arc<SessionM
             }
         });
 
+        // Input channel: replaces old channel so only this connection writes to PTY
+        let mut input_rx = session.replace_input_channel();
+        let write_session = Arc::clone(&session);
+        tokio::spawn(async move {
+            while let Some(data) = input_rx.recv().await {
+                let mut w = write_session.writer.lock().unwrap();
+                let _ = w.write_all(data.as_bytes());
+            }
+        });
+
         // Read loop
         while let Some(Ok(msg)) = ws_rx.next().await {
             match msg {
@@ -197,8 +207,10 @@ async fn handle_socket(socket: WebSocket, pane_id: String, manager: Arc<SessionM
                                     input_buffer.push(ch);
                                 }
                             }
-                            let mut w = session.writer.lock().unwrap();
-                            let _ = w.write_all(data.as_bytes());
+                            let tx = session.input_tx.lock().unwrap();
+                            if let Some(tx) = tx.as_ref() {
+                                let _ = tx.send(data);
+                            }
                         }
                         Ok(ClientMsg::Resize { cols, rows }) => {
                             let m = session.master.lock().unwrap();
@@ -247,6 +259,16 @@ async fn handle_socket(socket: WebSocket, pane_id: String, manager: Arc<SessionM
         }
     });
 
+    // Input channel: dedicated write task reads from channel → PTY writer
+    let mut input_rx = session.replace_input_channel();
+    let write_session = Arc::clone(&session);
+    tokio::spawn(async move {
+        while let Some(data) = input_rx.recv().await {
+            let mut w = write_session.writer.lock().unwrap();
+            let _ = w.write_all(data.as_bytes());
+        }
+    });
+
     // WS read loop
     while let Some(Ok(msg)) = ws_rx.next().await {
         match msg {
@@ -269,8 +291,10 @@ async fn handle_socket(socket: WebSocket, pane_id: String, manager: Arc<SessionM
                                 input_buffer.push(ch);
                             }
                         }
-                        let mut w = session.writer.lock().unwrap();
-                        let _ = w.write_all(data.as_bytes());
+                        let tx = session.input_tx.lock().unwrap();
+                        if let Some(tx) = tx.as_ref() {
+                            let _ = tx.send(data);
+                        }
                     }
                     Ok(ClientMsg::Resize { cols, rows }) => {
                         let m = session.master.lock().unwrap();

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -38,6 +38,7 @@ pub enum SyncClientMsg {
     ActivateTab { pane_id: String },
     CreateTab { pane_id: String },
     CloseTab { pane_id: String },
+    ClosePane { pane_id: String },
     UpdateLayout { pane_id: String, layout: serde_json::Value, active_pane_id: String },
 }
 
@@ -105,6 +106,12 @@ async fn handle_sync_socket(socket: WebSocket, manager: Arc<SessionManager>) {
                             manager.purge_pane_from_layouts(&pane_id);
                             manager.broadcast_sync(&SyncMsg::TabClosed { pane_id });
                         }
+                        SyncClientMsg::ClosePane { pane_id } => {
+                            // Close a single pane in a split — only remove its session,
+                            // don't touch tab layout or broadcast tab_closed
+                            manager.sessions.remove(&pane_id);
+                            manager.purge_pane_from_layouts(&pane_id);
+                        }
                         SyncClientMsg::UpdateLayout { pane_id, layout, active_pane_id } => {
                             manager.tab_layouts.insert(pane_id.clone(), serde_json::json!({
                                 "layout": layout,
@@ -169,7 +176,6 @@ async fn handle_socket(socket: WebSocket, pane_id: String, manager: Arc<SessionM
         });
 
         // Read loop
-        let mut normal_close = false;
         while let Some(Ok(msg)) = ws_rx.next().await {
             match msg {
                 Message::Text(text) => {
@@ -204,21 +210,14 @@ async fn handle_socket(socket: WebSocket, pane_id: String, manager: Arc<SessionM
                         Err(e) => error!("parse msg: {}", e),
                     }
                 }
-                Message::Close(frame) => {
-                    normal_close = frame.as_ref().map(|f| f.code == 1000).unwrap_or(false);
-                    break;
-                }
+                Message::Close(_) => break,
                 _ => {}
             }
         }
 
         fwd.abort();
 
-        if normal_close && !session.has_clients() {
-            manager.sessions.remove(&pane_id);
-            manager.broadcast_sync(&SyncMsg::TabClosed { pane_id: pane_id.clone() });
-            info!("Session destroyed (last client closed): pane={}", pane_id);
-        } else if !session.has_clients() {
+        if !session.has_clients() {
             *session.status.lock().unwrap() = SessionStatus::Detached { since: std::time::Instant::now() };
             info!("Session detached (all clients gone): pane={}", pane_id);
         }
@@ -249,7 +248,6 @@ async fn handle_socket(socket: WebSocket, pane_id: String, manager: Arc<SessionM
     });
 
     // WS read loop
-    let mut normal_close = false;
     while let Some(Ok(msg)) = ws_rx.next().await {
         match msg {
             Message::Text(text) => {
@@ -284,23 +282,16 @@ async fn handle_socket(socket: WebSocket, pane_id: String, manager: Arc<SessionM
                     Err(e) => error!("parse msg: {}", e),
                 }
             }
-            Message::Close(frame) => {
-                normal_close = frame.as_ref().map(|f| f.code == 1000).unwrap_or(false);
-                break;
-            }
+            Message::Close(_) => break,
             _ => {}
         }
     }
 
     fwd.abort();
 
-    if normal_close && !session.has_clients() {
-        manager.sessions.remove(&pane_id);
-        manager.broadcast_sync(&SyncMsg::TabClosed { pane_id: pane_id.clone() });
-        info!("Session destroyed (normal close): pane={}", pane_id);
-    } else if !session.has_clients() {
+    if !session.has_clients() {
         *session.status.lock().unwrap() = SessionStatus::Detached { since: std::time::Instant::now() };
-        info!("Session detached (abnormal close): pane={}", pane_id);
+        info!("Session detached (all clients gone): pane={}", pane_id);
     }
 }
 


### PR DESCRIPTION
## Summary

- **fix(pty):** Use dedicated input channel to prevent duplicate writes on reconnect — replaces direct writer access with a single-writer pattern so only the latest connection writes to PTY
- **fix(terminal):** Guard onData registration to prevent duplicate handlers on reconnection
- **fix(split-pane):** Collapse degenerate single-child splits on pane close to prevent incorrect closeTab triggers
- **fix(sync):** Match layout_updated by leaf paneIds for multi-client sync (tab-level paneIds are client-local)
- **fix(mobile):** Skip terminal focus when mobile keyboard is visible
- **fix(auth):** Allow /api/token-configured without authentication
- **fix(frontend):** Fix race condition when closing a split pane
- **perf(workspace):** Use streaming response for file downloads
- **refactor(transport):** Replace pty_kill with pty_detach for Tauri transport
- **chore:** Bump version to v0.10.2

## Test plan

- [ ] Open terminal, disconnect and reconnect — verify no duplicate output or input
- [ ] Split a pane, close inner pane — verify tab stays open and layout collapses correctly
- [ ] Open same session in two browser tabs — verify layout sync works across clients
- [ ] On mobile device — verify keyboard open/close doesn't steal focus unexpectedly
- [ ] Test file download in workspace — verify streaming works for large files