### PR TITLE
chore: bump version to 0.11.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["src-tauri"]
 
 [package]
 name = "dinotty-server"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 build = "build.rs"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dinotty-desktop"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nickelpack/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "Dinotty",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "identifier": "com.dinotty.terminal",
   "build": {
     "frontendDist": "../frontend/dist",


### PR DESCRIPTION
## Summary

- Update version to 0.11.1 in Cargo.toml, src-tauri/Cargo.toml, and src-tauri/tauri.conf.json

## Test plan

- [ ] `cargo build` succeeds with new version
- [ ] Tauri app reflects version 0.11.1