### PR TITLE
fix(pty): 修复 macOS 打包应用中文输入乱码

### DIFF
--- a/src/pty.rs
+++ b/src/pty.rs
@@ -32,6 +32,7 @@ pub fn create_session(
     let mut cmd = CommandBuilder::new(&shell);
     cmd.args(get_shell_args(&shell));
     cmd.env("TERM", "xterm-256color");
+    configure_utf8_locale(&mut cmd);
 
     let home_path = std::env::var("HOME").map_or_else(
         |_| std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/")),
@@ -237,6 +238,71 @@ fi
     Some(zdotdir)
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum LocaleAdjustment {
+    Preserve,
+    SetCtype,
+    RemoveAllAndSetCtype,
+}
+
+fn is_utf8_locale(value: &str) -> bool {
+    let normalized = value.trim().to_ascii_uppercase();
+    normalized.contains("UTF-8") || normalized.contains("UTF8")
+}
+
+fn is_default_locale(value: &str) -> bool {
+    matches!(value.trim().to_ascii_uppercase().as_str(), "" | "C" | "POSIX")
+}
+
+fn locale_adjustment(
+    lc_all: Option<&str>,
+    lc_ctype: Option<&str>,
+    lang: Option<&str>,
+) -> LocaleAdjustment {
+    if let Some(value) = lc_all.filter(|value| !value.trim().is_empty()) {
+        if is_utf8_locale(value) {
+            return LocaleAdjustment::Preserve;
+        }
+        return if is_default_locale(value) {
+            LocaleAdjustment::RemoveAllAndSetCtype
+        } else {
+            LocaleAdjustment::Preserve
+        };
+    }
+
+    if let Some(value) = lc_ctype.filter(|value| !value.trim().is_empty()) {
+        if is_utf8_locale(value) {
+            return LocaleAdjustment::Preserve;
+        }
+        return if is_default_locale(value) {
+            LocaleAdjustment::SetCtype
+        } else {
+            LocaleAdjustment::Preserve
+        };
+    }
+
+    match lang {
+        Some(value) if is_utf8_locale(value) => LocaleAdjustment::Preserve,
+        Some(value) if !is_default_locale(value) => LocaleAdjustment::Preserve,
+        _ => LocaleAdjustment::SetCtype,
+    }
+}
+
+fn configure_utf8_locale(cmd: &mut CommandBuilder) {
+    let lc_all = std::env::var("LC_ALL").ok();
+    let lc_ctype = std::env::var("LC_CTYPE").ok();
+    let lang = std::env::var("LANG").ok();
+
+    match locale_adjustment(lc_all.as_deref(), lc_ctype.as_deref(), lang.as_deref()) {
+        LocaleAdjustment::Preserve => {}
+        LocaleAdjustment::SetCtype => cmd.env("LC_CTYPE", "C.UTF-8"),
+        LocaleAdjustment::RemoveAllAndSetCtype => {
+            cmd.env_remove("LC_ALL");
+            cmd.env("LC_CTYPE", "C.UTF-8");
+        }
+    }
+}
+
 #[must_use]
 pub fn get_shell() -> String {
     // Non-interactive shells that should be skipped
@@ -279,5 +345,52 @@ pub fn get_shell_args(shell: &str) -> Vec<&'static str> {
         vec!["-i", "-l"]
     } else {
         vec!["-i"]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{locale_adjustment, LocaleAdjustment};
+
+    #[test]
+    fn locale_defaults_to_utf8_ctype_when_environment_is_missing() {
+        assert_eq!(locale_adjustment(None, None, None), LocaleAdjustment::SetCtype);
+    }
+
+    #[test]
+    fn locale_fixes_applications_launch_environment() {
+        assert_eq!(locale_adjustment(Some(""), Some("C"), Some("")), LocaleAdjustment::SetCtype);
+    }
+
+    #[test]
+    fn locale_removes_c_lc_all_override() {
+        assert_eq!(
+            locale_adjustment(Some("POSIX"), Some("C.UTF-8"), Some("")),
+            LocaleAdjustment::RemoveAllAndSetCtype
+        );
+    }
+
+    #[test]
+    fn locale_preserves_existing_utf8_environment() {
+        assert_eq!(
+            locale_adjustment(None, Some("zh_CN.UTF-8"), Some("C")),
+            LocaleAdjustment::Preserve
+        );
+        assert_eq!(
+            locale_adjustment(Some("C.UTF8"), Some("C"), Some("C")),
+            LocaleAdjustment::Preserve
+        );
+    }
+
+    #[test]
+    fn locale_preserves_explicit_non_utf8_environment() {
+        assert_eq!(
+            locale_adjustment(None, Some("zh_CN.GB2312"), Some("")),
+            LocaleAdjustment::Preserve
+        );
+        assert_eq!(
+            locale_adjustment(Some("en_US.ISO8859-1"), Some("C"), Some("")),
+            LocaleAdjustment::Preserve
+        );
     }
 }


### PR DESCRIPTION
## 问题描述

  通过 `cargo tauri dev` 启动时，终端可以正常输入中文；但从 macOS
  Applications 启动打包后的应用时，xterm.js 中的中文输入会显示为乱码。

  此时 PTY 内的 locale 为：

  ```text
  LANG=""
  LC_CTYPE="C"
  LC_ALL=
 ```

  输入的 UTF-8 字节实际没有损坏，因此命令执行后的 zsh 错误信息仍能正确显示
  中文。乱码发生在 zsh ZLE 的输入回显阶段，根因是 PTY 子进程使用了非 UTF-8
  locale。

  ## 修复内容

  - 创建 PTY 时检查 LC_ALL、LC_CTYPE 和 LANG
  - 环境缺失或为 C/POSIX 时，将 LC_CTYPE 设置为 C.UTF-8
  - LC_ALL=C/POSIX 覆盖字符编码设置时，仅对 PTY 子进程移除该覆盖
  - 保留用户已配置的 UTF-8 或其他明确 locale
  - 不修改 xterm.js IME 输入逻辑

  ## 测试

  新增测试覆盖：

  - locale 环境完全缺失
  - macOS Applications 启动时的空 LANG、LC_CTYPE=C
  - LC_ALL=C/POSIX 覆盖
  - 已有 UTF-8 locale
  - 用户明确配置的非 UTF-8 locale

  验证结果：

  - 131 个 Rust 库测试全部通过
  - cargo fmt --check 通过
  - 库目标 Clippy 检查通过


  源分支：`YuJ1Nan:fix/cantTypeChinese`
  目标分支：`xichan96:dev`