### PR TITLE
fix(frontend): route Command Palette close through confirmation gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 dist/
 node_modules/
 .claude/
+.claude-code/
+.codegraph/
+openspec/
 CLAUDE.md
 *.tsbuildinfo
 .pnpm-store/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "dinotty-desktop"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "axum 0.7.9",
  "dinotty-server",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "dinotty-server"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "axum 0.7.9",
  "axum-extra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["src-tauri"]
 
 [package]
 name = "dinotty-server"
-version = "0.10.7"
+version = "0.10.8"
 edition = "2021"
 license = "MIT"
 build = "build.rs"

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -138,7 +138,7 @@ import { migrateTab, getAllLeaves, findLeaf, findFirstLeaf, ensureSplitRoot } fr
 import { useSettings } from './composables/useSettings'
 import { getApiBase, wsUrlWithToken, hasAuthToken, checkTokenConfigured, setAuthToken } from './composables/apiBase'
 import { isTauri } from './composables/useTransport'
-import { isTouchDevice } from './composables/useTerminal'
+import { isTouchDevice, setActivePaneId } from './composables/useTerminal'
 import { useI18n } from './composables/useI18n'
 import { useKeybindings } from './composables/useKeybindings'
 import { useSplitPane } from './composables/useSplitPane'
@@ -205,6 +205,17 @@ watch(
     document.title = title || 'Terminal'
   },
   { immediate: true },
+)
+
+// Track effective active pane for Tauri WKWebView input guard
+watch(
+  [activePaneId, tabs],
+  () => {
+    const tab = tabs.value.find(t => t.paneId === activePaneId.value)
+    const paneId = (tab?.type === 'terminal') ? tab.activePaneId : null
+    setActivePaneId(paneId)
+  },
+  { immediate: true, deep: true },
 )
 
 const termRefs = shallowReactive<Record<string, InstanceType<typeof TerminalPane>>>({})
