### PR TITLE
feat(terminal): add tab rename and optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "dinotty-desktop"
-version = "0.12.3"
+version = "0.12.0"
 dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "dinotty-server"
-version = "0.12.3"
+version = "0.12.0"
 dependencies = [
  "axum 0.7.9",
  "axum-extra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["src-tauri"]
 
 [package]
 name = "dinotty-server"
-version = "0.12.3"
+version = "0.12.0"
 edition = "2021"
 license = "MIT"
 build = "build.rs"

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -14,6 +14,7 @@
       @action="onNewMenuAction"
       @reorder="reorderTab"
       @open-plugin="openPlugin"
+      @rename="onRenameTab"
     >
       <template #left>
         <button
@@ -282,14 +283,22 @@ watch(
 )
 
 // Track effective active pane for Tauri WKWebView input guard
+function syncActivePaneId() {
+  const tab = tabs.value.find((t) => t.paneId === activePaneId.value)
+  const paneId = tab?.type === 'terminal' ? tab.activePaneId : null
+  setActivePaneId(paneId)
+}
+// Fire on tab switch (store activePaneId change) and initial load
+watch(activePaneId, syncActivePaneId, { immediate: true })
+// Fire when tab list changes (add/remove) — not deep, just array reference
+watch(() => tabs.value.length, syncActivePaneId)
+// Fire when active terminal tab's internal focus changes (sync WS, etc.)
 watch(
-  [activePaneId, tabs],
   () => {
     const tab = tabs.value.find((t) => t.paneId === activePaneId.value)
-    const paneId = tab?.type === 'terminal' ? tab.activePaneId : null
-    setActivePaneId(paneId)
+    return tab?.type === 'terminal' ? tab.activePaneId : null
   },
-  { immediate: true, deep: true }
+  (paneId) => setActivePaneId(paneId),
 )
 
 const termRefs = shallowReactive<Record<string, InstanceType<typeof TerminalPane>>>({})
@@ -356,7 +365,8 @@ function onDividerDragEnd(tab: Tab) {
   }
 }
 
