### PR TITLE
chore: bump version to 0.14.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "dinotty-desktop"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
@@ -1142,7 +1142,7 @@ dependencies = [
 
 [[package]]
 name = "dinotty-server"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "axum 0.7.9",
  "axum-extra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["src-tauri"]
 
 [package]
 name = "dinotty-server"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 license = "MIT"
 build = "build.rs"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dinotty-desktop"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 license = "MIT"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nickelpack/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "Dinotty",
-"version": "0.14.0",
+"version": "0.14.1",
   "identifier": "com.dinotty.terminal",
   "build": {
     "frontendDist": "../frontend/dist",


### PR DESCRIPTION
## Summary
- Bump version from 0.14.0 to 0.14.1 in Cargo.toml, src-tauri/Cargo.toml, and tauri.conf.json

## Test plan
- [ ] Verify `cargo build` succeeds with new version
- [ ] Verify Tauri desktop app builds with updated version