### PR TITLE
perf: remove debug logs and add MIT license

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug Report
+about: Report a bug to help us improve
+title: ''
+labels: bug
+assignees: ''
+---
+
+## Environment
+
+- Dinotty version:
+- OS (server):
+- OS (client/device):
+- Browser:
+- Shell:
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+## Actual Behavior
+
+## Screenshots / Logs
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest a new feature
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+Describe the problem or pain point.
+
+## Proposed Solution
+
+How should it work?
+
+## Alternatives Considered
+
+Any other approaches you've thought about?
+
+## Additional Context
+
+Screenshots, mockups, or references.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Summary
+
+-
+
+## Changes
+
+-
+
+## Test Plan
+
+- [ ] Tested locally
+- [ ] Frontend type-check passes (`npx vue-tsc --noEmit`)
+- [ ] No regressions on desktop browser
+- [ ] No regressions on mobile browser (if applicable)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = ["src-tauri"]
 name = "dinotty-server"
 version = "0.10.5"
 edition = "2021"
+license = "MIT"
 build = "build.rs"
 repository = "https://github.com/xichan96/dinotty"
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ChenXi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.en.md
+++ b/README.en.md
@@ -5,6 +5,14 @@
 <h1 align="center">Dinotty</h1>
 
 <p align="center">
+  <a href="https://github.com/xichan96/dinotty/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue" alt="License"></a>
+  <img src="https://img.shields.io/badge/language-Rust-orange" alt="Rust">
+  <img src="https://img.shields.io/badge/frontend-Vue%203-brightgreen" alt="Vue 3">
+  <a href="https://github.com/xichan96/dinotty/stargazers"><img src="https://img.shields.io/github/stars/xichan96/dinotty?style=social" alt="GitHub Stars"></a>
+  <a href="https://github.com/xichan96/dinotty/issues"><img src="https://img.shields.io/github/issues/xichan96/dinotty" alt="GitHub Issues"></a>
+</p>
+
+<p align="center">
   English | <a href="./README.md">中文</a>
 </p>
 

--- a/README.en.md
+++ b/README.en.md
@@ -53,6 +53,8 @@ Terminal-based coding agents (Claude Code, opencode, Codex, OpenClaw, etc.) are 
 
 - **Server-side virtual terminal** — full VTE parser, server knows exact screen state, enables session recovery & screen snapshots
 - **Session persistence** — PTY processes survive disconnection, auto-reconnect with exponential backoff, refresh page to restore
+- **Split pane & multi-tab** — draggable split, multi-tab management with server-led pane lifecycle
+- **Server list** — manage multiple remote servers, quick switch connections
 - **Responsive layout** — portrait stacks vertically, landscape side-by-side; touch-optimized buttons & pane resizing
 - **Customizable shortcut keyboard** — add Ctrl/Esc/function keys for mobile, supports arbitrary escape sequences
 - **Built-in file browser** — code highlighting, Markdown rendering, Office document preview, audio/video playback
