### PR TITLE
feat: server-led tab and pane management API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "dinotty-desktop"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "axum 0.7.9",
  "dinotty-server",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "dinotty-server"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "axum 0.7.9",
  "axum-extra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["src-tauri"]
 
 [package]
 name = "dinotty-server"
-version = "0.10.4"
+version = "0.10.5"
 edition = "2021"
 build = "build.rs"
 repository = "https://github.com/xichan96/dinotty"

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -17,7 +17,7 @@
     >
       <template #left>
         <button v-if="isBroadcastActive" type="button" class="tab-bar-icon-btn broadcast-btn" :title="t('split.toggleBroadcast')" @click="splitPane.toggleBroadcast()" @touchend.prevent="splitPane.toggleBroadcast()">
-          <span class="broadcast-dot" />
+          <Radar :size="16" />
         </button>
       </template>
       <template #right>
@@ -33,7 +33,7 @@
     <div id="tab-content" @touchend="onTerminalTouch">
       <div
         v-for="tab in tabs"
-        :key="tab.paneId"
+        :key="tabKey(tab)"
         class="tab-page"
         :class="{ active: tab.paneId === activePaneId, 'has-preview': tab.type === 'terminal' && tab.previewVisible, ['pos-' + resolvedPosition]: tab.type === 'terminal' && tab.previewVisible }"
       >
@@ -137,7 +137,8 @@ import NotificationPanel from './components/notification/NotificationPanel.vue'
 import { useNotification } from './composables/useNotification'
 import { usePluginLoader, handlePluginChanged } from './composables/usePluginLoader'
 import PluginView from './components/plugin/PluginView.vue'
-import { Settings, Bell, Monitor, Plus, X, Star, AppWindow } from 'lucide-vue-next'
+import { apiCreateTab, apiCloseTab, apiClosePane, apiActivatePane } from './composables/useTabApi'
+import { Settings, Bell, Monitor, Plus, X, Star, AppWindow, Radar } from 'lucide-vue-next'
 import LoginPage from './components/LoginPage.vue'
 import SetupPage from './components/SetupPage.vue'
 
@@ -272,6 +273,13 @@ function genPaneId(): string {
   })
 }
 
