### PR TITLE
fix(frontend): resolve issues from confirm-before-close-tab review

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -433,13 +433,15 @@ async function onClosePane(tabId: string, paneId: string) {
 
   // Bypass 1: non-terminal tab
   if (tab.type !== 'terminal') {
-    await splitPane.closePane(paneId)
+    const closed = await splitPane.closePane(paneId)
+    if (!closed) await closeTab(tabId)
     return
   }
 
   // Bypass 2: user disabled confirmation
   if (appSettings.confirm_before_close_tab === false) {
-    await splitPane.closePane(paneId)
+    const closed = await splitPane.closePane(paneId)
+    if (!closed) await closeTab(tabId)
     return
   }
 
@@ -499,9 +501,6 @@ const pendingCloseMessage = computed(() => {
 async function onConfirmClose() {
   const tabId = pendingCloseTabId.value
   const paneId = pendingClosePaneId.value
-  pendingCloseTabId.value = null
-  pendingClosePaneId.value = null
-  confirmCloseVisible.value = false
 
   if (paneId) {
     // Pane close: try close pane first, fall back to tab close if last
@@ -513,6 +512,10 @@ async function onConfirmClose() {
     // Tab close (no pane specified)
     await closeTab(tabId)
   }
+
+  pendingCloseTabId.value = null
+  pendingClosePaneId.value = null
+  confirmCloseVisible.value = false
 }
 
 function onCancelClose() {

--- a/frontend/src/components/ui/ConfirmModal.vue
+++ b/frontend/src/components/ui/ConfirmModal.vue
@@ -8,7 +8,6 @@
         </div>
         <div class="confirm-body">
           <p class="confirm-message">{{ message }}</p>
-          <p v-if="target" class="confirm-target">{{ target }}</p>
         </div>
         <div class="confirm-footer">
           <button class="confirm-btn cancel" @click="onCancel">{{ cancelText }}</button>
@@ -26,7 +25,6 @@ const props = defineProps<{
   visible: boolean
   title: string
   message: string
-  target?: string
   confirmText: string
   cancelText: string
 }>()
@@ -114,17 +112,6 @@ onUnmounted(() => window.removeEventListener('keydown', onKey, true))
   font-size: 13px;
   color: var(--fg);
   line-height: 1.5;
-}
-
-.confirm-target {
-  margin-top: 6px;
-  font-size: 12px;
-  color: var(--accent);
-  word-break: break-all;
-  font-family: var(--font-mono);
-  background: var(--bg-input);
-  padding: 6px 8px;
-  border-radius: 4px;
 }
 
 .confirm-footer {

--- a/frontend/src/composables/formatCloseTabMessage.ts
+++ b/frontend/src/composables/formatCloseTabMessage.ts
@@ -1,14 +1,10 @@
-// Composable extracted for testability (Task 5, openspec change `confirm-before-close-tab`).
-// `t()` does not support {var} interpolation, so we inline the title into the message.
-// Spec: openspec/changes/confirm-before-close-tab/design.md §E9 fallback.
-
-export type Locale = 'en' | 'zh'
+import type { Locale } from './useI18n'
 
 /**
  * Build the modal message for "close this tab" confirmation.
  * - When `title` is empty, returns the base message unmodified.
- * - English locale wraps the title in double quotes:  `... "title"?`
- * - Chinese locale wraps the title in CJK brackets:     `...「title」？`
+ * - English locale wraps the title in single quotes:  `... 'title'?`
+ * - Chinese locale wraps the title in CJK brackets:   `...「title」？`
  */
 export function formatCloseTabMessage(
   base: string,
@@ -17,6 +13,6 @@ export function formatCloseTabMessage(
 ): string {
   if (!title) return base
   return locale === 'en'
-    ? `${base} "${title}"?`
+    ? `${base} '${title}'?`
     : `${base}「${title}」？`
 }

--- a/frontend/src/composables/useI18n.ts
+++ b/frontend/src/composables/useI18n.ts
@@ -283,7 +283,7 @@ const messages: Record<Locale, Record<string, string>> = {
       'Show a dialog before closing a tab that may run an AI agent',
     'settings.behavior': 'Behavior',
     'confirm.closeTabTitle': 'Close session?',
-    'confirm.closeTabMessage': 'Closing this session will terminate a possibly running AI agent. Proceed to',
+    'confirm.closeTabMessage': 'Closing this session will terminate a possibly running AI agent. Close',
     'confirm.closeTabConfirm': 'Close',
     'confirm.closeTabCancel': 'Cancel',
     'settings.about.checkForUpdates': 'Check for updates',

--- a/frontend/src/test/AppPaneClose.test.ts
+++ b/frontend/src/test/AppPaneClose.test.ts
@@ -272,4 +272,36 @@ describe('App.vue - onClosePane routes through confirmation gate', () => {
 
     wrapper.unmount()
   })
+
+  it('bypass with setting off + closePane returns false → falls back to closeTab', async () => {
+    settings.confirm_before_close_tab = false
+    mocks.closePane.mockResolvedValue(false)
+
+    const wrapper = await mountWithTabs()
+    const splitContainer = wrapper.findComponent(SplitContainerStub)
+    await splitContainer.vm.$emit('close', 'pane-1')
+    await nextTick()
+
+    // closePane should be called directly (bypass)
+    expect(mocks.closePane).toHaveBeenCalledWith('pane-1')
+    // Since closePane returned false, closeTab should be the fallback
+    expect(mocks.apiCloseTab).toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  it('bypass with setting off + closePane returns true → does NOT call closeTab', async () => {
+    settings.confirm_before_close_tab = false
+    mocks.closePane.mockResolvedValue(true)
+
+    const wrapper = await mountWithTabs()
+    const splitContainer = wrapper.findComponent(SplitContainerStub)
+    await splitContainer.vm.$emit('close', 'pane-1')
+    await nextTick()
+
+    expect(mocks.closePane).toHaveBeenCalledWith('pane-1')
+    expect(mocks.apiCloseTab).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
 })

--- a/frontend/src/test/ConfirmModal.test.ts
+++ b/frontend/src/test/ConfirmModal.test.ts
@@ -10,7 +10,6 @@ describe('ConfirmModal Esc 键支持', () => {
         visible: true,
         title: '关闭标签页',
         message: '是否关闭此标签页?',
-        target: 'tab-1',
         confirmText: '关闭',
         cancelText: '取消',
       },

--- a/frontend/src/test/formatCloseTabMessage.test.ts
+++ b/frontend/src/test/formatCloseTabMessage.test.ts
@@ -7,7 +7,7 @@ import { formatCloseTabMessage } from '../composables/formatCloseTabMessage'
 // Chinese uses 「title」 — different quotation styles per locale.
 
 describe('formatCloseTabMessage', () => {
-  const BASE = 'Closing this session will terminate a possibly running AI agent. Proceed to'
+  const BASE = 'Closing this session will terminate a possibly running AI agent. Close'
 
   it('returns base message unchanged when title is empty (en)', () => {
     expect(formatCloseTabMessage(BASE, '', 'en')).toBe(BASE)
@@ -17,9 +17,9 @@ describe('formatCloseTabMessage', () => {
     expect(formatCloseTabMessage(BASE, '', 'zh')).toBe(BASE)
   })
 
-  it('English: wraps title in double quotes with ASCII question mark', () => {
+  it('English: wraps title in single quotes with ASCII question mark', () => {
     expect(formatCloseTabMessage(BASE, 'npm install', 'en'))
-      .toBe(`${BASE} "npm install"?`)
+      .toBe(`${BASE} 'npm install'?`)
   })
 
   it('Chinese: wraps title in CJK brackets with fullwidth question mark', () => {
@@ -28,13 +28,17 @@ describe('formatCloseTabMessage', () => {
   })
 
   it('English: handles CJK characters in title (no special escaping)', () => {
-    // The composable does not sanitize; it just concatenates.
     expect(formatCloseTabMessage(BASE, '服务器', 'en'))
-      .toBe(`${BASE} "服务器"?`)
+      .toBe(`${BASE} '服务器'?`)
   })
 
   it('Chinese: handles ASCII characters in title', () => {
     expect(formatCloseTabMessage(BASE, '服务器', 'zh'))
       .toBe(`${BASE}「服务器」？`)
+  })
+
+  it('English: handles title containing single quotes', () => {
+    expect(formatCloseTabMessage(BASE, "it's running", 'en'))
+      .toBe(`${BASE} 'it's running'?`)
   })
 })

--- a/frontend/src/test/useI18n.test.ts
+++ b/frontend/src/test/useI18n.test.ts
@@ -115,7 +115,7 @@ describe('useI18n - confirm-before-close-tab strings', () => {
       [
         'en',
         'confirm.closeTabMessage',
-        'Closing this session will terminate a possibly running AI agent. Proceed to',
+        'Closing this session will terminate a possibly running AI agent. Close',
       ],
       ['en', 'confirm.closeTabConfirm', 'Close'],
       ['en', 'confirm.closeTabCancel', 'Cancel'],


### PR DESCRIPTION
## Summary

- Fix `onClosePane` bypass paths missing `closeTab` fallback when `closePane` returns false (functional regression when confirmation is disabled)
- Move state cleanup after async operations in `onConfirmClose` to prevent race condition
- Change English message quote style from double to single quotes to avoid nesting ambiguity
- Remove unused `target` prop and dead CSS from `ConfirmModal`
- Improve English close tab message wording ("Proceed to" → "Close")
- Import `Locale` type from `useI18n` instead of duplicating it
- Add bypass fallback tests for disabled confirmation setting

## Test plan

- [x] `pnpm test` — 55/55 tests pass
- [x] `npx vue-tsc --noEmit` — clean
- [x] `cargo check --lib` — clean