@@ -114,14 +116,18 @@ cd frontend && npx vue-tsc --noEmit
 ```
 src/               # Rust backend
   main.rs          # Axum router & server entry
+  lib.rs           # Library entry point
   ws.rs            # WebSocket ↔ PTY bridge
   vt_screen.rs     # Virtual terminal emulator (VTE-based)
   session.rs       # Session manager (multi-pane)
-  workspace.rs     # File workspace API
-  proxy.rs         # Reverse proxy for preview
+  pty.rs           # PTY creation & management
+  tabs.rs          # Tab & pane management
+  history.rs       # Session history
+  workspace/       # File workspace API
+  proxy/           # Reverse proxy for preview
   monitor.rs       # System monitor
   notification.rs  # Notification broadcast (bell/OSC detection)
-  plugin.rs        # Plugin system management
+  plugin/          # Plugin system management
   settings.rs      # Settings persistence
   auth.rs          # Authentication
   file_watcher.rs  # File change watching
@@ -129,8 +135,19 @@ src/               # Rust backend
 frontend/          # Vue 3 SPA
   src/
     App.vue
-    components/    # TabBar, TerminalPane, MobileKeyboard, etc.
-    composables/   # useTerminal, useTransport, useSettings, etc.
+    components/
+      split/           # SplitContainer, TabBar, PaneHeader, StatusBar
+      terminal/        # TerminalPane, MonitorPopover
+      command/         # CommandPalette, CommandBookmarks
+      keyboard/        # MobileKeyboard, HistoryPanel, SuggestionBar
+      notification/    # NotificationPanel, NotificationCard
+      preview/         # FileWorkspacePreview, PreviewPanel, WebPreview
+      settings/        # Settings tabs (General, Theme, Keyboard, etc.)
+      workspace/       # MonacoEditor, FilePreviewContent, gitDecorations
+      plugin/          # PluginView
+      ui/              # ConfirmModal and other shared components
+      ServerList.vue   # Server list
+    composables/   # useTerminal, useTransport, useSettings, useTabApi, etc.
 
 src-tauri/         # Tauri desktop client
 docs/              # Design documents

--- a/README.en.md
+++ b/README.en.md
@@ -10,7 +10,7 @@
 
 ---
 
-A **mobile-first** terminal server purpose-built for **coding agents**. Run Claude Code, opencode, Codex, or OpenClaw on your phone with the same experience as on your laptop — use fragmented time to stay productive while you're on the go.
+A **multi-device** terminal server purpose-built for **coding agents**. Run Claude Code, opencode, Codex, or OpenClaw on any device — desktop-class on your laptop, always in your pocket on your phone. Switch seamlessly, never lose a session.
 
 ## Screenshots
 
@@ -30,12 +30,12 @@ A **mobile-first** terminal server purpose-built for **coding agents**. Run Clau
 
 ## Why Dinotty?
 
-Terminal-based coding agents (Claude Code, opencode, Codex, OpenClaw, etc.) are powerful, but they are tethered to your desktop. Dinotty lets you:
+Terminal-based coding agents (Claude Code, opencode, Codex, OpenClaw, etc.) are powerful, but they're locked inside a single terminal window. Dinotty lets you:
 
-- **Kick off a coding task from your phone** while waiting in line, commuting, or walking around
-- **Check on a long-running agent** without pulling out your laptop
-- **Review and verify agent output** — code diffs, rendered pages, generated files — right from your phone's browser
-- **Never lose your session** — put your phone to sleep, switch apps, lose signal — come back and everything is exactly where you left it
+- **Manage agents from any device** — deep coding on desktop, scan a QR code on your phone when you leave your desk to keep monitoring and managing your agent's work without interruption
+- **Multi-device sync, seamless switching** — start on your laptop, continue on your phone; return to your laptop and pick up right where you left off
+- **Verify agent output directly** — code diffs, rendered pages, generated files, all visible in the built-in browser
+- **Never lose your session** — disconnect, lock your screen, switch devices — come back and everything is exactly where you left it
 
 ### Lightweight — Not a Remote Desktop
 
@@ -82,6 +82,24 @@ Terminal-based coding agents (Claude Code, opencode, Codex, OpenClaw, etc.) are 
 | Token auth | ✅ | ✅ | ❌ | ✅ |
 
 Other web terminals are thin WebSocket-to-PTY pipes. Dinotty runs a **full virtual terminal emulator on the server**, enabling session recovery and screen snapshots. Combined with the built-in file/web browser, it provides a self-contained environment where coding agents work and users verify results.
+
+## AI Coding Solutions Comparison
+
+| | Dinotty | Claude Code Remote | Codex Web | Happy | hapi | Termius | tmux |
+|---|---|---|---|---|---|---|---|
+| Positioning | Web terminal server | Built-in multi-device | Cloud agent | AI Agent remote client | AI Agent remote client | SSH client | Terminal multiplexer |
+| Approach | Server-side VTE + Web UI | Anthropic cloud + local | OpenAI cloud | CLI proxy wrapper | CLI proxy wrapper | Native app | Server-side process |
+| Web access | ✅ | ✅ claude.ai/code | ✅ chatgpt.com/codex | ✅ | ✅ PWA | ❌ | ❌ |
+| Native app | Tauri (optional) | iOS + Android | ❌ | iOS + Android | ❌ (PWA) | All platforms | ❌ |
+| General terminal | ✅ Any command | ❌ AI agents only | ❌ AI agents only | ❌ AI agents only | ❌ AI agents only | ✅ SSH | ✅ |
+| Coding agent support | ✅ File browser/preview/notify | ✅ Built-in | ✅ Built-in | ✅ Voice/approve | ✅ Voice/workspace | ❌ | ❌ |
+| Plugin system | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Multi-device sync | ✅ Browser-based | ✅ Cross-device session sync | ✅ Cloud sessions | ✅ | ✅ | ✅ Vault | ❌ Requires SSH |
+| Relay service | Planned | ✅ Anthropic hosted | ✅ OpenAI hosted | ✅ | ✅ | SaaS | ❌ |
+| Deployment | Self-hosted | SaaS | SaaS | Relay service | Self-hosted/relay | SaaS | Self-hosted |
+| Code runs on | Your own server | Local / Anthropic cloud | OpenAI cloud | Local | Local | Remote SSH | Remote server |
+
+Claude Code and Codex each offer built-in remote solutions, but are limited to their own agent ecosystem. Happy and hapi are third-party remote control layers that wrap CLI tools for phone-based approval and voice interaction. Dinotty is a general-purpose web terminal server where agents run natively on the server, with a full working environment including file browser, web preview, and plugin system, delivering a professional experience on both desktop and mobile.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@
 
 - **服务端虚拟终端** — 完整 VTE 解析，服务端掌握精确屏幕状态，支持会话恢复与屏幕快照
 - **会话持久化** — PTY 进程在断网后存活，自动重连 + 指数退避，刷新页面即可恢复
+- **分屏与多 Tab** — 可拖拽分屏、多 Tab 管理，服务端主导的 Pane 生命周期
+- **服务器列表** — 管理多台远程服务器，快速切换连接
 - **响应式布局** — 竖屏上下排列，横屏左右并排；触控优化的按钮与面板缩放
 - **可自定义快捷键盘** — 为手机补齐 Ctrl/Esc/功能键，支持任意转义序列
 - **内建文件浏览器** — 代码高亮、Markdown 渲染、Office 文档预览、音视频播放
@@ -114,14 +116,18 @@ cd frontend && npx vue-tsc --noEmit
 ```
 src/               # Rust 后端
   main.rs          # Axum 路由与服务入口
