### PR TITLE
docs: add macOS xattr note, Linux startup, and port config

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -151,6 +151,29 @@ Download the installer for your platform from [GitHub Releases](https://github.c
 
 > You can also build from source, see "Quick Start" below.
 
+**macOS Note**: Since the app is unsigned, macOS may show **"Dinotty" is damaged and can't be opened**. Run the following command after installation to remove the restriction:
+
+```bash
+xattr -cr /Applications/Dinotty.app
+```
+
+**Linux startup**:
+
+```bash
+# systemd
+systemctl start dinotty-server
+systemctl enable dinotty-server  # auto-start on boot
+
+# Docker container
+nohup dinotty-server &
+```
+
+Default port is **8999**. After starting, visit `http://<your-ip>:8999`. Use `-p` to specify a custom port:
+
+```bash
+dinotty-server -p 3000
+```
+
 ## Quick Start
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -151,6 +151,29 @@ Claude Code 和 Codex 各自提供了内建的远程方案，但仅限于自身 
 
 > 也可以从源码构建，见下方「快速开始」。
 
+**macOS 注意事项**：由于应用未签名，macOS 可能会提示 **"Dinotty" is damaged and can't be opened**。安装后请在终端执行以下命令解除限制：
+
+```bash
+xattr -cr /Applications/Dinotty.app
+```
+
+**Linux 启动方式**：
+
+```bash
+# systemd
+systemctl start dinotty-server
+systemctl enable dinotty-server  # 开机自启
+
+# Docker 容器
+nohup dinotty-server &
+```
+
+默认监听端口 **8999**，启动后访问 `http://<your-ip>:8999`。可通过 `-p` 参数指定端口：
+
+```bash
+dinotty-server -p 3000
+```
+
 ## 快速开始
 
 ```bash


### PR DESCRIPTION
## Summary

- Add macOS unsigned app workaround (xattr -cr) to installation section
- Add systemd and Docker startup instructions for Linux
- Document default port 8999 and -p flag for custom port

## Test plan

- [ ] Verify README.md installation section renders correctly
- [ ] Verify README.en.md installation section renders correctly