### PR TITLE
docs: switch demo videos from mov to mp4 format

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -43,15 +43,15 @@ The desktop client delivers a professional experience comparable to iTerm2:
 
 **Split Screen** — Draggable multi-pane split with free layout adjustment:
 
-<video src="https://github.com/xichan96/dinotty/releases/download/demo-media/split-screen.mov" autoplay muted loop playsinline width="600"></video>
+<video src="https://github.com/xichan96/dinotty/releases/download/demo-media/split-screen.mp4" autoplay muted loop playsinline width="600"></video>
 
 **Plugin System** — Hot-reloadable JS plugins with built-in CC Switch, JSON Formatter, and more:
 
-<video src="https://github.com/xichan96/dinotty/releases/download/demo-media/plugin-system.mov" autoplay muted loop playsinline width="600"></video>
+<video src="https://github.com/xichan96/dinotty/releases/download/demo-media/plugin-system.mp4" autoplay muted loop playsinline width="600"></video>
 
 **Web Preview** — Preview local dev servers on your phone, built-in reverse proxy, no need to switch browsers:
 
-<video src="https://github.com/xichan96/dinotty/releases/download/demo-media/web-preview.mov" autoplay muted loop playsinline width="600"></video>
+<video src="https://github.com/xichan96/dinotty/releases/download/demo-media/web-preview.mp4" autoplay muted loop playsinline width="600"></video>
 
 ## Why Dinotty?
 

--- a/README.md
+++ b/README.md
@@ -43,15 +43,15 @@
 
 **分屏** — 可拖拽的多面板分屏，自由调整布局：
 
-<video src="https://github.com/xichan96/dinotty/releases/download/demo-media/split-screen.mov" autoplay muted loop playsinline width="600"></video>
+<video src="https://github.com/xichan96/dinotty/releases/download/demo-media/split-screen.mp4" autoplay muted loop playsinline width="600"></video>
 
 **插件系统** — JS 插件热重载，内置 CC Switch、JSON Formatter 等：
 
-<video src="https://github.com/xichan96/dinotty/releases/download/demo-media/plugin-system.mov" autoplay muted loop playsinline width="600"></video>
+<video src="https://github.com/xichan96/dinotty/releases/download/demo-media/plugin-system.mp4" autoplay muted loop playsinline width="600"></video>
 
 **网页预览** — 手机上也能预览本地开发服务器，内建反向代理，不用切浏览器：
 
-<video src="https://github.com/xichan96/dinotty/releases/download/demo-media/web-preview.mov" autoplay muted loop playsinline width="600"></video>
+<video src="https://github.com/xichan96/dinotty/releases/download/demo-media/web-preview.mp4" autoplay muted loop playsinline width="600"></video>
 
 ## 为什么选择 Dinotty？
 


### PR DESCRIPTION
## Summary

- Replace .mov video URLs with .mp4 in README.md and README.en.md for GitHub video playback support

## Test plan

- [ ] Videos render and play correctly on GitHub README page