+  lib.rs           # 库入口
   ws.rs            # WebSocket ↔ PTY 桥接
   vt_screen.rs     # 虚拟终端仿真器（基于 VTE）
   session.rs       # 会话管理器（多面板）
-  workspace.rs     # 文件工作区 API
-  proxy.rs         # 反向代理（预览）
+  pty.rs           # PTY 创建与管理
+  tabs.rs          # Tab 与 Pane 管理
+  history.rs       # 会话历史记录
+  workspace/       # 文件工作区 API
+  proxy/           # 反向代理（预览）
   monitor.rs       # 系统监控
   notification.rs  # 通知广播（bell/OSC 检测）
-  plugin.rs        # 插件系统管理
+  plugin/          # 插件系统管理
   settings.rs      # 设置持久化
   auth.rs          # 身份认证
   file_watcher.rs  # 文件变更监听
@@ -129,8 +135,19 @@ src/               # Rust 后端
 frontend/          # Vue 3 SPA
   src/
     App.vue
-    components/    # TabBar, TerminalPane, MobileKeyboard 等
-    composables/   # useTerminal, useTransport, useSettings 等
+    components/
+      split/           # SplitContainer, TabBar, PaneHeader, StatusBar
+      terminal/        # TerminalPane, MonitorPopover
+      command/         # CommandPalette, CommandBookmarks
+      keyboard/        # MobileKeyboard, HistoryPanel, SuggestionBar
+      notification/    # NotificationPanel, NotificationCard
+      preview/         # FileWorkspacePreview, PreviewPanel, WebPreview
+      settings/        # 各设置 Tab（General, Theme, Keyboard 等）
+      workspace/       # MonacoEditor, FilePreviewContent, gitDecorations
+      plugin/          # PluginView
+      ui/              # ConfirmModal 等通用组件
+      ServerList.vue   # 服务器列表
+    composables/   # useTerminal, useTransport, useSettings, useTabApi 等
 
 src-tauri/         # Tauri 桌面客户端
 docs/              # 设计文档

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
 <h1 align="center">Dinotty</h1>
 
 <p align="center">
