### PR TITLE
release: v0.13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "dinotty-desktop"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
@@ -1142,7 +1142,7 @@ dependencies = [
 
 [[package]]
 name = "dinotty-server"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "axum 0.7.9",
  "axum-extra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["src-tauri"]
 
 [package]
 name = "dinotty-server"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 license = "MIT"
 build = "build.rs"

--- a/frontend/src/components/command/CommandBookmarks.vue
+++ b/frontend/src/components/command/CommandBookmarks.vue
@@ -10,6 +10,7 @@
               v-model="searchQuery"
               :placeholder="t('bookmarks.search')"
               class="bookmarks-search-input"
+              @keydown="onSearchKeydown"
             />
           </div>
           <div class="bookmarks-header-actions">
@@ -79,6 +80,7 @@
               'drag-over-top': dropTarget === bm.id && dropPos === 'top',
               'drag-over-bottom': dropTarget === bm.id && dropPos === 'bottom',
               dragging: dragId === bm.id,
+              selected: i === selectedIndex,
             }"
             :draggable="editId !== bm.id"
             @dragstart="onDragStart($event, bm.id)"
@@ -145,7 +147,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, nextTick } from 'vue'
+import { ref, computed, nextTick, watch } from 'vue'
 import { Plus, X, Check, GripVertical, Search, Pencil } from 'lucide-vue-next'
 import { useSettings } from '../../composables/useSettings'
 import { randomId } from '../../utils/id'
@@ -166,6 +168,7 @@ const nameInputRef = ref<HTMLInputElement>()
 const commandInputRef = ref<HTMLInputElement>()
 const searchInputRef = ref<HTMLInputElement>()
 const searchQuery = ref('')
+const selectedIndex = ref(-1)
 
 // Edit state
 const editId = ref<string | null>(null)
@@ -205,11 +208,44 @@ const filteredBookmarks = computed(() => {
   return list
 })
 
+watch(searchQuery, () => { selectedIndex.value = -1 })
+
+const isTouchDevice = window.matchMedia('(hover: none) and (pointer: coarse)').matches
+
+function onSearchKeydown(e: KeyboardEvent) {
+  const list = filteredBookmarks.value
+  if (!list.length) return
+  if (e.key === 'ArrowDown') {
+    e.preventDefault()
+    selectedIndex.value = selectedIndex.value < list.length - 1 ? selectedIndex.value + 1 : 0
+    scrollToSelected()
+  } else if (e.key === 'ArrowUp') {
+    e.preventDefault()
+    selectedIndex.value = selectedIndex.value > 0 ? selectedIndex.value - 1 : list.length - 1
+    scrollToSelected()
+  } else if (e.key === 'Enter') {
+    e.preventDefault()
+    if (selectedIndex.value >= 0 && selectedIndex.value < list.length) {
+      sendBookmark(list[selectedIndex.value])
+    }
+  }
+}
+
+function scrollToSelected() {
+  nextTick(() => {
+    const el = document.querySelector('.bookmark-item.selected')
+    el?.scrollIntoView({ block: 'nearest' })
+  })
+}
+
 function open() {
   visible.value = true
   addMode.value = false
   searchQuery.value = ''
-  nextTick(() => searchInputRef.value?.focus())
+  selectedIndex.value = -1
+  if (!isTouchDevice) {
+    nextTick(() => searchInputRef.value?.focus())
+  }
 }
 function close() {
   visible.value = false
@@ -220,7 +256,9 @@ function toggleAddMode() {
   addMode.value = !addMode.value
   if (addMode.value) {
     editId.value = null
-    nextTick(() => nameInputRef.value?.focus())
+    if (!isTouchDevice) {
+      nextTick(() => nameInputRef.value?.focus())
+    }
   }
 }
 
@@ -267,7 +305,9 @@ function startEdit(bm: { id: string; name: string; command: string; group: strin
   editCommand.value = bm.command
   editGroup.value = bm.group || ''
   addMode.value = false
-  nextTick(() => editNameInputRef.value?.focus())
+  if (!isTouchDevice) {
+    nextTick(() => editNameInputRef.value?.focus())
+  }
 }
 
 function saveEdit() {
@@ -455,8 +495,13 @@ defineExpose({ open, close })
   border: 1px solid transparent;
   transition: border-color 0.1s;
 }
-.bookmark-item:hover {
+.bookmark-item:hover,
+.bookmark-item.selected {
   background: rgba(255, 255, 255, 0.05);
+}
+.bookmark-item.selected {
+  outline: 1px solid var(--accent, #007acc);
+  outline-offset: -1px;
 }
 .bookmark-item.dragging {
   opacity: 0.4;
@@ -514,7 +559,8 @@ defineExpose({ open, close })
   opacity: 0;
   cursor: pointer;
 }
-.bookmark-item:hover .bookmark-del {
+.bookmark-item:hover .bookmark-del,
+.bookmark-item.selected .bookmark-del {
   opacity: 1;
 }
 .bookmark-del:hover {
@@ -535,7 +581,8 @@ defineExpose({ open, close })
   opacity: 0;
   cursor: pointer;
 }
-.bookmark-item:hover .bookmark-edit {
+.bookmark-item:hover .bookmark-edit,
+.bookmark-item.selected .bookmark-edit {
   opacity: 1;
 }
 .bookmark-edit:hover {

--- a/frontend/src/components/command/CommandPalette.vue
+++ b/frontend/src/components/command/CommandPalette.vue
@@ -80,10 +80,14 @@ watch(query, () => {
   selected.value = 0
 })
 
+const isTouchDevice = window.matchMedia('(hover: none) and (pointer: coarse)').matches
+
 function open() {
   isOpen.value = true
   query.value = ''
-  nextTick(() => inputRef.value?.focus())
+  if (!isTouchDevice) {
+    nextTick(() => inputRef.value?.focus())
+  }
 }
 
 function close() {
@@ -99,7 +103,9 @@ function openWithItems(items: Command[]) {
   overrideItems.value = items
   isOpen.value = true
   query.value = ''
-  nextTick(() => inputRef.value?.focus())
+  if (!isTouchDevice) {
+    nextTick(() => inputRef.value?.focus())
+  }
 }
 
 function onKey(e: KeyboardEvent) {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dinotty-desktop"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 license = "MIT"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nickelpack/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "Dinotty",
-"version": "0.13.0",
+"version": "0.13.1",
   "identifier": "com.dinotty.terminal",
   "build": {
     "frontendDist": "../frontend/dist",


### PR DESCRIPTION
## Summary

- feat(frontend): keyboard navigation for command bookmarks
  - Arrow keys to select, Enter to send selected bookmark
  - Skip auto-focus on touch devices to avoid system keyboard popup
- chore: bump version to 0.13.1

## Test plan

- [ ] Desktop: open command bookmarks, use ArrowUp/Down to navigate, Enter to send
- [ ] Desktop: search filters bookmarks, keyboard selection resets on query change
- [ ] Mobile/touch: open command bookmarks, no system keyboard popup
- [ ] Mobile/touch: command palette opens without system keyboard popup
- [ ] Version displays as 0.13.1 in app