### PR TITLE
docs: add fallback links for demo videos in README

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -43,15 +43,21 @@ The desktop client delivers a professional experience comparable to iTerm2:
 
 **Split Screen** — Draggable multi-pane split with free layout adjustment:
 
-<video src="https://github.com/xichan96/dinotty/releases/download/demo-media/split-screen.mp4" autoplay muted loop playsinline width="600"></video>
+<video src="https://github.com/xichan96/dinotty/releases/download/demo-media/split-screen.mp4" autoplay muted loop playsinline width="600">
+  <a href="https://github.com/xichan96/dinotty/releases/download/demo-media/split-screen.mp4">Watch split screen demo video</a>
+</video>
 
 **Plugin System** — Hot-reloadable JS plugins with built-in CC Switch, JSON Formatter, and more:
 
-<video src="https://github.com/xichan96/dinotty/releases/download/demo-media/plugin-system.mp4" autoplay muted loop playsinline width="600"></video>
+<video src="https://github.com/xichan96/dinotty/releases/download/demo-media/plugin-system.mp4" autoplay muted loop playsinline width="600">
+  <a href="https://github.com/xichan96/dinotty/releases/download/demo-media/plugin-system.mp4">Watch plugin system demo video</a>
+</video>
 
 **Web Preview** — Preview local dev servers on your phone, built-in reverse proxy, no need to switch browsers:
 
-<video src="https://github.com/xichan96/dinotty/releases/download/demo-media/web-preview.mp4" autoplay muted loop playsinline width="600"></video>
+<video src="https://github.com/xichan96/dinotty/releases/download/demo-media/web-preview.mp4" autoplay muted loop playsinline width="600">
+  <a href="https://github.com/xichan96/dinotty/releases/download/demo-media/web-preview.mp4">Watch web preview demo video</a>
+</video>
 
 ## Why Dinotty?
 

--- a/README.md
+++ b/README.md
@@ -43,15 +43,21 @@
 
 **分屏** — 可拖拽的多面板分屏，自由调整布局：
 
-<video src="https://github.com/xichan96/dinotty/releases/download/demo-media/split-screen.mp4" autoplay muted loop playsinline width="600"></video>
+<video src="https://github.com/xichan96/dinotty/releases/download/demo-media/split-screen.mp4" autoplay muted loop playsinline width="600">
+  <a href="https://github.com/xichan96/dinotty/releases/download/demo-media/split-screen.mp4">观看分屏演示视频</a>
+</video>
 
 **插件系统** — JS 插件热重载，内置 CC Switch、JSON Formatter 等：
 
-<video src="https://github.com/xichan96/dinotty/releases/download/demo-media/plugin-system.mp4" autoplay muted loop playsinline width="600"></video>
+<video src="https://github.com/xichan96/dinotty/releases/download/demo-media/plugin-system.mp4" autoplay muted loop playsinline width="600">
+  <a href="https://github.com/xichan96/dinotty/releases/download/demo-media/plugin-system.mp4">观看插件系统演示视频</a>
+</video>
 
 **网页预览** — 手机上也能预览本地开发服务器，内建反向代理，不用切浏览器：
 
-<video src="https://github.com/xichan96/dinotty/releases/download/demo-media/web-preview.mp4" autoplay muted loop playsinline width="600"></video>
+<video src="https://github.com/xichan96/dinotty/releases/download/demo-media/web-preview.mp4" autoplay muted loop playsinline width="600">
+  <a href="https://github.com/xichan96/dinotty/releases/download/demo-media/web-preview.mp4">观看网页预览演示视频</a>
+</video>
 
 ## 为什么选择 Dinotty？
 


### PR DESCRIPTION
## Summary

- Add fallback `<a>` links inside `<video>` tags in README.md and README.en.md, so users can still access demo videos when playback is unavailable

## Test plan

- [ ] Verify video fallback links render correctly on GitHub when video autoplay is blocked
- [ ] Confirm both Chinese and English README display properly