+  <a href="https://github.com/xichan96/dinotty/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue" alt="License"></a>
+  <img src="https://img.shields.io/badge/language-Rust-orange" alt="Rust">
+  <img src="https://img.shields.io/badge/frontend-Vue%203-brightgreen" alt="Vue 3">
+  <a href="https://github.com/xichan96/dinotty/stargazers"><img src="https://img.shields.io/github/stars/xichan96/dinotty?style=social" alt="GitHub Stars"></a>
+  <a href="https://github.com/xichan96/dinotty/issues"><img src="https://img.shields.io/github/issues/xichan96/dinotty" alt="GitHub Issues"></a>
+</p>
+
+<p align="center">
   <a href="./README.en.md">English</a> | 中文
 </p>
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ---
 
-为 **Coding Agent** 打造的**移动优先**终端服务器。在手机上运行 Claude Code、opencode、Codex 或 OpenClaw，获得与电脑上完全一致的体验——利用碎片时间，随时随地编程。
+为 **Coding Agent** 打造的**多端同步**终端服务器。在任意设备上运行 Claude Code、opencode、Codex 或 OpenClaw，桌面端专业高效，移动端随时掌控——无缝切换，会话永不丢失。
 
 ## 截图
 
@@ -30,12 +30,12 @@
 
 ## 为什么选择 Dinotty？
 
-终端 Coding Agent（Claude Code、opencode、Codex、OpenClaw 等）功能强大，但它们被束缚在桌面上。Dinotty 让你：
+终端 Coding Agent（Claude Code、opencode、Codex、OpenClaw 等）功能强大，但它们被束缚在单一终端窗口里。Dinotty 让你：
 
-- **在手机上启动编程任务**——排队、通勤时掏出手机就能让 agent 干活
-- **随时查看长时间运行的 agent**——不用打开笔记本电脑
-- **直接在手机上验证 agent 产出**——代码 diff、渲染的网页、生成的文件，浏览器里一目了然
-- **永远不会丢失会话**——手机息屏、切换 App、断网——回来后一切都在原处
+- **在任意设备上管理 agent**——桌面端深度编码，离开工位时手机扫码即可继续查看和管理 agent 工作，工作连贯不中断
+- **多端同步，无缝切换**——电脑上写到一半，掏出手机继续；回到电脑，一切原样
+- **直接验证 agent 产出**——代码 diff、渲染的网页、生成的文件，内置浏览器一目了然
+- **永远不会丢失会话**——断网、息屏、切换设备——回来后一切都在原处
 
 ### 轻量级——不是远程桌面
 
@@ -82,6 +82,24 @@
 | Token 认证 | ✅ | ✅ | ❌ | ✅ |
 
 其他 Web 终端只是 WebSocket 到 PTY 的透传管道。Dinotty 在服务端运行**完整的虚拟终端仿真器**，使得会话恢复、屏幕快照成为可能，结合内建文件/网页浏览器，提供自包含的 Coding Agent 工作环境。
