### PR TITLE
fix: failed to load manifest for workspace member `/app/src-tauri`

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -37,6 +37,7 @@ RUN mkdir -p src && \
 
 # 复制实际源码和前端产物
 COPY src/ src/
+COPY src-tauri/ src-tauri/ 
 COPY build.rs ./
 COPY --from=frontend /app/frontend/dist/ frontend/dist/
 


### PR DESCRIPTION
## Summary

- fix: failed to load manifest for workspace member `/app/src-tauri` 

## Changes

- Add a COPY for the src-tauri/ directory before the final cargo build command in the builder stage.

## Test Plan

- [x] Tested locally
- [x] Frontend type-check passes (`npx vue-tsc --noEmit`)
- [x] No regressions on desktop browser
- [x] No regressions on mobile browser (if applicable)
