### PR TITLE
fix(app): route Cmd+W in split-pane mode through confirmation gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 dist/
 node_modules/
 .claude/
+.claude-code/
+.codegraph/
+openspec/
 CLAUDE.md
 *.tsbuildinfo
 .pnpm-store/

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -879,12 +879,10 @@ function onGlobalKeydown(e: KeyboardEvent) {
       if (!activePaneId.value) return
       const tab = tabs.value.find(t => t.paneId === activePaneId.value)
       if (tab?.type === 'terminal' && getAllLeaves(tab.layout).length > 1) {
-        // Multi-pane: close current pane
-        if (!await splitPane.closePane(tab.activePaneId)) {
-          requestCloseTab(activePaneId.value)
-        }
+        // Multi-pane: route through confirmation gate (consistent with X button)
+        await onClosePane(tab.paneId, tab.activePaneId)
       } else {
-        requestCloseTab(activePaneId.value)
+        await requestCloseTab(activePaneId.value)
       }
     },
     splitHorizontal: () => splitPane.splitPane('horizontal'),

--- a/frontend/src/test/AppPaneClose.test.ts
+++ b/frontend/src/test/AppPaneClose.test.ts
@@ -58,9 +58,25 @@ vi.mock('../composables/apiBase', () => ({
 }))
 vi.mock('../composables/useTransport', () => ({ isTauri: () => false }))
 vi.mock('../composables/useTerminal', () => ({ isTouchDevice: () => false }))
+// Per-binding key map so Cmd+W can be dispatched without colliding with
+// other keyActions in onGlobalKeydown (the first matching binding wins).
+const BINDING_KEYS: Record<string, string> = {
+  togglePalette: 'p',
+  openBookmarks: 'b',
+  newTab: 't',
+  closeTab: 'w',
+  splitHorizontal: 'd',
+  splitVertical: 'e',
+  toggleBroadcast: 'g',
+  toggleZoom: 'z',
+  equalizePanes: '=',
+  focusNextPane: ']',
+  focusPrevPane: '[',
+  searchTerminal: 'f',
+}
 vi.mock('../composables/useKeybindings', () => ({
   useKeybindings: () => ({
-    getBinding: () => ({ key: 'x', shift: false }),
+    getBinding: (id: string) => ({ key: BINDING_KEYS[id] ?? 'x', shift: false }),
     formatBinding: (b: any) => b.key,
   }),
 }))
@@ -301,6 +317,98 @@ describe('App.vue - onClosePane routes through confirmation gate', () => {
 
     expect(mocks.closePane).toHaveBeenCalledWith('pane-1')
     expect(mocks.apiCloseTab).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+})
+
+describe('App.vue - Cmd+W routes through confirmation gate in split-pane mode', () => {
+  beforeEach(() => {
+    settings.confirm_before_close_tab = true
+    mocks.closePane.mockReset()
+    mocks.splitPane.mockReset()
+    mocks.toggleBroadcast.mockReset()
+    mocks.toggleZoom.mockReset()
+    mocks.equalizePanes.mockReset()
+    mocks.focusPane.mockReset()
+    mocks.focusNext.mockReset()
+    mocks.focusPrev.mockReset()
+    mocks.keyboardResize.mockReset()
+    mocks.reorderPane.mockReset()
+    mocks.onTerminalInput.mockReset()
+    mocks.focusNeighbor.mockReset()
+    mocks.apiCloseTab.mockReset()
+    localStorageMock.clear()
+  })
+
+  it('Cmd+W on multi-pane layout → does NOT closePane, shows modal', async () => {
+    mocks.closePane.mockResolvedValue(true)
+
+    const wrapper = await mountWithTabs()
+
+    // Dispatch Cmd+W (stubbed key 'w' for closeTab binding).
+    // App.vue attaches the keydown listener to `document`.
+    document.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'w',
+      metaKey: true,
+      bubbles: true,
+    }))
+    await nextTick()
+
+    // closePane must NOT have been called yet — we expect the modal gate
+    expect(mocks.closePane).not.toHaveBeenCalled()
+
+    // ConfirmModal must now be visible
+    const confirmModal = wrapper.findComponent(ConfirmModalStub)
+    expect(confirmModal.exists()).toBe(true)
+    expect((confirmModal.vm as any).$props.visible).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('Cmd+W + confirm in multi-pane mode → calls splitPane.closePane with active pane id', async () => {
+    mocks.closePane.mockResolvedValue(true)
+
+    const wrapper = await mountWithTabs()
+
+    document.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'w',
+      metaKey: true,
+      bubbles: true,
+    }))
+    await nextTick()
+
+    const confirmModal = wrapper.findComponent(ConfirmModalStub)
+    await confirmModal.vm.$emit('confirm')
+    await nextTick()
+
+    // closePane should be called with the active pane id (pane-1 in fixture)
+    expect(mocks.closePane).toHaveBeenCalledWith('pane-1')
+    // apiCloseTab should NOT have been called (closePane returned true)
+    expect(mocks.apiCloseTab).not.toHaveBeenCalled()
+    // Modal should be closed
+    expect((confirmModal.vm as any).$props.visible).toBe(false)
+
+    wrapper.unmount()
+  })
+
+  it('Cmd+W + setting off → bypasses modal and calls closePane directly', async () => {
+    settings.confirm_before_close_tab = false
+    mocks.closePane.mockResolvedValue(true)
+
+    const wrapper = await mountWithTabs()
+
+    document.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'w',
+      metaKey: true,
+      bubbles: true,
+    }))
+    await nextTick()
+
+    expect(mocks.closePane).toHaveBeenCalledWith('pane-1')
+    // Modal should NOT be visible (bypass)
+    const confirmModal = wrapper.findComponent(ConfirmModalStub)
+    expect((confirmModal.vm as any).$props.visible).toBe(false)
 
     wrapper.unmount()
   })


### PR DESCRIPTION
## Summary

Fixes a bug where pressing **Cmd+W** in split-pane mode silently closed the active pane without showing the confirmation modal, even when `confirm_before_close_tab` was enabled. The mouse X button correctly showed the modal; the keyboard path bypassed it.

The keyboard close path is now routed through the same `onClosePane(tabId, paneId)` helper that the X button uses, so the confirmation gate applies uniformly to both keyboard and mouse close paths.

## Changes

- `frontend/src/App.vue` — `onGlobalKeydown.closeTab` action now calls `onClosePane(tab.paneId, tab.activePaneId)` for the multi-pane branch instead of calling `splitPane.closePane()` directly. The single-pane branch is unchanged.
- `frontend/src/test/AppPaneClose.test.ts` — adds 3 regression tests covering the Cmd+W path on a multi-pane layout: modal shown, modal confirmed → `splitPane.closePane` called, and `confirm_before_close_tab = false` bypass path.
- `.gitignore` — excludes workflow artifacts (`openspec/`, `.codegraph/`, `.claude-code/`) so they cannot accidentally land in future PRs.

## Test Plan

- [x] Tested locally (Cmd+W in split-pane now shows modal; X button unchanged; setting-off bypass works)
- [x] Frontend type-check passes (`npx vue-tsc --noEmit`)
- [x] No regressions on desktop browser (8/8 vitest pass: `AppPaneClose.test.ts`)
- [x] No regressions on mobile browser (keyboard path is desktop-only; mobile uses on-screen keyboard)