+
+## AI Coding 方案对比
+
+| | Dinotty | Claude Code Remote | Codex Web | Happy | hapi | Termius | tmux |
+|---|---|---|---|---|---|---|---|
+| 定位 | Web 终端服务器 | 内建多端同步 | 云端 Agent | AI Agent 远程客户端 | AI Agent 远程客户端 | SSH 客户端 | 终端复用器 |
+| 技术方案 | 服务端 VTE + Web UI | Anthropic 云 + 本地 | OpenAI 云 | CLI 代理包装 | CLI 代理包装 | 原生 App | 服务端进程 |
+| Web 访问 | ✅ | ✅ claude.ai/code | ✅ chatgpt.com/codex | ✅ | ✅ PWA | ❌ | ❌ |
+| 原生 App | Tauri（可选） | iOS + Android | ❌ | iOS + Android | ❌（PWA） | 全平台 | ❌ |
+| 通用终端 | ✅ 任意命令 | ❌ 仅 AI Agent | ❌ 仅 AI Agent | ❌ 仅 AI Agent | ❌ 仅 AI Agent | ✅ SSH | ✅ |
+| Coding Agent 适配 | ✅ 文件浏览/预览/通知 | ✅ 内建 | ✅ 内建 | ✅ 语音/审批 | ✅ 语音/工作区 | ❌ | ❌ |
+| 插件系统 | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| 多端同步 | ✅ 浏览器即同步 | ✅ 跨设备会话同步 | ✅ 云端会话 | ✅ | ✅ | ✅ Vault | ❌ 需 SSH |
+| 中继服务 | 计划中 | ✅ Anthropic 托管 | ✅ OpenAI 托管 | ✅ | ✅ | SaaS | ❌ |
+| 部署方式 | 自托管 | SaaS | SaaS | 中继服务 | 自托管/中继 | SaaS | 自托管 |
+| 代码运行位置 | 自有服务器 | 本地 / Anthropic 云 | OpenAI 云 | 本地 | 本地 | 远程 SSH | 远程服务器 |
+
+Claude Code 和 Codex 各自提供了内建的远程方案，但仅限于自身 Agent 生态。Happy/hapi 是第三方远程控制层，包装 CLI 实现手机审批和语音交互。Dinotty 是通用 Web 终端服务器，Agent 在服务端原生运行，同时提供文件浏览、网页预览、插件系统等完整工作环境，桌面端和移动端均有专业体验。
 
 ## 快速开始
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -601,18 +601,15 @@ function onServerConnect(host: string, port: number) {
 }
 
 function openPlugin(pluginId: string) {
-  console.log('[openPlugin] called with:', pluginId)
   try {
     const paneId = `plugin:${pluginId}`
     const existing = tabs.value.find(t => t.paneId === paneId)
     if (existing) {
-      console.log('[openPlugin] tab already exists, activating')
       activateTab(paneId)
       return
     }
 
     const plugin = loadedPlugins.get(pluginId)
-    console.log('[openPlugin] plugin lookup:', !!plugin, plugin?.state)
     if (!plugin || plugin.state !== 'active') {
       const msg = plugin?.state === 'error'
         ? `Plugin "${pluginId}" failed to load: ${plugin.error ?? 'unknown error'}`
@@ -628,12 +625,10 @@ function openPlugin(pluginId: string) {
       title: plugin.manifest.name,
       pluginId,
     }
-    console.log('[openPlugin] pushing tab:', newTab)
     tabs.value.push(newTab)
     activePaneId.value = paneId
     sendSync({ type: 'activate_tab', pane_id: paneId })
     persist()
-    console.log('[openPlugin] done, tabs count:', tabs.value.length, 'activePaneId:', activePaneId.value)
     nextTick(() => focusActive())
   } catch (err) {
     console.error('[openPlugin] error:', err)
@@ -1076,7 +1071,6 @@ async function connectSyncWS() {
         })
       }
     } else if (msg.type === 'plugin_changed') {
-      console.log('[plugin_changed] plugin_id:', msg.plugin_id, 'change:', msg.change)
       handlePluginChanged(msg.plugin_id, msg.change)
     }
   }