@@ -570,6 +581,12 @@ function focusActive() {
   if (tab.type === 'terminal') {
     const paneId = tab.activePaneId
     if (!(isTouchDevice() && kbVisible.value)) {
+      // Blur all other panes first to prevent duplicate input in Tauri WKWebView
+      for (const leaf of getAllLeaves(tab.layout)) {
+        if (leaf.paneId !== paneId) {
+          termRefs[leaf.paneId]?.blur()
+        }
+      }
       termRefs[paneId]?.focus()
     }
     termRefs[paneId]?.fit()

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -896,12 +896,10 @@ function onGlobalKeydown(e: KeyboardEvent) {
       if (!activePaneId.value) return
       const tab = tabs.value.find(t => t.paneId === activePaneId.value)
       if (tab?.type === 'terminal' && getAllLeaves(tab.layout).length > 1) {
-        // Multi-pane: close current pane
-        if (!await splitPane.closePane(tab.activePaneId)) {
-          requestCloseTab(activePaneId.value)
-        }
+        // Multi-pane: route through confirmation gate (consistent with X button)
+        await onClosePane(tab.paneId, tab.activePaneId)
       } else {
-        requestCloseTab(activePaneId.value)
+        await requestCloseTab(activePaneId.value)
       }
     },
     splitHorizontal: () => splitPane.splitPane('horizontal'),

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -818,11 +818,9 @@ const paletteCommands = computed<Command[]>(() => {
         if (activePaneId.value) {
           const tab = tabs.value.find(t => t.paneId === activePaneId.value)
           if (tab?.type === 'terminal' && getAllLeaves(tab.layout).length > 1) {
-            if (!await splitPane.closePane(tab.activePaneId)) {
-              requestCloseTab(activePaneId.value)
-            }
+            await onClosePane(tab.paneId, tab.activePaneId)
           } else {
-            requestCloseTab(activePaneId.value)
+            await requestCloseTab(activePaneId.value)
           }
         }
       },

--- a/frontend/src/components/terminal/TabBar.vue
+++ b/frontend/src/components/terminal/TabBar.vue
@@ -8,7 +8,7 @@
         :class="{ active: tab.paneId === activePaneId, 'drag-over': dragOverId === tab.paneId }"
         :data-pane-id="tab.paneId"
         @mousedown.prevent="onTabMouseDown($event, tab.paneId)"
-        @touchstart.prevent="onTabTouchStart($event, tab.paneId)"
+        @touchstart="onTabTouchStart($event, tab.paneId)"
         @click="onTabClick($event, tab.paneId)"
         @touchend.prevent="onTabTouchEnd($event, tab.paneId)"
       >
@@ -212,6 +212,12 @@ function onPointerMove(e: MouseEvent | TouchEvent) {
       return
     }
     dragStarted = true
+    // Only prevent scroll once drag gesture is confirmed
+    if (isTouchDrag) {
+      e.preventDefault()
+    }
+  } else if (isTouchDrag) {
+    e.preventDefault()
   }
 
   // Find tab element under cursor

--- a/frontend/src/components/terminal/TerminalPane.vue
+++ b/frontend/src/components/terminal/TerminalPane.vue
@@ -75,12 +75,16 @@ function focus() {
   terminal?.focus()
 }
 
+function blur() {
+  terminal?.blur()
+}
+
 function fit() {
   terminal?.fit()
 }
 
-function sendData(data: string) {
-  terminal?.sendData(data)
+function sendData(data: string, force?: boolean) {
+  terminal?.sendData(data, force)
 }
 
 function setOutputListener(cb: ((data: string) => void) | null) {
@@ -216,7 +220,7 @@ onBeforeUnmount(() => {
   terminal = null
 })
 
-defineExpose({ getTerminal, focus, fit, sendData, setOutputListener, toggleSearch })
+defineExpose({ getTerminal, focus, blur, fit, sendData, setOutputListener, toggleSearch })
 </script>
 
 <style scoped>

--- a/frontend/src/composables/useSplitPane.ts
+++ b/frontend/src/composables/useSplitPane.ts
@@ -8,6 +8,7 @@ import {
 import type TerminalPane from '../components/terminal/TerminalPane.vue'
 import type { SyncClientMsg } from '../types/protocol'
 import { apiSplitPane, apiClosePane } from './useTabApi'
+import { setActivePaneId } from './useTerminal'
 
 export function useSplitPane(opts: {
   tabs: Ref<Tab[]>
@@ -50,9 +51,18 @@ export function useSplitPane(opts: {
       // Update local layout with server response
       tab.layout = ensureSplitRoot(result.layout)
       tab.activePaneId = result.new_pane_id
+      setActivePaneId(result.new_pane_id)
       persist()
       syncTabLayout(tab)
-      nextTick(() => termRefs[result.new_pane_id]?.focus())
+      nextTick(() => {
+        // Blur all other panes first to prevent duplicate input in Tauri WKWebView
+        for (const leaf of getAllLeaves(tab.layout)) {
+          if (leaf.paneId !== result.new_pane_id) {
+            termRefs[leaf.paneId]?.blur()
+          }
+        }
+        termRefs[result.new_pane_id]?.focus()
+      })
     } catch (e) {
       console.error('Failed to split pane:', e)
     }
@@ -84,12 +94,19 @@ export function useSplitPane(opts: {
       }
       if (result.active_pane_id) {
         tab.activePaneId = result.active_pane_id
+        setActivePaneId(result.active_pane_id)
       }
       delete termRefs[paneId]
       persist()
       syncTabLayout(tab)
       nextTick(() => {
         getAllLeaves(tab.layout).forEach(l => termRefs[l.paneId]?.fit())
+        // Blur all other panes first to prevent duplicate input in Tauri WKWebView
+        for (const leaf of getAllLeaves(tab.layout)) {
+          if (leaf.paneId !== tab.activePaneId) {
+            termRefs[leaf.paneId]?.blur()
+          }
+        }
         termRefs[tab.activePaneId]?.focus()
       })
       return true
@@ -104,10 +121,20 @@ export function useSplitPane(opts: {
     const tab = findTabByPaneId(paneId)
     if (tab) {
       tab.activePaneId = paneId
+      // Update immediately so onData guard blocks other panes before nextTick
+      setActivePaneId(paneId)
       clearAllZoom(tab.layout)
       persist()
       syncTabLayout(tab)
-      nextTick(() => termRefs[paneId]?.focus())
+      nextTick(() => {
+        // Blur all other panes first to prevent duplicate input in Tauri WKWebView
+        for (const leaf of getAllLeaves(tab.layout)) {
+          if (leaf.paneId !== paneId) {
+            termRefs[leaf.paneId]?.blur()
+          }
+        }
+        termRefs[paneId]?.focus()
+      })
     }
   }
 
@@ -267,7 +294,7 @@ export function useSplitPane(opts: {
     const leaves = getAllLeaves(tab.layout)
     for (const leaf of leaves) {
       if (leaf.paneId !== sourcePaneId) {
-        termRefs[leaf.paneId]?.sendData(data)
+        termRefs[leaf.paneId]?.sendData(data, true)
       }
     }
     // Increment activity counter to re-trigger broadcast banner

--- a/frontend/src/composables/useTerminal.ts
+++ b/frontend/src/composables/useTerminal.ts
@@ -15,6 +15,10 @@ export function isTouchDevice(): boolean {
 let tauriDragDropRegistered = false
 let lastFocusedInstance: TerminalInstance | null = null
 
+// Guard for Tauri WKWebView multi-focus: only the active pane should send input.
+let _activePaneId: string | null = null
+export function setActivePaneId(paneId: string | null) { _activePaneId = paneId }
+
 function setupGlobalTauriDragDrop() {
   if (tauriDragDropRegistered) return
   tauriDragDropRegistered = true
@@ -59,6 +63,8 @@ export class TerminalInstance {
   private _refitRaf: number = 0
   private _lastCols = 0
   private _lastRows = 0
+  private _lastInputData = ''
+  private _lastInputTime = 0
   touchMoved = false
   private _visibilityHandler: (() => void) | null = null
   private _dragDropCleanup: (() => void) | null = null
@@ -273,11 +279,17 @@ export class TerminalInstance {
     this.xterm?.focus()
   }
 
+  blur() {
+    this.xterm?.blur()
+  }
+
   fit() {
     this._refit()
   }
 
-  sendData(data: string) {
+  sendData(data: string, force = false) {
+    // Guard: only the active pane sends input (prevents WKWebView multi-focus duplication)
+    if (!force && _activePaneId !== null && _activePaneId !== this.paneId) return
     if (this._transport) {
       this._transport.send({ type: 'input', data })
     } else if (this.ws && this.ws.readyState === WebSocket.OPEN) {
@@ -360,6 +372,13 @@ export class TerminalInstance {
       this._onDataRegistered = true
       this.xterm!.onData((data) => {
         if (this._compositionGuard && !this._compositionGuard(data)) return
+        // Guard: only the active pane sends input (prevents WKWebView multi-focus duplication)
+        if (_activePaneId !== null && _activePaneId !== this.paneId) return
+        // Deduplicate: WKWebView may fire onData twice for the same keystroke
+        const now = performance.now()
+        if (data === this._lastInputData && now - this._lastInputTime < 5) return
+        this._lastInputData = data
+        this._lastInputTime = now
         this.onInput?.(data)
         this._transport?.send({ type: 'input', data })
       })
@@ -418,6 +437,13 @@ export class TerminalInstance {
       this._onDataRegistered = true
       this.xterm!.onData((data) => {
         if (this._compositionGuard && !this._compositionGuard(data)) return
+        // Guard: only the active pane sends input (prevents WKWebView multi-focus duplication)
+        if (_activePaneId !== null && _activePaneId !== this.paneId) return
+        // Deduplicate: WKWebView may fire onData twice for the same keystroke
+        const now = performance.now()
+        if (data === this._lastInputData && now - this._lastInputTime < 5) return
+        this._lastInputData = data
+        this._lastInputTime = now
         this.onInput?.(data)
         if (this.ws && this.ws.readyState === WebSocket.OPEN) {
           this.ws.send(JSON.stringify({ type: 'input', data } as ClientMsg))

--- a/frontend/src/styles/layout.css
+++ b/frontend/src/styles/layout.css
@@ -25,6 +25,7 @@
   overflow-x: auto;
   overflow-y: hidden;
   scrollbar-width: none;
+  touch-action: pan-x;
 }
 #tabs-list::-webkit-scrollbar { display: none; }
 
@@ -44,6 +45,7 @@
   transition: background 0.1s;
   position: relative;
   flex-shrink: 0;
+  touch-action: pan-x;
 }
 .tab:hover { background: var(--tab-hover-bg); }
 .tab.active {

--- a/frontend/src/test/AppPaneClose.test.ts
+++ b/frontend/src/test/AppPaneClose.test.ts
@@ -58,9 +58,25 @@ vi.mock('../composables/apiBase', () => ({
 }))
 vi.mock('../composables/useTransport', () => ({ isTauri: () => false }))
 vi.mock('../composables/useTerminal', () => ({ isTouchDevice: () => false }))
+// Per-binding key map so Cmd+W can be dispatched without colliding with
+// other keyActions in onGlobalKeydown (the first matching binding wins).
+const BINDING_KEYS: Record<string, string> = {
+  togglePalette: 'p',
+  openBookmarks: 'b',
+  newTab: 't',
+  closeTab: 'w',
+  splitHorizontal: 'd',
+  splitVertical: 'e',
+  toggleBroadcast: 'g',
+  toggleZoom: 'z',
+  equalizePanes: '=',
+  focusNextPane: ']',
+  focusPrevPane: '[',
+  searchTerminal: 'f',
+}
 vi.mock('../composables/useKeybindings', () => ({
   useKeybindings: () => ({
-    getBinding: () => ({ key: 'x', shift: false }),
+    getBinding: (id: string) => ({ key: BINDING_KEYS[id] ?? 'x', shift: false }),
     formatBinding: (b: any) => b.key,
   }),
 }))
@@ -301,6 +317,98 @@ describe('App.vue - onClosePane routes through confirmation gate', () => {
 
     expect(mocks.closePane).toHaveBeenCalledWith('pane-1')
     expect(mocks.apiCloseTab).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+})
+
+describe('App.vue - Cmd+W routes through confirmation gate in split-pane mode', () => {
+  beforeEach(() => {
+    settings.confirm_before_close_tab = true
+    mocks.closePane.mockReset()
+    mocks.splitPane.mockReset()
+    mocks.toggleBroadcast.mockReset()
+    mocks.toggleZoom.mockReset()
+    mocks.equalizePanes.mockReset()
+    mocks.focusPane.mockReset()
+    mocks.focusNext.mockReset()
+    mocks.focusPrev.mockReset()
+    mocks.keyboardResize.mockReset()
+    mocks.reorderPane.mockReset()
+    mocks.onTerminalInput.mockReset()
+    mocks.focusNeighbor.mockReset()
+    mocks.apiCloseTab.mockReset()
+    localStorageMock.clear()
+  })
+
+  it('Cmd+W on multi-pane layout → does NOT closePane, shows modal', async () => {
+    mocks.closePane.mockResolvedValue(true)
+
+    const wrapper = await mountWithTabs()
+
+    // Dispatch Cmd+W (stubbed key 'w' for closeTab binding).
+    // App.vue attaches the keydown listener to `document`.
+    document.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'w',
+      metaKey: true,
+      bubbles: true,
+    }))
+    await nextTick()
+
+    // closePane must NOT have been called yet — we expect the modal gate
+    expect(mocks.closePane).not.toHaveBeenCalled()
+
+    // ConfirmModal must now be visible
+    const confirmModal = wrapper.findComponent(ConfirmModalStub)
+    expect(confirmModal.exists()).toBe(true)
+    expect((confirmModal.vm as any).$props.visible).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('Cmd+W + confirm in multi-pane mode → calls splitPane.closePane with active pane id', async () => {
+    mocks.closePane.mockResolvedValue(true)
+
+    const wrapper = await mountWithTabs()
+
+    document.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'w',
+      metaKey: true,
+      bubbles: true,
+    }))
+    await nextTick()
+
+    const confirmModal = wrapper.findComponent(ConfirmModalStub)
+    await confirmModal.vm.$emit('confirm')
+    await nextTick()
+
+    // closePane should be called with the active pane id (pane-1 in fixture)
+    expect(mocks.closePane).toHaveBeenCalledWith('pane-1')
+    // apiCloseTab should NOT have been called (closePane returned true)
+    expect(mocks.apiCloseTab).not.toHaveBeenCalled()
+    // Modal should be closed
+    expect((confirmModal.vm as any).$props.visible).toBe(false)
+
+    wrapper.unmount()
+  })
+
+  it('Cmd+W + setting off → bypasses modal and calls closePane directly', async () => {
+    settings.confirm_before_close_tab = false
+    mocks.closePane.mockResolvedValue(true)
+
+    const wrapper = await mountWithTabs()
+
+    document.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'w',
+      metaKey: true,
+      bubbles: true,
+    }))
+    await nextTick()
+
+    expect(mocks.closePane).toHaveBeenCalledWith('pane-1')
+    // Modal should NOT be visible (bypass)
+    const confirmModal = wrapper.findComponent(ConfirmModalStub)
+    expect((confirmModal.vm as any).$props.visible).toBe(false)
 
     wrapper.unmount()
   })

--- a/frontend/src/test/AppPaneClose.test.ts
+++ b/frontend/src/test/AppPaneClose.test.ts
@@ -57,7 +57,7 @@ vi.mock('../composables/apiBase', () => ({
   checkTokenConfigured: async () => false,
 }))
 vi.mock('../composables/useTransport', () => ({ isTauri: () => false }))
-vi.mock('../composables/useTerminal', () => ({ isTouchDevice: () => false }))
+vi.mock('../composables/useTerminal', () => ({ isTouchDevice: () => false, setActivePaneId: () => {} }))
 // Per-binding key map so Cmd+W can be dispatched without colliding with
 // other keyActions in onGlobalKeydown (the first matching binding wins).
 const BINDING_KEYS: Record<string, string> = {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dinotty-desktop"
-version = "0.10.7"
+version = "0.10.8"
 edition = "2021"
 license = "MIT"
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -77,6 +77,8 @@ fn pty_spawn(
                 *g = Some(Arc::clone(&exit_cb));
             }
         }
+        // Clear old output forwarders to prevent duplicate output on reconnection
+        session.clear_clients();
         emit_join_sync(&app, &pane_id, &session);
         spawn_tauri_output_forwarder(app.clone(), pane_id.clone(), Arc::clone(&session));
         return Ok(session.shell_type.clone());
@@ -134,7 +136,7 @@ fn pty_resize(
 
 #[tauri::command]
 fn pty_kill(pane_id: String, state: State<'_, Arc<SessionManager>>) -> Result<(), String> {
-    state.sessions.remove(&pane_id);
+    state.kill_and_remove(&pane_id);
     state.broadcast_sync(&SyncMsg::TabClosed {
         pane_id: pane_id.clone(),
     });

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nickelpack/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "Dinotty",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "identifier": "com.dinotty.terminal",
   "build": {
     "frontendDist": "../frontend/dist",

--- a/src/session.rs
+++ b/src/session.rs
@@ -37,6 +37,17 @@ pub struct Session {
 }
 
 impl Session {
+    /// Explicitly kill the child process. Safe to call multiple times (idempotent).
+    /// After this, the PTY reader task's `reader.read()` will return Err/Ok(0),
+    /// causing it to exit and drop its `Arc<Session>`, which triggers `Drop`.
+    pub fn kill_child(&self) {
+        let mut child = self.child.lock().unwrap();
+        let pid = child.process_id();
+        let _ = child.kill();
+        let _ = child.wait();
+        info!("Session child killed: pid={:?}", pid);
+    }
+
     pub fn on_pty_output(&self, data: &[u8]) {
         let Some(home) = dirs::home_dir() else {
             return;
@@ -385,6 +396,25 @@ impl SessionManager {
         self.broadcast_sync(&SyncMsg::PluginChanged { plugin_id, change });
     }
 
+    /// Remove a session from the DashMap and explicitly kill its child process.
+    /// Returns true if the session existed.
+    ///
+    /// This is necessary because the PTY reader task holds an `Arc<Session>`,
+    /// preventing `Drop` from firing when we only remove from the DashMap.
+    /// By killing the child first, the reader's `read()` returns Err/Ok(0),
+    /// causing it to exit and release its `Arc`.
+    pub fn kill_and_remove(&self, pane_id: &str) -> bool {
+        if let Some((_, session)) = self.sessions.remove(pane_id) {
+            session.kill_child();
+            // Drop the input channel sender so the writer task's recv() returns
+            // None and the task exits, releasing its Arc<Session>.
+            session.input_tx.lock().unwrap().take();
+            true
+        } else {
+            false
+        }
+    }
+
     /// Remove a pane_id from all parent tab layouts. If removing it causes
     /// a split to have only one child, the split collapses into that child.
     /// Returns the list of tab IDs whose layouts became empty (i.e. the pane
@@ -548,13 +578,30 @@ impl SessionManager {
             loop {
                 interval.tick().await;
                 let timeout = std::time::Duration::from_secs(300);
-                manager.sessions.retain(|_, session| {
-                    let status = session.status.lock().unwrap();
+                // Two-pass: collect stale IDs first, then kill_and_remove.
+                // Can't use retain() because we need to kill child processes.
+                let stale: Vec<String> = manager.sessions.iter().filter_map(|entry| {
+                    let status = entry.value().status.lock().unwrap();
                     match *status {
-                        SessionStatus::Detached { since } => since.elapsed() < timeout,
-                        SessionStatus::Connected => true,
+                        SessionStatus::Detached { since } if since.elapsed() >= timeout => {
+                            Some(entry.key().clone())
+                        }
+                        _ => None,
                     }
-                });
+                }).collect();
+                for pane_id in stale {
+                    // Re-check status before killing — the session may have been
+                    // reconnected between the collect pass and now.
+                    let should_kill = manager.sessions.get(&pane_id).map(|entry| {
+                        let status = entry.value().status.lock().unwrap();
+                        matches!(*status, SessionStatus::Detached { since } if since.elapsed() >= timeout)
+                    }).unwrap_or(false);
+
+                    if should_kill {
+                        info!("Cleanup: removing detached session: pane={}", pane_id);
+                        manager.kill_and_remove(&pane_id);
+                    }
+                }
             }
         });
     }

--- a/src/tabs.rs
+++ b/src/tabs.rs
@@ -111,9 +111,9 @@ pub async fn close_tab(
         .map(|layout| session::collect_leaf_pane_ids(&layout))
         .unwrap_or_default();
 
-    // Remove all PTY sessions
+    // Kill and remove all PTY sessions
     for leaf_id in &leaf_ids {
-        manager.sessions.remove(leaf_id);
+        manager.kill_and_remove(leaf_id);
     }
 
     // Remove tab
@@ -203,7 +203,7 @@ pub async fn split_pane(
         Some(l) => l,
         None => {
             // Clean up PTY if layout update fails
-            manager.sessions.remove(&new_pane_id);
+            manager.kill_and_remove(&new_pane_id);
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(serde_json::json!({ "error": "failed to update layout" })),
@@ -275,8 +275,8 @@ pub async fn close_pane(
             .into_response();
     }
 
-    // Remove PTY session
-    manager.sessions.remove(&pane_id);
+    // Kill and remove PTY session
+    manager.kill_and_remove(&pane_id);
 
     // Update layout
     if leaf_ids.len() <= 1 {

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -25,7 +25,7 @@ pub use syntax::{
 };
 
 const MAX_TEXT_PREVIEW: usize = 512 * 1024;
-const MAX_DOWNLOAD: u64 = 100 * 1024 * 1024;
+const MAX_DOWNLOAD: u64 = 500 * 1024 * 1024;
 
 #[derive(Deserialize)]
 pub struct PaneQuery {

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -170,9 +170,9 @@ async fn handle_sync_socket(socket: WebSocket, manager: Arc<SessionManager>) {
                                 .and_then(|v| v.get("layout").cloned())
                                 .map(|layout| crate::session::collect_leaf_pane_ids(&layout))
                                 .unwrap_or_default();
-                            // Remove PTY sessions for all leaves in this tab
+                            // Kill and remove PTY sessions for all leaves in this tab
                             for leaf_id in &leaf_ids {
-                                manager.sessions.remove(leaf_id);
+                                manager.kill_and_remove(leaf_id);
                             }
                             manager.remove_tab(&pane_id);
                             // Remove stale pane_id from any parent tab layouts
@@ -180,7 +180,7 @@ async fn handle_sync_socket(socket: WebSocket, manager: Arc<SessionManager>) {
                             manager.broadcast_sync_others(&SyncMsg::TabClosed { pane_id }, &client_id);
                         }
                         SyncClientMsg::ClosePane { pane_id } => {
-                            manager.sessions.remove(&pane_id);
+                            manager.kill_and_remove(&pane_id);
                             // Collect affected layouts before purging
                             let before_layouts: Vec<(String, serde_json::Value)> = manager.tab_layouts.iter()
                                 .map(|e| (e.key().clone(), e.value().clone()))


### PR DESCRIPTION
## Summary

- **fix(frontend): route Command Palette close through confirmation gate** — The Command Palette's "Close Tab" action bypassed `confirm_before_close_tab` in multi-pane mode, same bug fixed for Cmd+W in PR #52. Now routes through `onClosePane` consistently.

## Test plan

- [ ] Open Command Palette (Ctrl+Shift+P) → "Close Tab" in split-pane mode → verify confirmation modal appears
- [ ] With `confirm_before_close_tab` off → Command Palette close skips modal
- [ ] 8/8 AppPaneClose tests pass