-function persist() {
+let persistTimer: ReturnType<typeof setTimeout> | null = null
+function persistNow() {
   const state = tabs.value.map((t) => {
     if (t.type === 'terminal') {
       return {
@@ -369,6 +379,7 @@ function persist() {
         previewAddress: t.previewAddress,
         previewUrl: t.previewUrl,
         previewKind: t.previewKind,
+        customTitle: t.customTitle,
       }
     }
     return {
@@ -381,6 +392,17 @@ function persist() {
   const activeIdx = tabs.value.findIndex((t) => t.paneId === activePaneId.value)
   localStorage.setItem('dinotty_tabs', JSON.stringify({ tabs: state, activeIdx }))
 }
+function persist() {
+  if (persistTimer) clearTimeout(persistTimer)
+  persistTimer = setTimeout(persistNow, 200)
+}
+// Flush pending persist on page unload
+window.addEventListener('beforeunload', () => {
+  if (persistTimer) {
+    clearTimeout(persistTimer)
+    persistNow()
+  }
+})
 
 const DEFAULT_PREVIEW_URL = ''
 
@@ -447,6 +469,11 @@ async function activateTab(tabId: string) {
 
 function reorderTab(fromId: string, toId: string) {
   session.reorderTab(fromId, toId)
+  persist()
+}
+
+function onRenameTab(paneId: string, title: string) {
+  session.renameTab(paneId, title)
   persist()
 }
 

--- a/frontend/src/components/SettingsPanel.vue
+++ b/frontend/src/components/SettingsPanel.vue
@@ -33,7 +33,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, defineAsyncComponent } from 'vue'
 import { useSettings, notifyTextChange } from '../composables/useSettings'
 import { useI18n } from '../composables/useI18n'
 import {
@@ -49,7 +49,7 @@ import {
 import GeneralTab from './settings/GeneralTab.vue'
 import AppearanceTab from './settings/AppearanceTab.vue'
 import KeyboardTab from './settings/KeyboardTab.vue'
-import MonitorTab from './settings/MonitorTab.vue'
+const MonitorTab = defineAsyncComponent(() => import('./settings/MonitorTab.vue'))
 import NotificationTab from './settings/NotificationTab.vue'
 import PluginsTab from './settings/PluginsTab.vue'
 import AboutTab from './settings/AboutTab.vue'

--- a/frontend/src/components/keyboard/MobileKeyboard.vue
+++ b/frontend/src/components/keyboard/MobileKeyboard.vue
@@ -668,27 +668,33 @@ onMounted(() => {
     naturalVH = window.visualViewport.height
     window.visualViewport.addEventListener('resize', onViewportChange)
     window.visualViewport.addEventListener('scroll', onViewportChange)
-    window.addEventListener('orientationchange', () => {
-      setTimeout(() => {
-        naturalVH = window.visualViewport!.height
-      }, 300)
-    })
+    window.addEventListener('orientationchange', onOrientationChange)
   }
 
-  let roAf = 0
   if (barRef.value) {
-    new ResizeObserver(() => {
+    resizeObserver = new ResizeObserver(() => {
       cancelAnimationFrame(roAf)
       roAf = requestAnimationFrame(() => updateHeight())
-    }).observe(barRef.value)
+    })
+    resizeObserver.observe(barRef.value)
   }
 })
+
+let roAf = 0
+let resizeObserver: ResizeObserver | null = null
+function onOrientationChange() {
+  setTimeout(() => {
+    naturalVH = window.visualViewport!.height
+  }, 300)
+}
 
 onBeforeUnmount(() => {
   if (window.visualViewport) {
     window.visualViewport.removeEventListener('resize', onViewportChange)
     window.visualViewport.removeEventListener('scroll', onViewportChange)
   }
+  window.removeEventListener('orientationchange', onOrientationChange)
+  resizeObserver?.disconnect()
   document.documentElement.style.setProperty('--mkb-height', '0px')
 })
 </script>

--- a/frontend/src/components/terminal/StatusBar.vue
+++ b/frontend/src/components/terminal/StatusBar.vue
@@ -30,7 +30,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, defineAsyncComponent } from 'vue'
 import { Cpu, MemoryStick, HardDrive, Wifi, Gpu } from 'lucide-vue-next'
 import { monitorData } from '../../composables/useMonitor'
 import {
@@ -43,7 +43,7 @@ import {
 } from '../../composables/useMonitor'
 import { useSettings } from '../../composables/useSettings'
 import { usePaneWarning } from '../../composables/usePaneWarning'
-import MonitorPopover from './MonitorPopover.vue'
+const MonitorPopover = defineAsyncComponent(() => import('./MonitorPopover.vue'))
 
 const data = monitorData
 const { settings } = useSettings()
@@ -171,8 +171,8 @@ function togglePopover(key: MetricKey, event: MouseEvent) {
 }
 .pane-warning {
   margin-left: auto;
-  font-size: 12px;
-  color: var(--color-yellow, #f59e0b);
+  font-size: 11px;
+  color: var(--fg-muted, rgba(255, 255, 255, 0.6));
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/frontend/src/components/terminal/TabBar.vue
+++ b/frontend/src/components/terminal/TabBar.vue
@@ -12,13 +12,31 @@
         @click="onTabClick($event, tab.paneId)"
         @touchend.prevent="onTabTouchEnd($event, tab.paneId)"
       >
-        <span class="tab-title">{{ tab.title }}</span>
+        <span class="tab-index">{{ tab.index }}</span>
+        <input
+          v-if="editingPaneId === tab.paneId"
+          ref="editInputRef"
+          class="tab-title-input"
+          :value="editValue"
+          @input="editValue = ($event.target as HTMLInputElement).value"
+          @blur="finishEdit(tab.paneId)"
+          @keydown.enter="finishEdit(tab.paneId)"
+          @keydown.escape.stop="cancelEdit"
+          @mousedown.stop
+          @click.stop
+        />
+        <span
+          v-else
+          class="tab-title"
+          @dblclick="startEdit(tab)"
+        >{{ tab.title }}</span>
         <span
           v-if="indicators[tab.paneId]"
           class="tab-notif-dot"
           :class="'dot-' + indicators[tab.paneId]"
         ></span>
         <button
+          v-if="editingPaneId !== tab.paneId"
           class="tab-close"
           @click.stop="$emit('close', tab.paneId)"
           @touchend.stop.prevent="$emit('close', tab.paneId)"
@@ -115,7 +133,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, onBeforeUnmount } from 'vue'
+import { ref, watch, onBeforeUnmount, nextTick } from 'vue'
 import { X, Terminal, Blocks, Columns2, Rows2, Radio } from 'lucide-vue-next'
 import { useI18n } from '../../composables/useI18n'
 import { useKeybindings } from '../../composables/useKeybindings'
@@ -130,6 +148,8 @@ const kbdBroadcast = formatBinding(getBinding('toggleBroadcast')).join('')
 export interface TabInfo {
   paneId: string
   title: string
+  index: number
+  type: 'terminal' | 'plugin'
 }
 
 export interface PluginInfo {
@@ -163,7 +183,52 @@ const emit = defineEmits<{
   action: [type: 'new-tab' | 'split-h' | 'split-v' | 'broadcast']
   reorder: [fromId: string, toId: string]
   'open-plugin': [pluginId: string]
+  rename: [paneId: string, title: string]
 }>()
+
+const editingPaneId = ref<string | null>(null)
+const editValue = ref('')
+const editInputRef = ref<HTMLInputElement | null>(null)
+
+function onDocMouseDown(e: MouseEvent) {
+  const el = e.target as HTMLElement
+  if (!el.closest('.tab-title-input')) {
+    finishEditIfAny()
+  }
+}
+
+function finishEditIfAny() {
+  if (editingPaneId.value != null) {
+    finishEdit(editingPaneId.value)
+  }
+}
+
+function startEdit(tab: TabInfo) {
+  if (tab.type !== 'terminal') return
+  editingPaneId.value = tab.paneId
+  editValue.value = tab.title
+  document.addEventListener('mousedown', onDocMouseDown)
+  nextTick(() => {
+    const input = editInputRef.value
+    if (input) {
+      input.focus()
+      input.select()
+    }
+  })
+}
+
+function finishEdit(paneId: string) {
+  if (editingPaneId.value !== paneId) return
+  const val = editValue.value.trim()
+  editingPaneId.value = null
+  document.removeEventListener('mousedown', onDocMouseDown)
+  if (val) emit('rename', paneId, val)
+}
+
+function cancelEdit() {
+  editingPaneId.value = null
+  document.removeEventListener('mousedown', onDocMouseDown)
+}
 
 const pluginMenuOpen = ref(false)
 const pluginWrapRef = ref<HTMLElement>()
@@ -315,11 +380,33 @@ function cleanup() {
 
 onBeforeUnmount(() => {
   cleanup()
+  document.removeEventListener('mousedown', onDocMouseDown)
   document.removeEventListener('touchstart', onDocTouchStart)
 })
 </script>
 
 <style scoped>
+.tab-index {
+  font-size: 10px;
+  color: var(--text-muted, #888);
+  min-width: 12px;
+  text-align: center;
+  flex-shrink: 0;
+  opacity: 0.7;
+}
+.tab-title-input {
+  background: var(--bg-input, #2a2a2a);
+  border: 1px solid var(--accent, #8a8a8a);
+  border-radius: 3px;
+  color: inherit;
+  font: inherit;
+  font-size: 12px;
+  padding: 0 4px;
+  min-width: 0;
+  width: 100%;
+  max-width: 160px;
+  outline: none;
+}
 .tab {
   cursor: grab;
 }

--- a/frontend/src/composables/useSyncWebSocket.ts
+++ b/frontend/src/composables/useSyncWebSocket.ts
@@ -129,6 +129,7 @@ export function useSyncWebSocket(opts: {
               previewAddress: migrated?.previewAddress ?? '',
               previewUrl: migrated?.previewUrl ?? '',
               previewKind: migrated?.previewKind ?? 'web',
+              customTitle: migrated?.customTitle,
             })
           }
         }

--- a/frontend/src/stores/sessionStore.ts
+++ b/frontend/src/stores/sessionStore.ts
@@ -17,10 +17,14 @@ export const useSessionStore = defineStore('session', () => {
 
   /** Tab list for TabBar component */
   const tabList = computed<TabInfo[]>(() =>
-    tabs.value.map((t) => ({
+    tabs.value.map((t, i) => ({
       paneId: t.paneId,
       title:
-        t.type === 'terminal' ? (findLeaf(t.layout, t.activePaneId)?.title ?? 'Terminal') : t.title,
+        t.type === 'terminal'
+          ? (t.customTitle ?? findLeaf(t.layout, t.activePaneId)?.title ?? 'Terminal')
+          : t.title,
+      index: i + 1,
+      type: t.type,
     }))
   )
 
@@ -109,6 +113,13 @@ export const useSessionStore = defineStore('session', () => {
     tabs.value.splice(toIdx, 0, moved)
   }
 
+  /** Rename a terminal tab's custom title. Pass empty string to clear. */
+  function renameTab(tabId: string, title: string) {
+    const tab = tabs.value.find((t) => t.paneId === tabId)
+    if (!tab || tab.type !== 'terminal') return
+    tab.customTitle = title || undefined
+  }
+
   /** Replace the entire tabs array (used during sync restore) */
   function setTabs(newTabs: Tab[]) {
     tabs.value = newTabs
@@ -134,6 +145,7 @@ export const useSessionStore = defineStore('session', () => {
     findTab,
     getActiveTerminal,
     reorderTab,
+    renameTab,
     setTabs,
   }
 })

--- a/frontend/src/types/pane.ts
+++ b/frontend/src/types/pane.ts
@@ -35,6 +35,7 @@ export interface TerminalTab {
   previewAddress: string
   previewUrl: string
   previewKind: 'web' | 'files'
+  customTitle?: string // User-set tab title (overrides shell title)
 }
 
 /** Plugin tab (unchanged) */

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dinotty-desktop"
-version = "0.12.3"
+version = "0.12.0"
 edition = "2021"
 license = "MIT"
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -78,7 +78,7 @@ fn pty_spawn(
     }
 
     let (session, shell_type) =
-        pty::create_session(&manager, &pane_id, Some(Arc::clone(&exit_cb)))?;
+        pty::create_session(&manager, &pane_id, Some(Arc::clone(&exit_cb)), None)?;
 
     spawn_tauri_output_forwarder(app.clone(), pane_id.clone(), Arc::clone(&session));
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nickelpack/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "Dinotty",
-  "version": "0.12.3",
+  "version": "0.12.0",
   "identifier": "com.dinotty.terminal",
   "build": {
     "frontendDist": "../frontend/dist",


### PR DESCRIPTION
## Summary

- feat(terminal): add tab rename with double-click and persist custom title
  - Inline edit on double-click for terminal tabs
  - Persist customTitle to localStorage with 200ms debounce
  - Sync customTitle via sync WebSocket
  - Optimize active pane watchers to avoid deep watch
  - Lazy-load MonitorTab and MonitorPopover components
  - Clean up ResizeObserver and orientation listeners in MobileKeyboard
  - Roll back version to 0.12.0

## Test plan

- [ ] Double-click a terminal tab to rename, verify title persists after refresh
- [ ] Verify rename syncs across multiple browser tabs via sync WebSocket
- [ ] Check Monitor popover still loads correctly (lazy-load)
- [ ] Test on mobile: keyboard open/close, orientation change
- [ ] Verify tab index numbers display correctly