--- a/frontend/src/composables/usePluginLoader.ts
+++ b/frontend/src/composables/usePluginLoader.ts
@@ -290,16 +290,13 @@ function createPluginContext(pluginId: string): PluginContext {
 
 async function loadPlugin(id: string): Promise<LoadedPlugin> {
   // 1. Fetch manifest
-  console.log(`[plugin] loadPlugin(${id}): fetching manifest`)
   const manifestRes = await authFetch(apiUrl(`/api/plugins/${id}/plugin.json`))
   if (!manifestRes.ok) throw new Error(`Plugin ${id}: manifest not found (${manifestRes.status})`)
   const manifest: PluginManifest = await manifestRes.json()
-  console.log(`[plugin] loadPlugin(${id}): manifest ok, entry=${manifest.entry || './main.js'}`)
 
   // 2. Fetch main.js via authFetch (includes auth token) then import from blob URL
   const entry = manifest.entry || './main.js'
   const jsUrl = apiUrl(`/api/plugins/${id}/${entry.replace('./', '')}`)
-  console.log(`[plugin] loadPlugin(${id}): fetching ${jsUrl}`)
   const jsRes = await authFetch(jsUrl)
   if (!jsRes.ok) throw new Error(`Plugin ${id}: failed to fetch ${entry} (${jsRes.status})`)
   const jsContent = await jsRes.text()
@@ -314,7 +311,6 @@ async function loadPlugin(id: string): Promise<LoadedPlugin> {
   } finally {
     URL.revokeObjectURL(blobUrl)
   }
-  console.log(`[plugin] loadPlugin(${id}): module loaded, activate=${typeof mod.activate}`)
 
   if (typeof mod.activate !== 'function') {
     throw new Error(`Plugin ${id}: main.js must export activate(context)`)
@@ -323,12 +319,9 @@ async function loadPlugin(id: string): Promise<LoadedPlugin> {
   // 3. Load optional CSS (fetch via authFetch then inject as style element)
   if (manifest.styles) {
     const cssUrl = apiUrl(`/api/plugins/${id}/${manifest.styles.replace('./', '')}`)
-    console.log(`[plugin] loadPlugin(${id}): loading CSS from ${cssUrl}`)
     const cssRes = await authFetch(cssUrl)
-    console.log(`[plugin] loadPlugin(${id}): CSS response status=${cssRes.status}`)
     if (cssRes.ok) {
       const cssText = await cssRes.text()
-      console.log(`[plugin] loadPlugin(${id}): CSS loaded, ${cssText.length} bytes`)
       const styleEl = document.createElement('style')
       styleEl.textContent = cssText
       styleEl.dataset.pluginId = id
@@ -336,8 +329,6 @@ async function loadPlugin(id: string): Promise<LoadedPlugin> {
     } else {
       console.error(`[plugin] loadPlugin(${id}): CSS fetch failed, status=${cssRes.status}`)
     }
-  } else {
-    console.log(`[plugin] loadPlugin(${id}): no styles defined in manifest`)
   }
 
   // 4. Activate
@@ -352,7 +343,6 @@ async function loadPlugin(id: string): Promise<LoadedPlugin> {
       ),
     ])
     exports = (result as PluginExports) || null
-    console.log(`[plugin] loadPlugin(${id}): activated, has component=${!!exports?.component}`)
   } catch (e: any) {
     throw new Error(`Plugin ${id}: activate() threw: ${e.message}`)
   }
@@ -404,11 +394,9 @@ export async function handlePluginChanged(pluginId: string, change: string) {
       try {
         if (ch === 'deleted') {
           await unloadPlugin(id)
-          console.log(`[plugin] hot-reload: unloaded ${id}`)
         } else {
           await unloadPlugin(id)
           await loadPlugin(id)
-          console.log(`[plugin] hot-reload: reloaded ${id} (${ch})`)
         }
       } catch (e: any) {
         console.error(`[plugin] hot-reload failed for ${id}:`, e.message)
@@ -429,16 +417,13 @@ export function usePluginLoader() {
         return
       }
       const list: PluginManifest[] = await res.json()
-      console.log('[plugin] loadAll: backend returned', list.length, 'plugins:', list.map(p => p.id))
 
       for (const manifest of list) {
         if (loadedPlugins.has(manifest.id)) {
-          console.log('[plugin] loadAll: skipping', manifest.id, '(already loaded)')
           continue
         }
         try {
           await loadPlugin(manifest.id)
-          console.log('[plugin] loadAll: loaded', manifest.id)
         } catch (e: any) {
           console.error(`[plugin] loadAll: failed ${manifest.id}:`, e.message)
           loadedPlugins.set(manifest.id, {
@@ -451,7 +436,6 @@ export function usePluginLoader() {
           })
         }
       }
-      console.log('[plugin] loadAll: done. loadedPlugins keys:', [...loadedPlugins.keys()])
     } catch (e: any) {
       console.error('[plugin] failed to load plugins:', e.message)
     }

--- a/frontend/src/composables/useTerminal.ts
+++ b/frontend/src/composables/useTerminal.ts
@@ -357,7 +357,6 @@ export class TerminalInstance {
     this.ws = new WebSocket(url)
 
     this.ws.onopen = () => {
-      console.log(`[TerminalInstance] WS onopen: pane=${this.paneId}`)
       this._reconnectAttempts = 0
       this._hideOverlay()
       this.onConnect?.()
@@ -365,10 +364,10 @@ export class TerminalInstance {
     }
 
     this.ws.onmessage = (e) => {
-      if (this._destroyed) { console.log(`[TerminalInstance] WS onmessage: pane=${this.paneId} IGNORED (destroyed)`); return }
+      if (this._destroyed) return
       let msg: ServerMsg
       try { msg = JSON.parse(e.data) } catch { return }
-      if (!this.xterm) { console.log(`[TerminalInstance] WS onmessage: pane=${this.paneId} IGNORED (xterm null)`); return }
+      if (!this.xterm) return
       if (msg.type === 'reconnected') {
         this._suppressTitleChange = true
         this.xterm.reset()
@@ -377,17 +376,14 @@ export class TerminalInstance {
         this._hideOverlay()
         this._doFitAndResize(true)
       } else if (msg.type === 'output') {
-        console.log(`[TerminalInstance] WS output: pane=${this.paneId}, data_len=${msg.data.length}`)
         this.xterm.write(msg.data)
         this.onRawOutput?.(msg.data)
       } else if (msg.type === 'shell_info') {
-        console.log(`[TerminalInstance] WS shell_info: pane=${this.paneId}, shell=${msg.shell_type}`)
         this.onShellInfo?.(msg.shell_type)
       }
     }
 
     this.ws.onclose = (e) => {
-      console.log(`[TerminalInstance] WS onclose: pane=${this.paneId}, code=${e.code}, reason=${e.reason}`)
       if (this._destroyed) return
       this.onDisconnect?.()
       if (e.code === 1000) {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,6 +2,7 @@
 name = "dinotty-desktop"
 version = "0.10.5"
 edition = "2021"
+license = "MIT"
 
 [dependencies]
 tauri = { version = "2", features = ["tray-icon"] }


### PR DESCRIPTION
## Summary

- Remove 27 debug console.log statements from frontend (App.vue, useTerminal.ts, usePluginLoader.ts), eliminating hot-path logging on every terminal output chunk
- Add MIT license to project root, Cargo.toml, and src-tauri/Cargo.toml

## Test plan

- [ ] `cd frontend && npx vue-tsc --noEmit` passes
- [ ] Terminal I/O works normally without console noise
- [ ] Plugin loading/unloading works correctly
- [ ] LICENSE file renders correctly on GitHub