### PR TITLE
chore: bump version to v0.10.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "dinotty-desktop"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "axum 0.7.9",
  "dinotty-server",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "dinotty-server"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "axum 0.7.9",
  "axum-extra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["src-tauri"]
 
 [package]
 name = "dinotty-server"
-version = "0.10.3"
+version = "0.10.4"
 edition = "2021"
 build = "build.rs"
 repository = "https://github.com/xichan96/dinotty"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dinotty-desktop"
-version = "0.10.3"
+version = "0.10.4"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nickelpack/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "Dinotty",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "identifier": "com.dinotty.terminal",
   "build": {
     "frontendDist": "../frontend/dist",


### PR DESCRIPTION
## Summary
- Bump version to 0.10.4 to match v0.10.4 tag

## Test plan
- [ ] Version displays correctly in UI