### PR TITLE
fix(frontend): 修复 split pane 后焦点丢失问题

### DIFF
--- a/frontend/src/components/terminal/TerminalPane.vue
+++ b/frontend/src/components/terminal/TerminalPane.vue
@@ -63,6 +63,7 @@ const emit = defineEmits<{
 
 const wrapperRef = ref<HTMLElement>()
 let terminal: TerminalInstance | null = null
+let pendingFocus = false
 const searchVisible = ref(false)
 
 // Context menu state
@@ -97,10 +98,16 @@ function getTerminal() {
 }
 
 function focus() {
-  terminal?.focus()
+  if (terminal?.xterm) {
+    pendingFocus = false
+    terminal.focus()
+    return
+  }
+  pendingFocus = true
 }
 
 function blur() {
+  pendingFocus = false
   terminal?.blur()
 }
 
@@ -504,6 +511,10 @@ onMounted(() => {
   requestAnimationFrame(() => {
     if (wrapperRef.value) {
       terminal!.attach(wrapperRef.value)
+      if (pendingFocus) {
+        pendingFocus = false
+        terminal!.focus()
+      }
     }
   })
 })

--- a/frontend/src/composables/useTerminal.ts
+++ b/frontend/src/composables/useTerminal.ts
@@ -390,7 +390,8 @@ export class TerminalInstance {
   }
 
   focus() {
-    this.xterm?.focus()
+    if (!this.xterm) return
+    this.xterm.focus()
   }
 
   blur() {


### PR DESCRIPTION
## 问题

   Command+D 分割 pane 后，新 pane 无法直接输入文字。

   ## 原因

   `splitPane()` 在 `nextTick` 中调用 `focus()`，但 `onMounted` 中 xterm 的 `attach()` 是在 `requestAnimationFrame` 中执行的。微任务优先于渲染帧，导致 `focus()` 被调用时 `xterm` 还是 null，`?.focus()` 静默跳过，焦点丢失。

   ## 修复

   在 `TerminalPane.vue` 中添加 `pendingFocus` 机制：
   - `focus()` 调用时若 `xterm` 未就绪，设置 `pendingFocus = true`
   - `requestAnimationFrame` 中 `attach()` 完成后检查标志并执行真正的 `focus()`
   - `blur()` 时清除标志，避免过时的 focus

   ## 测试

   1. Command+D 分割 pane
   2. 直接输入文字，新 pane 应能正常接收输入