+/** Stable key for tab v-for — uses the first leaf paneId which never changes */
+function tabKey(tab: Tab): string {
+  if (tab.type !== 'terminal') return tab.paneId
+  const leaf = findFirstLeaf(tab.layout)
+  return leaf ? leaf.paneId : tab.paneId
+}
+
 function sendSync(msg: SyncClientMsg) {
   if (syncWs && syncWs.readyState === WebSocket.OPEN && !suppressSync) {
     syncWs.send(JSON.stringify(msg))
@@ -340,25 +348,30 @@ function getSavedTitle(paneId: string): string | null {
 
 const DEFAULT_PREVIEW_URL = ''
 
-function newTab() {
-  const tabId = genPaneId()
-  const paneId = genPaneId()
-  tabs.value.push({
-    type: 'terminal',
-    paneId: tabId,
-    layout: ensureSplitRoot({ type: 'leaf', paneId, title: 'Terminal', ratio: 1, zoomed: false }),
-    activePaneId: paneId,
-    broadcastMode: false,
-    broadcastActivity: 0,
-    previewVisible: false,
-    previewAddress: '',
-    previewUrl: '',
-    previewKind: 'web',
-  })
-  activePaneId.value = tabId
-  sendSync({ type: 'create_tab', pane_id: paneId })
-  persist()
-  nextTick(() => focusActive())
+async function newTab() {
+  try {
+    const result = await apiCreateTab()
+    const layout = ensureSplitRoot(result.layout)
+    tabs.value.push({
+      type: 'terminal',
+      paneId: result.tab_id,
+      layout,
+      activePaneId: result.pane_id,
+      broadcastMode: false,
+      broadcastActivity: 0,
+      previewVisible: false,
+      previewAddress: '',
+      previewUrl: '',
+      previewKind: 'web',
+    })
+    activePaneId.value = result.tab_id
+    persist()
+    // Notify other sync clients
+    sendSync({ type: 'create_tab', layout: result.layout, tab_id: result.tab_id, pane_id: result.pane_id })
+    nextTick(() => focusActive())
+  } catch (e) {
+    console.error('Failed to create tab:', e)
+  }
 }
 
 function onNewMenuAction(type: 'new-tab' | 'split-h' | 'split-v' | 'broadcast') {
@@ -370,11 +383,16 @@ function onNewMenuAction(type: 'new-tab' | 'split-h' | 'split-v' | 'broadcast') 
   }
 }
 
-function activateTab(tabId: string) {
+async function activateTab(tabId: string) {
   activePaneId.value = tabId
   const tab = tabs.value.find(t => t.paneId === tabId)
   if (tab?.type === 'terminal') {
     notif.clearPaneUnread(tab.activePaneId)
+    try {
+      await apiActivatePane(tab.paneId, tab.activePaneId)
+    } catch (e) {
+      console.error('Failed to activate pane:', e)
+    }
     sendSync({ type: 'activate_tab', pane_id: tab.activePaneId })
   }
   persist()
@@ -390,52 +408,44 @@ function reorderTab(fromId: string, toId: string) {
   persist()
 }
 
-function onClosePane(tabId: string, paneId: string) {
-  const closed = splitPane.closePane(paneId)
+async function onClosePane(tabId: string, paneId: string) {
+  const closed = await splitPane.closePane(paneId)
   if (!closed) {
     closeTab(tabId)
   }
 }
 
-function closeTab(tabId: string) {
+async function closeTab(tabId: string) {
   const tab = tabs.value.find(t => t.paneId === tabId)
   if (!tab) return
 
   if (tab.type === 'terminal') {
-    // Clean up all leaf pane refs and close their sessions
+    // Clean up local term refs
     for (const leaf of getAllLeaves(tab.layout)) {
       delete termRefs[leaf.paneId]
-      sendSync({ type: 'close_pane', pane_id: leaf.paneId })
     }
-    // Remove the tab layout entry and broadcast tab_closed
-    sendSync({ type: 'close_tab', pane_id: tab.paneId })
+
+    try {
+      await apiCloseTab(tabId)
+    } catch (e) {
+      console.error('Failed to close tab:', e)
+      return
+    }
+    // Notify other sync clients
+    sendSync({ type: 'close_tab', pane_id: tabId })
   }
 
-  if (tabs.value.length === 1) {
-    const newTabId = genPaneId()
-    const newPaneId = genPaneId()
-    tabs.value[0] = {
-      type: 'terminal',
-      paneId: newTabId,
-      layout: ensureSplitRoot({ type: 'leaf', paneId: newPaneId, title: 'Terminal', ratio: 1, zoomed: false }),
-      activePaneId: newPaneId,
-      broadcastMode: false,
-      broadcastActivity: 0,
-      previewVisible: false,
-      previewAddress: '',
-      previewUrl: '',
-      previewKind: 'web',
-    }
-    activePaneId.value = newTabId
-    sendSync({ type: 'create_tab', pane_id: newPaneId })
-    persist()
-    return
-  }
-
+  // Remove tab from local array
   const idx = tabs.value.findIndex((t) => t.paneId === tabId)
   if (idx === -1) return
 
   tabs.value.splice(idx, 1)
+
+  // If this was the last tab, create a new one
+  if (tabs.value.length === 0) {
+    await newTab()
+    return
+  }
 
   if (activePaneId.value === tabId) {
     const newIdx = Math.min(idx, tabs.value.length - 1)
@@ -684,11 +694,11 @@ const paletteCommands = computed<Command[]>(() => {
       title: 'Close Tab',
       subtitle: 'Close the current tab',
       kbd: formatBinding(getBinding('closeTab')),
-      action: () => {
+      action: async () => {
         if (activePaneId.value) {
           const tab = tabs.value.find(t => t.paneId === activePaneId.value)
           if (tab?.type === 'terminal' && getAllLeaves(tab.layout).length > 1) {
-            if (!splitPane.closePane(tab.activePaneId)) {
+            if (!await splitPane.closePane(tab.activePaneId)) {
               closeTab(activePaneId.value)
             }
           } else {
@@ -786,12 +796,12 @@ function onGlobalKeydown(e: KeyboardEvent) {
     togglePalette: () => paletteRef.value?.toggle(),
     openBookmarks: () => openQuickPicks(),
     newTab: () => newTab(),
-    closeTab: () => {
+    closeTab: async () => {
       if (!activePaneId.value) return
       const tab = tabs.value.find(t => t.paneId === activePaneId.value)
       if (tab?.type === 'terminal' && getAllLeaves(tab.layout).length > 1) {
         // Multi-pane: close current pane
-        if (!splitPane.closePane(tab.activePaneId)) {
+        if (!await splitPane.closePane(tab.activePaneId)) {
           closeTab(activePaneId.value)
         }
       } else {
@@ -870,10 +880,12 @@ async function connectSyncWS() {
     }
 
     if (msg.type === 'tab_list') {
-      // Collect all local leaf paneIds
+      // Collect all local leaf paneIds and tab-level paneIds
       const localLeafIds = new Set<string>()
+      const localTabIds = new Set<string>()
       for (const t of tabs.value) {
         if (t.type === 'terminal') {
+          localTabIds.add(t.paneId)
           for (const leaf of getAllLeaves(t.layout)) {
             localLeafIds.add(leaf.paneId)
           }
@@ -882,15 +894,14 @@ async function connectSyncWS() {
 
       // Create tabs for any server paneIds we don't have locally
       for (const tab of msg.tabs) {
-        if (!localLeafIds.has(tab.pane_id)) {
+        if (!localLeafIds.has(tab.pane_id) && !localTabIds.has(tab.pane_id) && !localTabIds.has(tab.tab_id)) {
           // Prefer server layout, then localStorage, then default single leaf
           const serverLayout = tab.layout ?? null
           const saved = !serverLayout ? getSavedTab(tab.pane_id) : null
           const migrated = saved ? migrateTab(saved) : null
-          const tabId = genPaneId()
           tabs.value.push({
             type: 'terminal',
-            paneId: tabId,
+            paneId: tab.tab_id,
             layout: ensureSplitRoot(serverLayout ?? migrated?.layout ?? { type: 'leaf', paneId: tab.pane_id, title: 'Terminal', ratio: 1, zoomed: false }),
             activePaneId: tab.active_pane_id ?? migrated?.activePaneId ?? tab.pane_id,
             broadcastMode: false,
@@ -922,11 +933,11 @@ async function connectSyncWS() {
       } catch { /* noop */ }
 
       // Remove terminal tabs whose leaf paneIds are no longer on the server
-      const serverTabIds = new Set(msg.tabs.map((t) => t.pane_id))
+      const serverTabIds = new Set(msg.tabs.map((t) => t.tab_id))
       const serverLeafIds = new Set(msg.tabs.flatMap((t) => t.layout ? getAllLeaves(t.layout).map(l => l.paneId) : []))
       tabs.value = tabs.value.filter((t) => {
         if (t.type === 'plugin') return true
-        // Keep tab if it matches a server tab by tabId, or if at least one leaf is in a server layout
+        // Keep tab if it matches a server tab by tabId or leaf paneId, or if at least one leaf is in a server layout
         return serverTabIds.has(t.paneId) || getAllLeaves(t.layout).some(l => serverLeafIds.has(l.paneId))
       })
 
@@ -951,44 +962,64 @@ async function connectSyncWS() {
         newTab()
       }
 
+      // Fallback: ensure at least one tab is active after sync
+      if (!activePaneId.value || !tabs.value.some(t => t.paneId === activePaneId.value)) {
+        if (tabs.value.length > 0) {
+          activePaneId.value = tabs.value[0].paneId
+        }
+      }
+
       persist()
     } else if (msg.type === 'tab_created') {
-      // Check if this leaf paneId already exists in any tab
+      // Check if this tab already exists locally (either our own or from tab_list)
       const exists = tabs.value.some(t => {
         if (t.type !== 'terminal') return false
-        return !!findLeaf(t.layout, msg.pane_id)
+        return t.paneId === msg.tab_id || !!findLeaf(t.layout, msg.pane_id)
       })
       if (!exists) {
-        const tabId = genPaneId()
+        // Broadcast from another client — create the tab
+        const layout = msg.layout ? ensureSplitRoot(msg.layout) : ensureSplitRoot({ type: 'leaf', paneId: msg.pane_id, title: 'Terminal', ratio: 1, zoomed: false })
         tabs.value.push({
           type: 'terminal',
-          paneId: tabId,
-          layout: ensureSplitRoot({ type: 'leaf', paneId: msg.pane_id, title: 'Terminal', ratio: 1, zoomed: false }),
+          paneId: msg.tab_id,
+          layout,
           activePaneId: msg.pane_id,
           broadcastMode: false,
-      broadcastActivity: 0,
+          broadcastActivity: 0,
           previewVisible: false,
           previewAddress: '',
           previewUrl: '',
           previewKind: 'web',
         })
+        suppressSync = true
+        activePaneId.value = msg.tab_id
+        suppressSync = false
+        persist()
+        nextTick(() => focusActive())
       }
     } else if (msg.type === 'tab_closed') {
-      // Tab-level close: find the tab by its paneId
-      const tabIdx = tabs.value.findIndex(t =>
+      // Find the tab by its paneId (server's tab_id), or by leaf paneId in layouts
+      let tabIdx = tabs.value.findIndex(t =>
         t.type === 'terminal' && t.paneId === msg.pane_id,
       )
+      if (tabIdx === -1) {
+        // Fallback: search by leaf paneId in layouts (handles PTY exit case)
+        tabIdx = tabs.value.findIndex(t =>
+          t.type === 'terminal' && !!findLeaf(t.layout, msg.pane_id),
+        )
+      }
       if (tabIdx !== -1) {
         const tab = tabs.value[tabIdx] as TerminalTab
-        if (tabs.value.length > 1) {
-          for (const leaf of getAllLeaves(tab.layout)) {
-            delete termRefs[leaf.paneId]
-          }
-          tabs.value.splice(tabIdx, 1)
-          if (activePaneId.value === tab.paneId) {
-            activePaneId.value = tabs.value[Math.min(tabIdx, tabs.value.length - 1)].paneId
-          }
+        for (const leaf of getAllLeaves(tab.layout)) {
+          delete termRefs[leaf.paneId]
+        }
+        tabs.value.splice(tabIdx, 1)
+        if (tabs.value.length === 0) {
+          newTab()
+        } else if (activePaneId.value === tab.paneId) {
+          activePaneId.value = tabs.value[Math.min(tabIdx, tabs.value.length - 1)].paneId
           persist()
+          nextTick(() => focusActive())
         }
       }
     } else if (msg.type === 'tab_activated') {
@@ -1017,8 +1048,16 @@ async function connectSyncWS() {
         return incomingLeafIds.some((id: string) => localLeafIds.includes(id))
       }) as TerminalTab | undefined
       if (targetTab) {
+        const incomingLeafIds = getAllLeaves(msg.layout).map((l: any) => l.paneId)
+        const localLeafIds = getAllLeaves(targetTab.layout).map(l => l.paneId)
+        const sameLeaves = incomingLeafIds.length === localLeafIds.length
+          && incomingLeafIds.every((id: string) => localLeafIds.includes(id))
+
         suppressSync = true
-        targetTab.layout = ensureSplitRoot(msg.layout)
+        if (!sameLeaves) {
+          // Structural change from another client — replace layout
+          targetTab.layout = ensureSplitRoot(msg.layout)
+        }
         targetTab.activePaneId = msg.active_pane_id
         suppressSync = false
 
@@ -1158,18 +1197,11 @@ onBeforeUnmount(() => {
 .broadcast-btn {
   position: relative;
   color: #ef4444;
-}
-.broadcast-dot {
-  display: inline-block;
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: #ef4444;
-  animation: broadcast-pulse 1s infinite;
+  animation: broadcast-pulse 2s ease-in-out infinite;
 }
 @keyframes broadcast-pulse {
   0%, 100% { opacity: 1; }
-  50% { opacity: 0.3; }
+  50% { opacity: 0.5; }
 }
 .notif-btn {
   position: relative;

--- a/frontend/src/components/split/PaneHeader.vue
+++ b/frontend/src/components/split/PaneHeader.vue
@@ -5,7 +5,6 @@
     @mousedown.prevent="onMouseDown"
     @touchstart.prevent="onTouchStart"
   >
-    <span class="pane-header-drag-handle">&#x2630;</span>
     <span class="pane-header-title">{{ title }}</span>
   </div>
 </template>
@@ -254,13 +253,6 @@ onBeforeUnmount(() => {
 
 .pane-header.dragging {
   opacity: 0.5;
-}
-
-.pane-header-drag-handle {
-  font-size: 12px;
-  color: var(--text-tertiary, #666);
-  margin-right: 6px;
-  opacity: 0.6;
 }
 
 .pane-header-title {

--- a/frontend/src/components/split/SplitContainer.vue
+++ b/frontend/src/components/split/SplitContainer.vue
@@ -22,14 +22,21 @@
       @click.stop="emit('close', leaf!.paneId)"
     >&times;</button>
     <template v-if="broadcastActive">
-      <div class="broadcast-icon" :title="t('split.broadcastTooltip')">
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-          <circle cx="8" cy="8" r="3" stroke="currentColor" stroke-width="1.5" fill="none"/>
-          <circle cx="8" cy="8" r="1" fill="currentColor"/>
+      <div class="broadcast-icon broadcast-icon--active" :title="t('split.broadcastTooltip')">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M2 12C2 6.5 6.5 2 12 2"/>
+          <path d="M6 12c0-3.3 2.7-6 6-6"/>
+          <circle cx="12" cy="12" r="2" fill="currentColor"/>
         </svg>
       </div>
     </template>
-    <div v-else-if="broadcastReceiving" class="broadcast-dot" />
+    <div v-else-if="broadcastReceiving" class="broadcast-icon broadcast-icon--receiving" :title="t('split.broadcastTooltip')">
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M2 12C2 6.5 6.5 2 12 2"/>
+        <path d="M6 12c0-3.3 2.7-6 6-6"/>
+        <circle cx="12" cy="12" r="2" fill="currentColor"/>
+      </svg>
+    </div>
     <TerminalPane
       :ref="(el: any) => emit('register', leaf!.paneId, el)"
       :pane-id="leaf.paneId"
@@ -227,6 +234,11 @@ function getChildStyle(idx: number) {
   top: 11px;
 }
 
+/* Push header title right to avoid overlapping the close button */
+.split-leaf:has(.pane-close-btn) .pane-header {
+  padding-left: 28px;
+}
+
 .split-leaf:hover .pane-close-btn {
   opacity: 1;
 }
@@ -236,30 +248,30 @@ function getChildStyle(idx: number) {
   color: var(--text-primary, #e0e0e0);
 }
 
-/* Broadcast indicator — subtle dot style */
+/* Broadcast indicator — radar style */
 .broadcast-icon {
   position: absolute;
   top: 4px;
-  right: 28px;
+  right: 8px;
   z-index: 10;
-  color: var(--accent-color, #4d80ff);
+  color: var(--text-secondary, #888);
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: default;
-  opacity: 0.85;
 }
 
-.broadcast-dot {
-  position: absolute;
-  top: 6px;
-  right: 28px;
-  z-index: 10;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--accent-color, #4d80ff);
-  opacity: 0.35;
-  pointer-events: none;
+.broadcast-icon--active {
+  opacity: 0.9;
+  animation: radar-pulse 2s ease-in-out infinite;
+}
+
+.broadcast-icon--receiving {
+  opacity: 0.45;
+}
+
+@keyframes radar-pulse {
+  0%, 100% { opacity: 0.9; }
+  50% { opacity: 0.5; }
 }
 </style>

--- a/frontend/src/composables/useSplitPane.ts
+++ b/frontend/src/composables/useSplitPane.ts
@@ -3,10 +3,11 @@ import type { Tab, TerminalTab, PaneLayout, LeafPane, SplitPane, DropPosition } 
 import {
   findLeaf, findParentSplit, getAllLeaves, findFirstLeaf,
   replaceLeaf, replaceNode, redistributeRatios, clearAllZoom, equalizeRecursive,
-  removeLeaf, genSplitId,
+  removeLeaf, genSplitId, ensureSplitRoot,
 } from '../types/pane'
 import type TerminalPane from '../components/terminal/TerminalPane.vue'
 import type { SyncClientMsg } from '../types/protocol'
+import { apiSplitPane, apiClosePane } from './useTabApi'
 
 export function useSplitPane(opts: {
   tabs: Ref<Tab[]>
@@ -39,105 +40,63 @@ export function useSplitPane(opts: {
   }
 
   /** Split the active pane in the given direction */
-  function splitPane(direction: 'horizontal' | 'vertical') {
+  async function splitPane(direction: 'horizontal' | 'vertical') {
     const tab = getActiveTerminal()
     if (!tab) return
     if (getAllLeaves(tab.layout).length >= 6) return
 
-    const newPaneId = genPaneId()
-    const currentLeaf = findLeaf(tab.layout, tab.activePaneId)
-    if (!currentLeaf || currentLeaf.type !== 'leaf') return
-
-    const newLeaf: LeafPane = {
-      type: 'leaf',
-      paneId: newPaneId,
-      title: 'Terminal',
-      ratio: 0.5,
-      zoomed: false,
+    try {
+      const result = await apiSplitPane(tab.paneId, tab.activePaneId, direction)
+      // Update local layout with server response
+      tab.layout = ensureSplitRoot(result.layout)
+      tab.activePaneId = result.new_pane_id
+      persist()
+      syncTabLayout(tab)
+      nextTick(() => termRefs[result.new_pane_id]?.focus())
+    } catch (e) {
+      console.error('Failed to split pane:', e)
     }
-
-    const split: SplitPane = {
-      type: 'split',
-      id: genSplitId(),
-      direction,
-      children: [{ ...currentLeaf, ratio: 0.5 }, newLeaf],
-      ratios: [0.5, 0.5],
-    }
-
-    if (tab.layout.type === 'leaf') {
-      tab.layout = split
-    } else if (tab.layout.type === 'split' && tab.layout.children.length === 1 && tab.layout.direction === direction) {
-      // Single-child root split with same direction — add sibling directly
-      tab.layout.children.push(newLeaf)
-      redistributeRatios(tab.layout)
-    } else {
-      replaceLeaf(tab.layout, tab.activePaneId, split)
-    }
-
-    tab.activePaneId = newPaneId
-    persist()
-    syncTabLayout(tab)
-    nextTick(() => termRefs[newPaneId]?.focus())
   }
 
   /** Close a pane. If it's the last leaf, close the entire tab. */
-  function closePane(paneId: string): boolean {
+  async function closePane(paneId: string): Promise<boolean> {
     const tab = findTabByPaneId(paneId)
     if (!tab) return false
 
-    const parent = findParentSplit(tab.layout, paneId)
-    if (!parent) {
+    // Check if this is the only leaf
+    const leaves = getAllLeaves(tab.layout)
+    if (leaves.length <= 1) {
       // This is the only leaf — signal to close the tab
       return false
     }
 
-    const idx = parent.children.findIndex(c => c.type === 'leaf' && c.paneId === paneId)
-    if (idx === -1) return false
+    try {
+      const result = await apiClosePane(tab.paneId, paneId)
 
-    // If removing this leaf would leave the parent with 0 children, signal to close the tab
-    if (parent.children.length <= 1) {
+      if (result.tab_closed) {
+        // Tab was removed entirely
+        return false
+      }
+
+      // Update local layout from server response
+      if (result.layout) {
+        tab.layout = ensureSplitRoot(result.layout)
+      }
+      if (result.active_pane_id) {
+        tab.activePaneId = result.active_pane_id
+      }
+      delete termRefs[paneId]
+      persist()
+      syncTabLayout(tab)
+      nextTick(() => {
+        getAllLeaves(tab.layout).forEach(l => termRefs[l.paneId]?.fit())
+        termRefs[tab.activePaneId]?.focus()
+      })
+      return true
+    } catch (e) {
+      console.error('Failed to close pane:', e)
       return false
     }
-
-    parent.children.splice(idx, 1)
-    parent.ratios.splice(idx, 1)
-    redistributeRatios(parent)
-
-    if (parent.children.length === 1) {
-      const remaining = parent.children[0]
-      if (parent === tab.layout) {
-        // Root-level: only collapse if the remaining child is a split
-        // (collapsing split→leaf destroys and recreates all TerminalPane components,
-        // breaking active sessions — e.g. htop loses its PTY)
-        if (remaining.type === 'split') {
-          tab.layout = remaining
-        }
-      } else {
-        // Nested split: always collapse regardless of remaining child type.
-        // A single-child non-root split is degenerate — leaving it causes
-        // findParentSplit to return the degenerate split on next closePane,
-        // which then returns false and triggers closeTab (closing the whole tab).
-        replaceNode(tab.layout, parent, remaining)
-      }
-    }
-
-    if (tab.activePaneId === paneId) {
-      tab.activePaneId = findFirstLeaf(tab.layout).paneId
-    }
-
-    if (getAllLeaves(tab.layout).length <= 1) {
-      tab.broadcastMode = false
-    }
-
-    delete termRefs[paneId]
-    persist()
-    syncTabLayout(tab)
-    sendSync({ type: 'close_pane', pane_id: paneId })
-    nextTick(() => {
-      getAllLeaves(tab.layout).forEach(l => termRefs[l.paneId]?.fit())
-      termRefs[tab.activePaneId]?.focus()
-    })
-    return true
   }
 
   /** Focus a specific pane */

--- a/frontend/src/composables/useTabApi.ts
+++ b/frontend/src/composables/useTabApi.ts
@@ -1,0 +1,60 @@
+import { authFetch, apiUrl } from './apiBase'
+
+export interface CreateTabResult {
+  tab_id: string
+  pane_id: string
+  layout: any
+}
+
+export interface SplitPaneResult {
+  new_pane_id: string
+  layout: any
+}
+
+export interface ClosePaneResult {
+  ok: boolean
+  tab_closed: boolean
+  layout?: any
+  active_pane_id?: string
+}
+
+export async function apiCreateTab(): Promise<CreateTabResult> {
+  const res = await authFetch(apiUrl('/api/tabs'), { method: 'POST' })
+  if (!res.ok) throw new Error(`create tab failed: ${res.status}`)
+  return res.json()
+}
+
+export async function apiCloseTab(tabId: string): Promise<void> {
+  const res = await authFetch(apiUrl(`/api/tabs/${tabId}`), { method: 'DELETE' })
+  if (!res.ok) throw new Error(`close tab failed: ${res.status}`)
+}
+
+export async function apiSplitPane(tabId: string, paneId: string, direction: string): Promise<SplitPaneResult> {
+  const res = await authFetch(apiUrl(`/api/tabs/${tabId}/pane`), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ pane_id: paneId, direction }),
+  })
+  if (!res.ok) throw new Error(`split pane failed: ${res.status}`)
+  return res.json()
+}
+
+export async function apiClosePane(tabId: string, paneId: string): Promise<ClosePaneResult> {
+  const res = await authFetch(apiUrl(`/api/tabs/${tabId}/pane/${paneId}`), { method: 'DELETE' })
+  if (!res.ok) throw new Error(`close pane failed: ${res.status}`)
+  return res.json()
+}
+
+export async function apiActivatePane(tabId: string, paneId: string): Promise<void> {
+  const res = await authFetch(apiUrl(`/api/tabs/${tabId}/pane/${paneId}/activate`), { method: 'PUT' })
+  if (!res.ok) throw new Error(`activate pane failed: ${res.status}`)
+}
+
+export async function apiUpdateLayout(tabId: string, layout: any, activePaneId: string): Promise<void> {
+  const res = await authFetch(apiUrl(`/api/tabs/${tabId}/layout`), {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ layout, active_pane_id: activePaneId }),
+  })
+  if (!res.ok) throw new Error(`update layout failed: ${res.status}`)
+}

--- a/frontend/src/composables/useTerminal.ts
+++ b/frontend/src/composables/useTerminal.ts
@@ -60,6 +60,7 @@ export class TerminalInstance {
   touchMoved = false
   private _visibilityHandler: (() => void) | null = null
   private _dragDropCleanup: (() => void) | null = null
+  private _initialResizeTimer: ReturnType<typeof setInterval> | null = null
 
   onTitleChange: ((title: string) => void) | null = null
   onShellInfo: ((shell: string) => void) | null = null
@@ -220,9 +221,10 @@ export class TerminalInstance {
       },
     })
 
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => this.fitAddon?.fit())
-    })
+    // Retry the initial resize until it actually reaches the server.
+    // On new tabs the WebGL renderer and WebSocket may not be ready when the
+    // first RAF fires, so we loop until _doFitAndResize successfully sends.
+    this._scheduleInitialResize()
 
     this.xterm.onTitleChange((title) => {
       if (this._suppressTitleChange) return
@@ -279,8 +281,10 @@ export class TerminalInstance {
   }
 
   destroy() {
+    if (this._destroyed) return
     this._destroyed = true
     if (this._reconnectTimer) clearTimeout(this._reconnectTimer)
+    if (this._initialResizeTimer) clearInterval(this._initialResizeTimer)
     if (this._refitRaf) cancelAnimationFrame(this._refitRaf)
     this._resizeObserver?.disconnect()
     if (this._visibilityHandler) {
@@ -300,8 +304,12 @@ export class TerminalInstance {
       this.ws.close(1000)
       this.ws = null
     }
-    this.xterm?.dispose()
-    this.xterm = null
+    if (this.xterm) {
+      const xt = this.xterm
+      this.xterm = null
+      this.fitAddon = null
+      try { xt.dispose() } catch { /* already disposed or addon race */ }
+    }
   }
 
   private _connectViaTransport() {
@@ -313,14 +321,15 @@ export class TerminalInstance {
     })
 
     this._transport.onMessage((msg) => {
+      if (this._destroyed || !this.xterm) return
       if (msg.type === 'output') {
-        this.xterm!.write(msg.data)
+        this.xterm.write(msg.data)
         this.onRawOutput?.(msg.data)
       } else if (msg.type === 'shell_info') {
         this.onShellInfo?.(msg.shell_type)
       } else if (msg.type === 'reconnected') {
         this._suppressTitleChange = true
-        this.xterm!.reset()
+        this.xterm.reset()
         this._suppressTitleChange = false
         this._doFitAndResize(true)
       }
@@ -348,6 +357,7 @@ export class TerminalInstance {
     this.ws = new WebSocket(url)
 
     this.ws.onopen = () => {
+      console.log(`[TerminalInstance] WS onopen: pane=${this.paneId}`)
       this._reconnectAttempts = 0
       this._hideOverlay()
       this.onConnect?.()
@@ -355,24 +365,29 @@ export class TerminalInstance {
     }
 
     this.ws.onmessage = (e) => {
+      if (this._destroyed) { console.log(`[TerminalInstance] WS onmessage: pane=${this.paneId} IGNORED (destroyed)`); return }
       let msg: ServerMsg
       try { msg = JSON.parse(e.data) } catch { return }
+      if (!this.xterm) { console.log(`[TerminalInstance] WS onmessage: pane=${this.paneId} IGNORED (xterm null)`); return }
       if (msg.type === 'reconnected') {
         this._suppressTitleChange = true
-        this.xterm!.reset()
+        this.xterm.reset()
         this._suppressTitleChange = false
         this._reconnectAttempts = 0
         this._hideOverlay()
         this._doFitAndResize(true)
       } else if (msg.type === 'output') {
-        this.xterm!.write(msg.data)
+        console.log(`[TerminalInstance] WS output: pane=${this.paneId}, data_len=${msg.data.length}`)
+        this.xterm.write(msg.data)
         this.onRawOutput?.(msg.data)
       } else if (msg.type === 'shell_info') {
+        console.log(`[TerminalInstance] WS shell_info: pane=${this.paneId}, shell=${msg.shell_type}`)
         this.onShellInfo?.(msg.shell_type)
       }
     }
 
     this.ws.onclose = (e) => {
+      console.log(`[TerminalInstance] WS onclose: pane=${this.paneId}, code=${e.code}, reason=${e.reason}`)
       if (this._destroyed) return
       this.onDisconnect?.()
       if (e.code === 1000) {
@@ -382,7 +397,9 @@ export class TerminalInstance {
       }
     }
 
-    this.ws.onerror = () => {}
+    this.ws.onerror = (e) => {
+      console.error(`[TerminalInstance] WS error: pane=${this.paneId}`, e)
+    }
 
     if (!this._onDataRegistered) {
       this._onDataRegistered = true
@@ -441,11 +458,39 @@ export class TerminalInstance {
     })
   }
 
+  /**
+   * Retry the initial resize in a loop until it succeeds.
+   * Handles the race where the WebGL renderer, DOM layout, or WebSocket
+   * aren't ready when the first attempt fires.
+   */
+  private _scheduleInitialResize() {
+    if (this._initialResizeTimer) return
+    let attempts = 0
+    const MAX_ATTEMPTS = 40 // 40 × 50ms = 2s max
+    this._initialResizeTimer = setInterval(() => {
+      attempts++
+      if (this._destroyed || attempts > MAX_ATTEMPTS) {
+        if (this._initialResizeTimer) {
+          clearInterval(this._initialResizeTimer)
+          this._initialResizeTimer = null
+        }
+        return
+      }
+      // If we've already sent a resize (lastCols/lastRows are non-zero), stop.
+      if (this._lastCols > 0 && this._lastRows > 0) {
+        clearInterval(this._initialResizeTimer!)
+        this._initialResizeTimer = null
+        return
+      }
+      this._doFitAndResize(true)
+    }, 50)
+  }
+
   private _doFitAndResize(force = false) {
     if (!this.fitAddon || !this.xterm || !this._wrapper) return
     const rect = this._wrapper.getBoundingClientRect()
     if (rect.width === 0 || rect.height === 0) return
-    this.fitAddon.fit()
+    try { this.fitAddon.fit() } catch { return }
     const cols = this.xterm.cols
     const rows = this.xterm.rows
     if (cols < 2 || rows < 2) return
@@ -453,8 +498,6 @@ export class TerminalInstance {
     const heightChanged = rows !== this._lastRows
     this._lastCols = cols
     this._lastRows = rows
-    // When container height decreases (e.g. mobile keyboard opens), scroll to
-    // bottom so the current input line stays visible.
     if (heightChanged && !this._isMouseModeEnabled()) {
       this.xterm.scrollToBottom()
     }
@@ -696,7 +739,6 @@ export class TerminalInstance {
       if (modes !== undefined) {
         return modes !== 'NONE'
       }
-      console.warn('[useTerminal] _isMouseModeEnabled: xterm internal API unavailable — touch scroll may misbehave in mouse-tracking TUIs after an xterm.js upgrade')
       return false
     } catch {
       return false

--- a/frontend/src/types/protocol.ts
+++ b/frontend/src/types/protocol.ts
@@ -32,13 +32,15 @@ export type ServerMsg = OutputMsg | ShellInfoMsg | ReconnectedMsg
 // Sync WS messages
 export interface SyncTabList {
   type: 'tab_list'
-  tabs: { pane_id: string; layout?: any; active_pane_id?: string }[]
+  tabs: { tab_id: string; pane_id: string; layout?: any; active_pane_id?: string }[]
   active_pane_id: string | null
 }
 
 export interface SyncTabCreated {
   type: 'tab_created'
+  tab_id: string
   pane_id: string
+  layout?: any
 }
 
 export interface SyncTabClosed {
@@ -68,7 +70,9 @@ export type SyncServerMsg = SyncTabList | SyncTabCreated | SyncTabClosed | SyncT
 
 export interface SyncCreateTab {
   type: 'create_tab'
-  pane_id: string
+  layout: any
+  tab_id?: string
+  pane_id?: string
 }
 
 export interface SyncCloseTab {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dinotty-desktop"
-version = "0.10.4"
+version = "0.10.5"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/src/embedded_server.rs
+++ b/src-tauri/src/embedded_server.rs
@@ -25,6 +25,7 @@ use dinotty_server::proxy;
 use dinotty_server::session::SessionManager;
 use dinotty_server::settings;
 use dinotty_server::history::HistoryState;
+use dinotty_server::tabs;
 use dinotty_server::ws;
 use dinotty_server::workspace;
 
@@ -293,6 +294,14 @@ pub async fn run_server(port: u16, manager: Arc<SessionManager>) {
         .route("/ws/monitor", get(monitor::ws_monitor_handler))
         .route("/ws/notify", get(ws::notification_ws_handler))
         .route("/ws/history", get(history::ws_history_handler))
+        // Tab/Pane management
+        .route("/api/tabs", get(tabs::list_tabs).post(tabs::create_tab))
+        .route("/api/tabs/:tab_id", delete(tabs::close_tab))
+        .route("/api/tabs/:tab_id/pane", post(tabs::split_pane))
+        .route("/api/tabs/:tab_id/pane/:pane_id", delete(tabs::close_pane))
+        .route("/api/tabs/:tab_id/pane/:pane_id/activate", put(tabs::activate_pane))
+        .route("/api/tabs/:tab_id/layout", put(tabs::update_layout))
+        .route("/api/input", post(ws::post_input))
         .route("/api/settings", get(settings::get_settings).put(settings::put_settings))
         .route("/api/settings/background", post(settings::upload_background).get(settings::get_background))
         .route("/api/workspace/resolve", get(workspace::workspace_resolve))

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -139,6 +139,28 @@ fn pty_kill(pane_id: String, state: State<'_, Arc<SessionManager>>) -> Result<()
     state.broadcast_sync(&SyncMsg::TabClosed {
         pane_id: pane_id.clone(),
     });
+    // Collect affected layouts before purging
+    let before_layouts: Vec<(String, serde_json::Value)> = state.tab_layouts.iter()
+        .map(|e| (e.key().clone(), e.value().clone()))
+        .collect();
+    state.purge_pane_from_layouts(&pane_id);
+    // Broadcast layout changes to all clients
+    for (tab_id, old_val) in &before_layouts {
+        if let Some(new_val) = state.tab_layouts.get(tab_id) {
+            if *new_val.value() != *old_val {
+                let layout = new_val.value().get("layout").cloned().unwrap_or(serde_json::Value::Null);
+                let active = new_val.value().get("active_pane_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                state.broadcast_sync(&SyncMsg::LayoutUpdated {
+                    pane_id: tab_id.clone(),
+                    layout,
+                    active_pane_id: active,
+                });
+            }
+        }
+    }
     Ok(())
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nickelpack/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "Dinotty",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "identifier": "com.dinotty.terminal",
   "build": {
     "frontendDist": "../frontend/dist",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,3 +11,4 @@ pub mod monitor;
 pub mod notification;
 pub mod history;
 pub mod plugin;
+pub mod tabs;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use dinotty_server::{auth, session, settings, ws, proxy, workspace, file_watcher, monitor, notification, history, plugin};
+use dinotty_server::{auth, session, settings, ws, proxy, workspace, file_watcher, monitor, notification, history, plugin, tabs};
 
 use axum::{
     body::Body,
@@ -454,6 +454,13 @@ async fn main() {
         .route("/ws/notify", get(ws::notification_ws_handler))
         .route("/api/notify", post(notification::post_notify))
         .route("/api/input", post(ws::post_input))
+        // Tab/Pane management
+        .route("/api/tabs", get(tabs::list_tabs).post(tabs::create_tab))
+        .route("/api/tabs/:tab_id", delete(tabs::close_tab))
+        .route("/api/tabs/:tab_id/pane", post(tabs::split_pane))
+        .route("/api/tabs/:tab_id/pane/:pane_id", delete(tabs::close_pane))
+        .route("/api/tabs/:tab_id/pane/:pane_id/activate", put(tabs::activate_pane))
+        .route("/api/tabs/:tab_id/layout", put(tabs::update_layout))
         .route("/api/auth", post(check_auth))
         .route("/api/token-configured", get(token_configured))
         .route("/api/settings", get(settings::get_settings).put(settings::put_settings))

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -120,8 +120,12 @@ pub fn create_session(
             }
         }
         if manager_clone.sessions.remove(&pane_id_clone).is_some() {
+            // Find the parent tab and clean up its layout; for single-pane tabs
+            // this returns the tab-level pane_id so we broadcast the correct ID.
+            let tab_pane_id = manager_clone.on_pty_exited(&pane_id_clone)
+                .unwrap_or_else(|| pane_id_clone.clone());
             manager_clone.broadcast_sync(&SyncMsg::TabClosed {
-                pane_id: pane_id_clone.clone(),
+                pane_id: tab_pane_id,
             });
         }
         info!("PTY exited, session removed: pane={}", pane_id_clone);

--- a/src/session.rs
+++ b/src/session.rs
@@ -131,13 +131,13 @@ fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
         .position(|window| window == needle)
 }
 
-fn collect_leaf_pane_ids(layout: &serde_json::Value) -> Vec<String> {
+pub fn collect_leaf_pane_ids(layout: &serde_json::Value) -> Vec<String> {
     let mut ids = Vec::new();
     collect_leaf_ids_recursive(layout, &mut ids);
     ids
 }
 
-fn remove_pane_from_layout(node: &serde_json::Value, pane_id: &str) -> Option<serde_json::Value> {
+pub fn remove_pane_from_layout(node: &serde_json::Value, pane_id: &str) -> Option<serde_json::Value> {
     let node_type = node.get("type")?.as_str()?;
     match node_type {
         "leaf" => {
@@ -155,7 +155,13 @@ fn remove_pane_from_layout(node: &serde_json::Value, pane_id: &str) -> Option<se
                 .collect();
             match new_children.len() {
                 0 => None,
-                _ if new_children.len() == children.len() => Some(node.clone()),
+                _ if new_children.len() == children.len() => {
+                    // Children count unchanged — but a child may have changed internally
+                    // (e.g. a nested split collapsed). Always use the updated children.
+                    let mut result = node.clone();
+                    result["children"] = serde_json::Value::Array(new_children);
+                    Some(result)
+                }
                 1 => {
                     // Single-child split is degenerate — collapse by returning the child directly
                     Some(new_children.into_iter().next().unwrap())
@@ -192,6 +198,80 @@ fn collect_leaf_ids_recursive(node: &serde_json::Value, ids: &mut Vec<String>) {
     }
 }
 
+/// Insert a new pane into the layout tree by splitting the target pane.
+/// Returns the updated layout, or None if the target pane was not found.
+pub fn insert_pane_into_layout(
+    layout: &serde_json::Value,
+    target_pane_id: &str,
+    direction: &str,
+    new_pane_id: &str,
+) -> Option<serde_json::Value> {
+    let node_type = layout.get("type")?.as_str()?;
+    match node_type {
+        "leaf" => {
+            let pane_id = layout.get("paneId")?.as_str()?;
+            if pane_id == target_pane_id {
+                // Found the target — wrap in a new split node
+                let new_leaf = serde_json::json!({
+                    "type": "leaf",
+                    "paneId": new_pane_id,
+                    "title": "Terminal",
+                    "ratio": 1,
+                    "zoomed": false,
+                });
+                let existing_leaf = layout.clone();
+                let split_id = uuid::Uuid::new_v4().to_string();
+                Some(serde_json::json!({
+                    "type": "split",
+                    "id": split_id,
+                    "direction": direction,
+                    "children": [existing_leaf, new_leaf],
+                    "ratios": [0.5, 0.5],
+                }))
+            } else {
+                Some(layout.clone())
+            }
+        }
+        "split" => {
+            let children = layout.get("children")?.as_array()?;
+            let mut new_children = Vec::new();
+            let mut found = false;
+            for child in children {
+                if let Some(updated) = insert_pane_into_layout(child, target_pane_id, direction, new_pane_id) {
+                    if !found && updated != *child {
+                        found = true;
+                    }
+                    new_children.push(updated);
+                }
+            }
+            if !found {
+                return Some(layout.clone());
+            }
+            let mut result = layout.clone();
+            result["children"] = serde_json::Value::Array(new_children);
+            Some(result)
+        }
+        _ => Some(layout.clone()),
+    }
+}
+
+pub fn first_leaf_id(node: &serde_json::Value) -> Option<String> {
+    let node_type = node.get("type")?.as_str()?;
+    match node_type {
+        "leaf" => node.get("paneId")?.as_str().map(String::from),
+        "split" => {
+            let children = node.get("children")?.as_array()?;
+            for child in children {
+                if let Some(id) = first_leaf_id(child) {
+                    return Some(id);
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
 fn parse_title_cwd(title: &str, home: &Path) -> Option<PathBuf> {
     let at = title.rfind('@')?;
     let tail = title.get(at + 1..)?;
@@ -212,18 +292,24 @@ fn parse_title_cwd(title: &str, home: &Path) -> Option<PathBuf> {
     Some(path)
 }
 
+pub struct SyncClient {
+    pub id: String,
+    pub tx: mpsc::UnboundedSender<String>,
+}
+
 pub struct SessionManager {
     pub sessions: DashMap<String, Arc<Session>>,
-    pub sync_clients: Arc<Mutex<Vec<mpsc::UnboundedSender<String>>>>,
+    pub sync_clients: Arc<Mutex<Vec<SyncClient>>>,
     pub active_pane_id: Arc<Mutex<Option<String>>>,
     pub tab_layouts: DashMap<String, serde_json::Value>,
+    pub tab_order: Mutex<Vec<String>>,
 }
 
 #[derive(Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum SyncMsg {
     TabList { tabs: Vec<TabInfo>, active_pane_id: Option<String> },
-    TabCreated { pane_id: String },
+    TabCreated { tab_id: String, pane_id: String, layout: Option<serde_json::Value> },
     TabClosed { pane_id: String },
     TabActivated { pane_id: String },
     LayoutUpdated { pane_id: String, layout: serde_json::Value, active_pane_id: String },
@@ -233,6 +319,7 @@ pub enum SyncMsg {
 
 #[derive(Serialize, Clone)]
 pub struct TabInfo {
+    pub tab_id: String,
     pub pane_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub layout: Option<serde_json::Value>,
@@ -247,19 +334,51 @@ impl SessionManager {
             sync_clients: Arc::new(Mutex::new(Vec::new())),
             active_pane_id: Arc::new(Mutex::new(None)),
             tab_layouts: DashMap::new(),
+            tab_order: Mutex::new(Vec::new()),
         }
+    }
+
+    /// Insert a tab layout and record its order position.
+    pub fn insert_tab(&self, tab_id: String, value: serde_json::Value) {
+        let mut order = self.tab_order.lock().unwrap();
+        if !order.contains(&tab_id) {
+            order.push(tab_id.clone());
+        }
+        drop(order);
+        self.tab_layouts.insert(tab_id, value);
+    }
+
+    /// Remove a tab layout and its order entry.
+    pub fn remove_tab(&self, tab_id: &str) {
+        self.tab_layouts.remove(tab_id);
+        let mut order = self.tab_order.lock().unwrap();
+        order.retain(|id| id != tab_id);
     }
 
     pub fn broadcast_sync(&self, msg: &SyncMsg) {
         let json = serde_json::to_string(msg).unwrap();
         let mut clients = self.sync_clients.lock().unwrap();
-        clients.retain(|tx| tx.send(json.clone()).is_ok());
+        clients.retain(|c| c.tx.send(json.clone()).is_ok());
     }
 
-    pub fn add_sync_client(&self) -> mpsc::UnboundedReceiver<String> {
+    /// Broadcast to all sync clients except the one with the given ID.
+    pub fn broadcast_sync_others(&self, msg: &SyncMsg, exclude_id: &str) {
+        let json = serde_json::to_string(msg).unwrap();
+        let mut clients = self.sync_clients.lock().unwrap();
+        clients.retain(|c| {
+            if c.id == exclude_id {
+                true // keep in list but don't send
+            } else {
+                c.tx.send(json.clone()).is_ok()
+            }
+        });
+    }
+
+    pub fn add_sync_client(&self) -> (String, mpsc::UnboundedReceiver<String>) {
+        let id = uuid::Uuid::new_v4().to_string();
         let (tx, rx) = mpsc::unbounded_channel();
-        self.sync_clients.lock().unwrap().push(tx);
-        rx
+        self.sync_clients.lock().unwrap().push(SyncClient { id: id.clone(), tx });
+        (id, rx)
     }
 
     pub fn broadcast_plugin_changed(&self, plugin_id: String, change: String) {
@@ -268,56 +387,88 @@ impl SessionManager {
 
     /// Remove a pane_id from all parent tab layouts. If removing it causes
     /// a split to have only one child, the split collapses into that child.
-    pub fn purge_pane_from_layouts(&self, pane_id: &str) {
-        let updates: Vec<(String, serde_json::Value)> = self.tab_layouts.iter().filter_map(|entry| {
+    /// Returns the list of tab IDs whose layouts became empty (i.e. the pane
+    /// was the last leaf) so the caller can broadcast TabClosed for them.
+    pub fn purge_pane_from_layouts(&self, pane_id: &str) -> Vec<String> {
+        let mut updates: Vec<(String, serde_json::Value)> = Vec::new();
+        let mut emptied_tabs: Vec<String> = Vec::new();
+
+        for entry in self.tab_layouts.iter() {
             let tab_pane_id = entry.key();
             if tab_pane_id == pane_id {
-                return None;
+                continue;
             }
             let val = entry.value();
-            let layout = val.get("layout")?;
-            let new_layout = remove_pane_from_layout(layout, pane_id)?;
-            if new_layout == *layout {
-                return None;
+            let Some(layout) = val.get("layout") else { continue };
+            match remove_pane_from_layout(layout, pane_id) {
+                None => {
+                    // The pane was the only leaf — tab is now empty
+                    emptied_tabs.push(tab_pane_id.clone());
+                }
+                Some(new_layout) if new_layout != *layout => {
+                    let active = val.get("active_pane_id").and_then(|v| v.as_str());
+                    let new_leaf_ids = collect_leaf_pane_ids(&new_layout);
+                    let active_pane_id = active.filter(|id| new_leaf_ids.iter().any(|lid| lid == *id));
+                    let mut new_val = serde_json::json!({ "layout": new_layout });
+                    if let Some(a) = active_pane_id {
+                        new_val["active_pane_id"] = serde_json::Value::String(a.to_string());
+                    }
+                    updates.push((tab_pane_id.clone(), new_val));
+                }
+                _ => {}
             }
-            let active = val.get("active_pane_id").and_then(|v| v.as_str());
-            let new_leaf_ids = collect_leaf_pane_ids(&new_layout);
-            let active_pane_id = active.filter(|id| new_leaf_ids.iter().any(|lid| lid == *id));
-            let mut new_val = serde_json::json!({ "layout": new_layout });
-            if let Some(a) = active_pane_id {
-                new_val["active_pane_id"] = serde_json::Value::String(a.to_string());
-            }
-            Some((tab_pane_id.clone(), new_val))
-        }).collect();
+        }
 
         for (key, val) in updates {
-            self.tab_layouts.insert(key, val);
+            self.insert_tab(key, val);
         }
+        for tab_id in &emptied_tabs {
+            self.remove_tab(tab_id);
+        }
+        emptied_tabs
     }
 
     pub fn tab_list(&self) -> (Vec<TabInfo>, Option<String>) {
-        // Collect stale tab layout keys (layouts whose leaf pane_ids no longer exist)
-        let stale: Vec<String> = self.tab_layouts.iter().filter_map(|e| {
-            let v = e.value();
-            let layout = v.get("layout")?;
-            let leaf_ids = collect_leaf_pane_ids(layout);
-            if leaf_ids.is_empty() || !leaf_ids.iter().any(|id| self.sessions.contains_key(id)) {
-                Some(e.key().clone())
-            } else {
-                None
-            }
-        }).collect();
-        for key in stale {
-            self.tab_layouts.remove(&key);
+        // Prune stale tab layouts whose leaf pane_ids no longer have sessions.
+        // Without this, tab_layouts entries accumulate forever (phantom tabs).
+        let stale: Vec<String> = {
+            self.tab_layouts.iter().filter_map(|e| {
+                let v = e.value();
+                let layout = v.get("layout")?;
+                let leaf_ids = collect_leaf_pane_ids(layout);
+                if leaf_ids.is_empty() || !leaf_ids.iter().any(|id| self.sessions.contains_key(id)) {
+                    Some(e.key().clone())
+                } else {
+                    None
+                }
+            }).collect()
+        };
+        for key in &stale {
+            self.tab_layouts.remove(key);
+        }
+        if !stale.is_empty() {
+            let mut order = self.tab_order.lock().unwrap();
+            order.retain(|id| !stale.contains(id));
         }
 
-        let mut tabs: Vec<TabInfo> = self.tab_layouts.iter().map(|e| {
+        let order = self.tab_order.lock().unwrap();
+        let order_index = |tab_id: &str| -> usize {
+            order.iter().position(|id| id == tab_id).unwrap_or(usize::MAX)
+        };
+
+        let mut tabs: Vec<TabInfo> = self.tab_layouts.iter().filter_map(|e| {
+            let tab_id = e.key().clone();
             let v = e.value();
-            let pane_id = e.key().clone();
             let layout = v.get("layout").cloned();
+            let pane_id = layout.as_ref()
+                .and_then(|l| first_leaf_id(l))
+                .unwrap_or_else(|| tab_id.clone());
             let active_pane_id = v.get("active_pane_id").and_then(|v| v.as_str()).map(String::from);
-            TabInfo { pane_id, layout, active_pane_id }
+            Some(TabInfo { tab_id, pane_id, layout, active_pane_id })
         }).collect();
+
+        tabs.sort_by_key(|t| order_index(&t.tab_id));
+        drop(order);
 
         // Include sessions that don't belong to any existing tab (neither as tab id nor as a leaf)
         let leaf_ids: std::collections::HashSet<String> = tabs.iter()
@@ -327,12 +478,67 @@ impl SessionManager {
         for entry in self.sessions.iter() {
             let pane_id = entry.key().clone();
             if !tabs.iter().any(|t| t.pane_id == pane_id) && !leaf_ids.contains(&pane_id) {
-                tabs.push(TabInfo { pane_id, layout: None, active_pane_id: None });
+                tabs.push(TabInfo { tab_id: pane_id.clone(), pane_id, layout: None, active_pane_id: None });
             }
         }
 
         let active = self.active_pane_id.lock().unwrap().clone();
         (tabs, active)
+    }
+
+    /// When a PTY exits, find the parent tab and either remove it (single-pane)
+    /// or update the layout (multi-pane). Returns the tab-level pane_id for
+    /// single-pane tabs so the caller can broadcast TabClosed.
+    pub fn on_pty_exited(&self, leaf_pane_id: &str) -> Option<String> {
+        // Find the tab layout that contains this leaf
+        let mut found_tab_id: Option<String> = None;
+        for entry in self.tab_layouts.iter() {
+            let tab_id = entry.key();
+            let val = entry.value();
+            if let Some(layout) = val.get("layout") {
+                let leaf_ids = collect_leaf_pane_ids(layout);
+                if leaf_ids.iter().any(|id| id == leaf_pane_id) {
+                    found_tab_id = Some(tab_id.clone());
+                    break;
+                }
+            }
+        }
+
+        let tab_id = found_tab_id?;
+
+        // Get the current layout for this tab
+        let tab_val = self.tab_layouts.get(&tab_id)?;
+        let layout = tab_val.value().get("layout")?.clone();
+        let leaf_ids = collect_leaf_pane_ids(&layout);
+
+        if leaf_ids.len() <= 1 {
+            // Single-pane tab — remove the whole tab
+            drop(tab_val);
+            self.remove_tab(&tab_id);
+            Some(tab_id)
+        } else {
+            // Multi-pane tab — update the layout by removing the exited pane
+            let new_layout = remove_pane_from_layout(&layout, leaf_pane_id)?;
+            let new_leaf_ids = collect_leaf_pane_ids(&new_layout);
+            let active = tab_val.value().get("active_pane_id").and_then(|v| v.as_str());
+            let active_pane_id = active
+                .filter(|id| new_leaf_ids.iter().any(|lid| lid == *id))
+                .or_else(|| new_leaf_ids.first().map(|s| s.as_str()))
+                .unwrap_or("")
+                .to_string();
+            drop(tab_val);
+
+            self.insert_tab(tab_id.clone(), serde_json::json!({
+                "layout": new_layout.clone(),
+                "active_pane_id": active_pane_id,
+            }));
+            self.broadcast_sync(&SyncMsg::LayoutUpdated {
+                pane_id: tab_id,
+                layout: new_layout,
+                active_pane_id,
+            });
+            None
+        }
     }
 
     pub fn start_cleanup_task(self: &Arc<Self>) {

--- a/src/tabs.rs
+++ b/src/tabs.rs
@@ -1,0 +1,368 @@
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use serde::Deserialize;
+use std::sync::Arc;
+
+use crate::pty;
+use crate::session::{self, SessionManager};
+
+// ─── Request/Response types ────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct SplitPaneRequest {
+    pub pane_id: String,
+    pub direction: String, // "horizontal" or "vertical"
+}
+
+#[derive(Deserialize)]
+pub struct UpdateLayoutRequest {
+    pub layout: serde_json::Value,
+    pub active_pane_id: String,
+}
+
+// ─── GET /api/tabs ─────────────────────────────────────────────────
+
+pub async fn list_tabs(
+    State(manager): State<Arc<SessionManager>>,
+) -> impl IntoResponse {
+    let (tabs, active_pane_id) = manager.tab_list();
+    Json(serde_json::json!({
+        "tabs": tabs,
+        "active_pane_id": active_pane_id,
+    }))
+}
+
+// ─── POST /api/tabs ────────────────────────────────────────────────
+
+pub async fn create_tab(
+    State(manager): State<Arc<SessionManager>>,
+) -> impl IntoResponse {
+    let tab_id = uuid::Uuid::new_v4().to_string();
+    let pane_id = uuid::Uuid::new_v4().to_string();
+
+    // Create PTY session
+    let (_session, _shell_type) = match pty::create_session(
+        Arc::clone(&manager),
+        pane_id.clone(),
+        None,
+    ) {
+        Ok(x) => x,
+        Err(e) => {
+            tracing::error!("Failed to create PTY: {}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": e })),
+            )
+                .into_response();
+        }
+    };
+
+    // Create initial layout with single leaf
+    let layout = serde_json::json!({
+        "type": "leaf",
+        "paneId": pane_id,
+        "title": "Terminal",
+        "ratio": 1,
+        "zoomed": false,
+    });
+
+    // Store tab
+    manager.insert_tab(
+        tab_id.clone(),
+        serde_json::json!({
+            "layout": layout,
+            "active_pane_id": pane_id,
+        }),
+    );
+
+    // Set as active tab
+    *manager.active_pane_id.lock().unwrap() = Some(pane_id.clone());
+
+    Json(serde_json::json!({
+        "tab_id": tab_id,
+        "pane_id": pane_id,
+        "layout": layout,
+    }))
+    .into_response()
+}
+
+// ─── DELETE /api/tabs/{tab_id} ─────────────────────────────────────
+
+pub async fn close_tab(
+    State(manager): State<Arc<SessionManager>>,
+    Path(tab_id): Path<String>,
+) -> impl IntoResponse {
+    // Get tab layout to find all leaf pane IDs
+    let leaf_ids: Vec<String> = manager
+        .tab_layouts
+        .get(&tab_id)
+        .and_then(|v| v.get("layout").cloned())
+        .map(|layout| session::collect_leaf_pane_ids(&layout))
+        .unwrap_or_default();
+
+    // Remove all PTY sessions
+    for leaf_id in &leaf_ids {
+        manager.sessions.remove(leaf_id);
+    }
+
+    // Remove tab
+    manager.remove_tab(&tab_id);
+
+    Json(serde_json::json!({ "ok": true })).into_response()
+}
+
+// ─── POST /api/tabs/{tab_id}/pane ──────────────────────────────────
+
+pub async fn split_pane(
+    State(manager): State<Arc<SessionManager>>,
+    Path(tab_id): Path<String>,
+    Json(req): Json<SplitPaneRequest>,
+) -> impl IntoResponse {
+    // Verify tab exists
+    let tab_val = match manager.tab_layouts.get(&tab_id) {
+        Some(v) => v.value().clone(),
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "error": "tab not found" })),
+            )
+                .into_response();
+        }
+    };
+
+    let layout = match tab_val.get("layout") {
+        Some(l) => l.clone(),
+        None => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "tab has no layout" })),
+            )
+                .into_response();
+        }
+    };
+
+    // Verify target pane exists in layout
+    let leaf_ids = session::collect_leaf_pane_ids(&layout);
+    if !leaf_ids.contains(&req.pane_id) {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "pane not found in tab" })),
+        )
+            .into_response();
+    }
+
+    // Check max panes
+    if leaf_ids.len() >= 6 {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "maximum 6 panes per tab" })),
+        )
+            .into_response();
+    }
+
+    let new_pane_id = uuid::Uuid::new_v4().to_string();
+
+    // Create PTY for new pane
+    let (_session, _shell_type) = match pty::create_session(
+        Arc::clone(&manager),
+        new_pane_id.clone(),
+        None,
+    ) {
+        Ok(x) => x,
+        Err(e) => {
+            tracing::error!("Failed to create PTY for split: {}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": e })),
+            )
+                .into_response();
+        }
+    };
+
+    // Update layout tree
+    let new_layout = match session::insert_pane_into_layout(
+        &layout,
+        &req.pane_id,
+        &req.direction,
+        &new_pane_id,
+    ) {
+        Some(l) => l,
+        None => {
+            // Clean up PTY if layout update fails
+            manager.sessions.remove(&new_pane_id);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "failed to update layout" })),
+            )
+                .into_response();
+        }
+    };
+
+    // Store updated layout
+    let active_pane_id = new_pane_id.clone();
+    manager.insert_tab(
+        tab_id.clone(),
+        serde_json::json!({
+            "layout": new_layout,
+            "active_pane_id": active_pane_id,
+        }),
+    );
+
+    Json(serde_json::json!({
+        "new_pane_id": new_pane_id,
+        "layout": new_layout,
+    }))
+    .into_response()
+}
+
+// ─── DELETE /api/tabs/{tab_id}/pane/{pane_id} ──────────────────────
+
+pub async fn close_pane(
+    State(manager): State<Arc<SessionManager>>,
+    Path((tab_id, pane_id)): Path<(String, String)>,
+) -> impl IntoResponse {
+    // Verify tab exists
+    let tab_val = match manager.tab_layouts.get(&tab_id) {
+        Some(v) => v.value().clone(),
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "error": "tab not found" })),
+            )
+                .into_response();
+        }
+    };
+
+    let layout = match tab_val.get("layout") {
+        Some(l) => l.clone(),
+        None => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "tab has no layout" })),
+            )
+                .into_response();
+        }
+    };
+
+    // Verify pane exists in layout
+    let leaf_ids = session::collect_leaf_pane_ids(&layout);
+    if !leaf_ids.contains(&pane_id) {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "pane not found in tab" })),
+        )
+            .into_response();
+    }
+
+    // Remove PTY session
+    manager.sessions.remove(&pane_id);
+
+    // Update layout
+    if leaf_ids.len() <= 1 {
+        // Last pane - remove entire tab
+        manager.remove_tab(&tab_id);
+
+        Json(serde_json::json!({ "ok": true, "tab_closed": true }))
+    } else {
+        // Remove pane from layout
+        let new_layout = session::remove_pane_from_layout(&layout, &pane_id)
+            .unwrap_or(serde_json::Value::Null);
+
+        let new_leaf_ids = session::collect_leaf_pane_ids(&new_layout);
+        let active = tab_val
+            .get("active_pane_id")
+            .and_then(|v| v.as_str());
+        let active_pane_id = active
+            .filter(|id| new_leaf_ids.iter().any(|lid| lid == *id))
+            .or_else(|| new_leaf_ids.first().map(|s| s.as_str()))
+            .unwrap_or("")
+            .to_string();
+
+        manager.insert_tab(
+            tab_id.clone(),
+            serde_json::json!({
+                "layout": new_layout,
+                "active_pane_id": active_pane_id,
+            }),
+        );
+
+        Json(serde_json::json!({ "ok": true, "tab_closed": false, "layout": new_layout, "active_pane_id": active_pane_id }))
+    }
+    .into_response()
+}
+
+// ─── PUT /api/tabs/{tab_id}/pane/{pane_id}/activate ────────────────
+
+pub async fn activate_pane(
+    State(manager): State<Arc<SessionManager>>,
+    Path((tab_id, pane_id)): Path<(String, String)>,
+) -> impl IntoResponse {
+    // Verify tab exists
+    let tab_val = match manager.tab_layouts.get(&tab_id) {
+        Some(v) => v.value().clone(),
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "error": "tab not found" })),
+            )
+                .into_response();
+        }
+    };
+
+    // Verify pane exists in layout
+    let layout = tab_val.get("layout").cloned().unwrap_or(serde_json::Value::Null);
+    let leaf_ids = session::collect_leaf_pane_ids(&layout);
+    if !leaf_ids.contains(&pane_id) {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "pane not found in tab" })),
+        )
+            .into_response();
+    }
+
+    // Update active pane
+    manager.insert_tab(
+        tab_id.clone(),
+        serde_json::json!({
+            "layout": layout,
+            "active_pane_id": pane_id,
+        }),
+    );
+
+    // Update global active pane
+    *manager.active_pane_id.lock().unwrap() = Some(pane_id.clone());
+
+    Json(serde_json::json!({ "ok": true })).into_response()
+}
+
+// ─── PUT /api/tabs/{tab_id}/layout ─────────────────────────────────
+
+pub async fn update_layout(
+    State(manager): State<Arc<SessionManager>>,
+    Path(tab_id): Path<String>,
+    Json(req): Json<UpdateLayoutRequest>,
+) -> impl IntoResponse {
+    // Verify tab exists
+    if !manager.tab_layouts.contains_key(&tab_id) {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "tab not found" })),
+        )
+            .into_response();
+    }
+
+    // Store updated layout
+    manager.insert_tab(
+        tab_id.clone(),
+        serde_json::json!({
+            "layout": req.layout,
+            "active_pane_id": req.active_pane_id,
+        }),
+    );
+
+    Json(serde_json::json!({ "ok": true })).into_response()
+}

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -36,7 +36,13 @@ pub enum ClientMsg {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum SyncClientMsg {
     ActivateTab { pane_id: String },
-    CreateTab { pane_id: String },
+    CreateTab {
+        layout: serde_json::Value,
+        #[serde(default)]
+        tab_id: Option<String>,
+        #[serde(default)]
+        pane_id: Option<String>,
+    },
     CloseTab { pane_id: String },
     ClosePane { pane_id: String },
     UpdateLayout { pane_id: String, layout: serde_json::Value, active_pane_id: String },
@@ -76,11 +82,21 @@ async fn handle_sync_socket(socket: WebSocket, manager: Arc<SessionManager>) {
     let msg = serde_json::to_string(&tab_list).unwrap();
     if ws_tx.send(Message::Text(msg.into())).await.is_err() { return; }
 
-    // Register this client for sync broadcasts
-    let mut rx = manager.add_sync_client();
+    // Use mpsc channel to bridge broadcast messages and direct responses to the WebSocket
+    let (client_id, mut rx) = manager.add_sync_client();
+    let (msg_tx, mut msg_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
 
-    let fwd = tokio::spawn(async move {
+    // Forward broadcast messages into the shared channel
+    let msg_tx_broadcast = msg_tx.clone();
+    tokio::spawn(async move {
         while let Some(data) = rx.recv().await {
+            if msg_tx_broadcast.send(data).is_err() { break; }
+        }
+    });
+
+    // Forward all messages from the shared channel to the WebSocket
+    let fwd = tokio::spawn(async move {
+        while let Some(data) = msg_rx.recv().await {
             if ws_tx.send(Message::Text(data.into())).await.is_err() { break; }
         }
     });
@@ -93,35 +109,85 @@ async fn handle_sync_socket(socket: WebSocket, manager: Arc<SessionManager>) {
                     match sync_msg {
                         SyncClientMsg::ActivateTab { pane_id } => {
                             *manager.active_pane_id.lock().unwrap() = Some(pane_id.clone());
-                            manager.broadcast_sync(&SyncMsg::TabActivated { pane_id });
+                            manager.broadcast_sync_others(&SyncMsg::TabActivated { pane_id }, &client_id);
                         }
-                        SyncClientMsg::CreateTab { pane_id } => {
-                            *manager.active_pane_id.lock().unwrap() = Some(pane_id.clone());
-                            manager.broadcast_sync(&SyncMsg::TabCreated { pane_id });
+                        SyncClientMsg::CreateTab { layout, tab_id, pane_id } => {
+                            let tab_id = tab_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+                            let leaf_id = pane_id
+                                .or_else(|| crate::session::first_leaf_id(&layout))
+                                .unwrap_or_else(|| tab_id.clone());
+                            *manager.active_pane_id.lock().unwrap() = Some(leaf_id.clone());
+                            manager.insert_tab(tab_id.clone(), serde_json::json!({
+                                "layout": layout,
+                                "active_pane_id": leaf_id,
+                            }));
+                            // Reply to the sender with server-generated IDs
+                            let _ = msg_tx.send(serde_json::to_string(&SyncMsg::TabCreated {
+                                tab_id: tab_id.clone(),
+                                pane_id: leaf_id.clone(),
+                                layout: Some(layout.clone()),
+                            }).unwrap());
+                            // Broadcast to other clients
+                            manager.broadcast_sync_others(&SyncMsg::TabCreated {
+                                tab_id,
+                                pane_id: leaf_id,
+                                layout: Some(layout),
+                            }, &client_id);
                         }
                         SyncClientMsg::CloseTab { pane_id } => {
-                            manager.sessions.remove(&pane_id);
-                            manager.tab_layouts.remove(&pane_id);
+                            // Collect leaf pane IDs from the layout before removing it
+                            let leaf_ids: Vec<String> = manager.tab_layouts.get(&pane_id)
+                                .and_then(|v| v.get("layout").cloned())
+                                .map(|layout| crate::session::collect_leaf_pane_ids(&layout))
+                                .unwrap_or_default();
+                            // Remove PTY sessions for all leaves in this tab
+                            for leaf_id in &leaf_ids {
+                                manager.sessions.remove(leaf_id);
+                            }
+                            manager.remove_tab(&pane_id);
                             // Remove stale pane_id from any parent tab layouts
                             manager.purge_pane_from_layouts(&pane_id);
-                            manager.broadcast_sync(&SyncMsg::TabClosed { pane_id });
+                            manager.broadcast_sync_others(&SyncMsg::TabClosed { pane_id }, &client_id);
                         }
                         SyncClientMsg::ClosePane { pane_id } => {
-                            // Close a single pane in a split — only remove its session,
-                            // don't touch tab layout or broadcast tab_closed
                             manager.sessions.remove(&pane_id);
-                            manager.purge_pane_from_layouts(&pane_id);
+                            // Collect affected layouts before purging
+                            let before_layouts: Vec<(String, serde_json::Value)> = manager.tab_layouts.iter()
+                                .map(|e| (e.key().clone(), e.value().clone()))
+                                .collect();
+                            let emptied_tabs = manager.purge_pane_from_layouts(&pane_id);
+                            // Broadcast layout changes to other clients
+                            for (tab_id, old_val) in &before_layouts {
+                                if let Some(new_val) = manager.tab_layouts.get(tab_id) {
+                                    if *new_val.value() != *old_val {
+                                        let layout = new_val.value().get("layout").cloned().unwrap_or(serde_json::Value::Null);
+                                        let active = new_val.value().get("active_pane_id")
+                                            .and_then(|v| v.as_str())
+                                            .unwrap_or("")
+                                            .to_string();
+                                        manager.broadcast_sync_others(&SyncMsg::LayoutUpdated {
+                                            pane_id: tab_id.clone(),
+                                            layout,
+                                            active_pane_id: active,
+                                        }, &client_id);
+                                    }
+                                }
+                            }
+                            // Broadcast TabClosed for tabs that became empty
+                            for tab_id in emptied_tabs {
+                                manager.broadcast_sync_others(&SyncMsg::TabClosed { pane_id: tab_id }, &client_id);
+                            }
                         }
                         SyncClientMsg::UpdateLayout { pane_id, layout, active_pane_id } => {
-                            manager.tab_layouts.insert(pane_id.clone(), serde_json::json!({
+                            manager.insert_tab(pane_id.clone(), serde_json::json!({
                                 "layout": layout,
                                 "active_pane_id": active_pane_id,
                             }));
-                            manager.broadcast_sync(&SyncMsg::LayoutUpdated {
+                            manager.broadcast_sync_others(&SyncMsg::LayoutUpdated {
                                 pane_id,
                                 layout,
                                 active_pane_id,
-                            });
+                            }, &client_id);
                         }
                     }
                 }
@@ -154,25 +220,41 @@ async fn handle_socket(socket: WebSocket, pane_id: String, manager: Arc<SessionM
             let chunks = screen.snapshot_scrollback_chunks(200);
             let snap = screen.snapshot();
             let rx = session.add_client();
+            info!("Snapshot for pane={}: cols={}, rows={}, scrollback_chunks={}, snapshot_len={}", pane_id, cols, rows, chunks.len(), snap.len());
             (cols, rows, chunks, snap, rx)
         };
 
         // Send reconnected message
         let msg = serde_json::to_string(&ServerMsg::Reconnected { cols, rows }).unwrap();
-        if ws_tx.send(Message::Text(msg.into())).await.is_err() { return; }
+        info!("Sending reconnected to pane={}: {}", pane_id, msg);
+        if ws_tx.send(Message::Text(msg.into())).await.is_err() {
+            error!("Failed to send reconnected msg to pane={}", pane_id);
+            return;
+        }
         for chunk in &scrollback_chunks {
             let msg = serde_json::to_string(&ServerMsg::Output { data: chunk }).unwrap();
             if ws_tx.send(Message::Text(msg.into())).await.is_err() { return; }
         }
 
         let msg = serde_json::to_string(&ServerMsg::Output { data: &snapshot }).unwrap();
-        if ws_tx.send(Message::Text(msg.into())).await.is_err() { return; }
+        info!("Sending snapshot to pane={}: msg_len={}", pane_id, msg.len());
+        if ws_tx.send(Message::Text(msg.into())).await.is_err() {
+            error!("Failed to send snapshot to pane={}", pane_id);
+            return;
+        }
+        info!("All initial messages sent to pane={}", pane_id);
 
+        let pane_id_fwd = pane_id.clone();
         let fwd = tokio::spawn(async move {
             while let Some(data) = rx.recv().await {
+                info!("Forwarder: pane={}, data_len={}", pane_id_fwd, data.len());
                 let msg = serde_json::to_string(&ServerMsg::Output { data: &data }).unwrap();
-                if ws_tx.send(Message::Text(msg.into())).await.is_err() { break; }
+                if ws_tx.send(Message::Text(msg.into())).await.is_err() {
+                    error!("Forwarder: failed to send WS message for pane={}", pane_id_fwd);
+                    break;
+                }
             }
+            info!("Forwarder: exited for pane={}", pane_id_fwd);
         });
 
         // Input channel: replaces old channel so only this connection writes to PTY
@@ -237,6 +319,7 @@ async fn handle_socket(socket: WebSocket, pane_id: String, manager: Arc<SessionM
     }
 
     // ── New session ──
+    info!("No existing session found for pane={}, creating new PTY session (this is unexpected for new tabs!)", pane_id);
     let (session, shell_type) = match crate::pty::create_session(Arc::clone(&manager), pane_id.clone(), None) {
         Ok(x) => x,
         Err(e) => {
@@ -252,11 +335,17 @@ async fn handle_socket(socket: WebSocket, pane_id: String, manager: Arc<SessionM
     let _ = ws_tx.send(Message::Text(shell_info.into())).await;
 
     // Forward PTY output to this WS client
+    let pane_id_fwd = pane_id.clone();
     let fwd = tokio::spawn(async move {
         while let Some(data) = rx.recv().await {
+            info!("Forwarder (new): pane={}, data_len={}", pane_id_fwd, data.len());
             let msg = serde_json::to_string(&ServerMsg::Output { data: &data }).unwrap();
-            if ws_tx.send(Message::Text(msg.into())).await.is_err() { break; }
+            if ws_tx.send(Message::Text(msg.into())).await.is_err() {
+                error!("Forwarder (new): failed to send WS message for pane={}", pane_id_fwd);
+                break;
+            }
         }
+        info!("Forwarder (new): exited for pane={}", pane_id_fwd);
     });
 
     // Input channel: dedicated write task reads from channel → PTY writer


### PR DESCRIPTION
## Summary
- Add REST API for tab/pane CRUD (create, close, split, activate, layout update)
- Migrate frontend tab operations from client-side logic to server APIs
- Introduce `tab_id` in sync protocol for stable multi-client tab identification
- Add `broadcast_sync_others` to prevent echo back to originating client
- Handle PTY exit lifecycle with automatic tab layout cleanup
- Fix terminal initial resize with retry loop for WebGL renderer readiness
- Replace broadcast dot indicator with radar icon
- Bump version to v0.10.5

## Test plan
- [ ] Create new tab via UI and verify PTY starts correctly
- [ ] Split pane horizontal/vertical and verify layout syncs across clients
- [ ] Close pane in split and verify remaining pane stays active
- [ ] Close last tab and verify a new tab auto-creates
- [ ] Open two browser tabs and verify multi-client sync works (no echo)
- [ ] Exit a shell (type `exit`) and verify tab closes cleanly
- [ ] Verify broadcast radar icon appears when broadcast mode is active
- [ ] Test on mobile: terminal resize works after keyboard opens