### PR TITLE
chore: bump version to 0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["src-tauri"]
 
 [package]
 name = "dinotty-server"
-version = "0.10.9"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 build = "build.rs"

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-0.10.9
+0.11.0
 https://github.com/xichan96/dinotty

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dinotty-desktop"
-version = "0.10.9"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nickelpack/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "Dinotty",
-  "version": "0.10.9",
+  "version": "0.11.0",
   "identifier": "com.dinotty.terminal",
   "build": {
     "frontendDist": "../frontend/dist",


### PR DESCRIPTION
## Summary
- Update VERSION, Cargo.toml, and Tauri config from 0.10.9 to 0.11.0

## Test plan
- [ ] Verify About page shows v0.11.0