### PR TITLE
fix(terminal): fix mobile touch scrolling for TUI apps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "dinotty-desktop"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
@@ -1142,7 +1142,7 @@ dependencies = [
 
 [[package]]
 name = "dinotty-server"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "axum 0.7.9",
  "axum-extra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["src-tauri"]
 
 [package]
 name = "dinotty-server"
-version = "0.14.3"
+version = "0.14.4"
 edition = "2021"
 license = "MIT"
 build = "build.rs"

--- a/frontend/src/composables/useTerminal.ts
+++ b/frontend/src/composables/useTerminal.ts
@@ -1018,173 +1018,152 @@ export class TerminalInstance {
   }
 
   private _setupTouchScroll(wrapper: HTMLElement) {
-    const attachHandlers = (viewport: HTMLElement) => {
-      // Prevent native browser scroll on the viewport from conflicting with our
-      // custom touch-to-wheel translation.
-      wrapper.style.touchAction = 'none'
+    // Prevent native browser scroll on the wrapper from conflicting with our
+    // custom touch-to-wheel translation.
+    wrapper.style.touchAction = 'none'
 
-      let startX = 0
-      let startY = 0
-      let lastY = 0
-      let lastTime = 0
-      let accumulatedDeltaY = 0
-      let velocity = 0
-      let momentumId = 0
-      let mode: 'undecided' | 'scroll' | 'select' = 'undecided'
-      let scrollEventFired = false
-      const THRESHOLD = 10
-      const SCROLL_THRESHOLD = 12 // Lower threshold for more responsive feel
+    let startX = 0
+    let startY = 0
+    let lastY = 0
+    let lastTime = 0
+    let accumulatedDeltaY = 0
+    let velocity = 0
+    let momentumId = 0
+    let mode: 'undecided' | 'scroll' | 'select' = 'undecided'
+    let scrollEventFired = false
+    const THRESHOLD = 10
+    const SCROLL_THRESHOLD = 12 // Lower threshold for more responsive feel
 
-      const clearMomentum = () => {
-        if (momentumId) {
-          cancelAnimationFrame(momentumId)
-          momentumId = 0
-        }
-      }
-
-      const onTouchStart = (e: TouchEvent) => {
-        clearMomentum()
-        this.touchMoved = false
-        scrollEventFired = false
-        startX = e.touches[0].clientX
-        startY = e.touches[0].clientY
-        lastY = startY
-        lastTime = Date.now()
-        accumulatedDeltaY = 0
-        velocity = 0
-        mode = 'undecided'
-      }
-      const onTouchMove = (e: TouchEvent) => {
-        if (this.inTouchSelection) return
-        const cx = e.touches[0].clientX
-        const cy = e.touches[0].clientY
-        const now = Date.now()
-        if (mode === 'undecided') {
-          const dx = Math.abs(cx - startX)
-          const dy = Math.abs(cy - startY)
-          if (dy > THRESHOLD || dx > THRESHOLD) {
-            mode = dy > dx ? 'scroll' : 'select'
-            if (mode === 'scroll') this.touchMoved = true
-          } else {
-            return
-          }
-        }
-        if (mode === 'scroll') {
-          e.preventDefault() // suppress native scroll — safe because passive: false
-          // Fire terminal-scroll on first scroll movement to collapse virtual keyboard
-          if (!scrollEventFired) {
-            scrollEventFired = true
-            viewport.dispatchEvent(new CustomEvent('terminal-scroll', { bubbles: true }))
-          }
-          const deltaY = lastY - cy
-          const dt = now - lastTime || 1
-          velocity = deltaY / dt // px/ms
-          accumulatedDeltaY += deltaY
-
-          if (this.xterm && Math.abs(accumulatedDeltaY) >= SCROLL_THRESHOLD) {
-            this._sendWheelEvent(viewport, accumulatedDeltaY, cx, cy)
-            accumulatedDeltaY = 0
-          }
-        }
-        lastY = cy
-        lastTime = now
-      }
-
-      const onTouchEnd = () => {
-        if (mode !== 'scroll') return
-        // Flush remaining delta
-        if (this.xterm && Math.abs(accumulatedDeltaY) > 2) {
-          this._sendWheelEvent(viewport, accumulatedDeltaY, lastY, lastY)
-        }
-        accumulatedDeltaY = 0
-
-        // Momentum: keep sending wheel events with decaying velocity
-        if (this.xterm && Math.abs(velocity) > 0.15) {
-          const friction = 0.92
-          let v = velocity
-          const step = () => {
-            v *= friction
-            if (Math.abs(v) < 0.05) return
-            const delta = v * 16 // ~1 frame at 60fps
-            this._sendWheelEvent(viewport, delta, lastY, lastY)
-            momentumId = requestAnimationFrame(step)
-          }
-          momentumId = requestAnimationFrame(step)
-        }
-
-        // Notify that a scroll gesture ended — used to dismiss the virtual keyboard.
-        // Dispatch on viewport so it bubbles through xterm's DOM to #tab-content.
-        viewport.dispatchEvent(new CustomEvent('terminal-scroll', { bubbles: true }))
-      }
-
-      // Attach directly to the viewport (.xterm-viewport) — this intercepts
-      // touch events before iOS Safari's native scroll handler on the
-      // overflow-y:scroll element can consume them.
-      viewport.addEventListener('touchstart', onTouchStart, { passive: true })
-      viewport.addEventListener('touchmove', onTouchMove, { passive: false })
-      viewport.addEventListener('touchend', onTouchEnd, { passive: true })
-      // Wheel listener: collapse virtual keyboard on trackpad/mouse scroll
-      const onWheel = () => {
-        viewport.dispatchEvent(new CustomEvent('terminal-scroll', { bubbles: true }))
-      }
-      viewport.addEventListener('wheel', onWheel, { passive: true })
-      this._touchCleanup = () => {
-        clearMomentum()
-        viewport.removeEventListener('touchstart', onTouchStart)
-        viewport.removeEventListener('touchmove', onTouchMove)
-        viewport.removeEventListener('touchend', onTouchEnd)
-        viewport.removeEventListener('wheel', onWheel)
+    const clearMomentum = () => {
+      if (momentumId) {
+        cancelAnimationFrame(momentumId)
+        momentumId = 0
       }
     }
 
-    // Retry until xterm renders its DOM — single rAF is unreliable on slower
-    // devices / Safari where the renderer may need an extra frame.
-    let retries = 0
-    const tryAttach = () => {
-      requestAnimationFrame(() => {
-        const viewport = wrapper.querySelector('.xterm-viewport') as HTMLElement | null
-        if (viewport) {
-          attachHandlers(viewport)
+    const onTouchStart = (e: TouchEvent) => {
+      clearMomentum()
+      this.touchMoved = false
+      scrollEventFired = false
+      startX = e.touches[0].clientX
+      startY = e.touches[0].clientY
+      lastY = startY
+      lastTime = Date.now()
+      accumulatedDeltaY = 0
+      velocity = 0
+      mode = 'undecided'
+    }
+    const onTouchMove = (e: TouchEvent) => {
+      if (this.inTouchSelection) return
+      const cx = e.touches[0].clientX
+      const cy = e.touches[0].clientY
+      const now = Date.now()
+      if (mode === 'undecided') {
+        const dx = Math.abs(cx - startX)
+        const dy = Math.abs(cy - startY)
+        if (dy > THRESHOLD || dx > THRESHOLD) {
+          mode = dy > dx ? 'scroll' : 'select'
+          if (mode === 'scroll') this.touchMoved = true
+        } else {
           return
         }
-        if (++retries < 30) tryAttach() // ~500ms at 60fps, then give up
-      })
+      }
+      if (mode === 'scroll') {
+        e.preventDefault() // suppress native scroll — safe because passive: false
+        // Fire terminal-scroll on first scroll movement to collapse virtual keyboard
+        if (!scrollEventFired) {
+          scrollEventFired = true
+          wrapper.dispatchEvent(new CustomEvent('terminal-scroll', { bubbles: true }))
+        }
+        const deltaY = lastY - cy
+        const dt = now - lastTime || 1
+        velocity = deltaY / dt // px/ms
+        accumulatedDeltaY += deltaY
+
+        if (this.xterm && Math.abs(accumulatedDeltaY) >= SCROLL_THRESHOLD) {
+          this._sendWheelEvent(wrapper, accumulatedDeltaY, cx, cy)
+          accumulatedDeltaY = 0
+        }
+      }
+      lastY = cy
+      lastTime = now
     }
-    tryAttach()
+
+    const onTouchEnd = () => {
+      if (mode !== 'scroll') return
+      // Flush remaining delta
+      if (this.xterm && Math.abs(accumulatedDeltaY) > 2) {
+        this._sendWheelEvent(wrapper, accumulatedDeltaY, lastY, lastY)
+      }
+      accumulatedDeltaY = 0
+
+      // Momentum: keep sending wheel events with decaying velocity
+      if (this.xterm && Math.abs(velocity) > 0.15) {
+        const friction = 0.92
+        let v = velocity
+        const step = () => {
+          v *= friction
+          if (Math.abs(v) < 0.05) return
+          const delta = v * 16 // ~1 frame at 60fps
+          this._sendWheelEvent(wrapper, delta, lastY, lastY)
+          momentumId = requestAnimationFrame(step)
+        }
+        momentumId = requestAnimationFrame(step)
+      }
+
+      // Notify that a scroll gesture ended — used to dismiss the virtual keyboard.
+      wrapper.dispatchEvent(new CustomEvent('terminal-scroll', { bubbles: true }))
+    }
+
+    // Attach to the wrapper element, NOT .xterm-viewport. The xterm.js canvas
+    // (.xterm-screen) sits on top of .xterm-viewport in the DOM and intercepts
+    // all touch events — handlers on the viewport never fire. The wrapper
+    // receives touch events first (before the canvas) and already has
+    // touch-action: none set.
+    wrapper.addEventListener('touchstart', onTouchStart, { passive: true })
+    wrapper.addEventListener('touchmove', onTouchMove, { passive: false })
+    wrapper.addEventListener('touchend', onTouchEnd, { passive: true })
+    // Wheel listener: collapse virtual keyboard on trackpad/mouse scroll
+    const onWheel = () => {
+      wrapper.dispatchEvent(new CustomEvent('terminal-scroll', { bubbles: true }))
+    }
+    wrapper.addEventListener('wheel', onWheel, { passive: true })
+    this._touchCleanup = () => {
+      clearMomentum()
+      wrapper.removeEventListener('touchstart', onTouchStart)
+      wrapper.removeEventListener('touchmove', onTouchMove)
+      wrapper.removeEventListener('touchend', onTouchEnd)
+      wrapper.removeEventListener('wheel', onWheel)
+    }
   }
 
   private _sendWheelEvent(_target: HTMLElement, deltaY: number, clientX: number, clientY: number) {
     if (!this.xterm || deltaY === 0) return
 
-    if (this.isMouseModeEnabled()) {
-      // App has mouse tracking active (e.g. Codex, Claude Code TUI):
-      // let xterm convert the wheel event into escape sequences for the app.
-      // Do NOT call scrollLines() — that shifts xterm's viewport into the main-screen
-      // scrollback while the app is rendering on the alternate screen, causing a
-      // garbled display when both effects are applied simultaneously.
-      // Dispatch on the xterm element so the event reaches xterm's internal listeners.
-      const xtermEl = this.xterm.element
-      if (xtermEl) {
-        xtermEl.dispatchEvent(
-          new WheelEvent('wheel', {
-            deltaY,
-            deltaX: 0,
-            deltaZ: 0,
-            deltaMode: 0,
-            bubbles: true,
-            cancelable: true,
-            clientX,
-            clientY,
-          })
-        )
-      }
-    } else {
-      // No mouse tracking: scroll xterm's viewport directly (normal shell / less / man).
-      const el = this.xterm.element
-      const lineHeight =
-        this.xterm.rows && el?.clientHeight ? el.clientHeight / this.xterm.rows : 20
-      const lines = Math.round(deltaY / lineHeight)
-      if (lines !== 0) this.xterm.scrollLines(lines)
+    // Always dispatch a synthetic WheelEvent on the xterm element and let xterm.js
+    // handle it through its own event pipeline. This matches how real desktop wheel
+    // events are processed:
+    //   - Mouse tracking active: xterm.js sends mouse report escape sequences to PTY
+    //   - No scrollback (alt screen): xterm.js converts to Up/Down arrow sequences
+    //   - Normal shell with scrollback: xterm.js scrolls the viewport
+    // Previously the no-mouse-tracking path called scrollLines() directly, which only
+    // moves xterm's internal viewport — it never sends data to the PTY. On the alt
+    // screen (no scrollback) this was a no-op, so TUI apps like opencode never
+    // received scroll input on mobile.
+    const xtermEl = this.xterm.element
+    if (xtermEl) {
+      xtermEl.dispatchEvent(
+        new WheelEvent('wheel', {
+          deltaY,
+          deltaX: 0,
+          deltaZ: 0,
+          deltaMode: 0,
+          bubbles: true,
+          cancelable: true,
+          clientX,
+          clientY,
+        })
+      )
     }
   }
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dinotty-desktop"
-version = "0.14.3"
+version = "0.14.4"
 edition = "2021"
 license = "MIT"
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -30,16 +30,68 @@ fn spawn_tauri_output_forwarder(
     session: Arc<dinotty_server::session::Session>,
 ) {
     let mut rx = session.add_client();
-    let app2 = app.clone();
-    let pid = pane_id.clone();
+    // Use a dedicated OS thread instead of tokio async task.
+    // app.emit() may block when the WKWebView IPC queue is full — if this
+    // happened on a tokio worker thread it would freeze the entire runtime,
+    // killing all terminals and the embedded Axum server.
+    std::thread::Builder::new()
+        .name(format!("fwd-{}", pane_id))
+        .spawn(move || {
+            while let Some(first) = rx.blocking_recv() {
+                let mut batch = first;
+                while let Ok(data) = rx.try_recv() {
+                    batch.push_str(&data);
+                }
+                if app
+                    .emit("pty-output", PtyOutput { pane_id: pane_id.clone(), data: batch })
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        })
+        .ok();
+}
+
+/// Spawn a dedicated write task for the session that reads from the input channel
+/// and writes to the PTY. This avoids the thread-leak problem where each `pty_write`
+/// command spawned a `spawn_blocking` with a timeout — if `write_all` blocked (PTY
+/// input buffer full), the timeout fired but the thread was never reclaimed.
+fn spawn_tauri_write_task(session: Arc<dinotty_server::session::Session>, pane_id: String) {
+    let mut input_rx = session.replace_input_channel();
+    let write_session = Arc::clone(&session);
+    let write_pane = pane_id.clone();
     tauri::async_runtime::spawn(async move {
-        while let Some(first) = rx.recv().await {
+        while let Some(first) = input_rx.recv().await {
+            if write_session.is_exited() {
+                break;
+            }
+            // Batch: drain all pending messages to minimize lock acquisitions
             let mut batch = first;
-            while let Ok(data) = rx.try_recv() {
+            while let Ok(data) = input_rx.try_recv() {
                 batch.push_str(&data);
             }
-            let _ = app2.emit("pty-output", PtyOutput { pane_id: pid.clone(), data: batch });
+            let ws = Arc::clone(&write_session);
+            let batch_len = batch.len();
+            match tokio::task::spawn_blocking(move || {
+                use std::io::Write;
+                let mut w = ws.writer.lock().unwrap_or_else(|e| e.into_inner());
+                w.write_all(batch.as_bytes())
+            })
+            .await
+            {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    tracing::error!("PTY write error ({}B): {}, pane={}", batch_len, e, write_pane);
+                    break;
+                }
+                Err(e) => {
+                    tracing::error!("PTY write task panic: {}, pane={}", e, write_pane);
+                    break;
+                }
+            }
         }
+        tracing::info!("PTY write task exited, pane={}", write_pane);
     });
 }
 
@@ -81,6 +133,8 @@ fn pty_spawn(
         session.clear_clients();
         emit_join_sync(&app, &pane_id, &session);
         spawn_tauri_output_forwarder(app.clone(), pane_id.clone(), Arc::clone(&session));
+        // Set up channel-based write task (replaces old input channel, if any)
+        spawn_tauri_write_task(Arc::clone(&session), pane_id.clone());
         return Ok(session.shell_type.clone());
     }
 
@@ -88,6 +142,7 @@ fn pty_spawn(
         pty::create_session(&manager, &pane_id, Some(Arc::clone(&exit_cb)), None)?;
 
     spawn_tauri_output_forwarder(app.clone(), pane_id.clone(), Arc::clone(&session));
+    spawn_tauri_write_task(Arc::clone(&session), pane_id.clone());
 
     Ok(shell_type)
 }
@@ -102,16 +157,15 @@ async fn pty_write(
     if session.is_exited() {
         return Err("session exited".into());
     }
-    let result = tokio::task::spawn_blocking(move || {
-        use std::io::Write;
-        let mut w = session.writer.lock().unwrap_or_else(|e| e.into_inner());
-        w.write_all(data.as_bytes())
-    });
-    match tokio::time::timeout(std::time::Duration::from_secs(5), result).await {
-        Ok(Ok(Ok(()))) => Ok(()),
-        Ok(Ok(Err(e))) => Err(e.to_string()),
-        Ok(Err(e)) => Err(format!("task join error: {e}")),
-        Err(_) => Err("write timeout".into()),
+    // Send through the input channel — the dedicated write task handles the actual
+    // PTY write. This avoids the old pattern of spawn_blocking + timeout which leaked
+    // a thread per call when write_all blocked (PTY input buffer full).
+    let tx = session.input_tx.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(tx) = tx.as_ref() {
+        tx.send(data).map_err(|_| "input channel closed".to_string())?;
+        Ok(())
+    } else {
+        Err("input channel not initialized".to_string())
     }
 }
 
@@ -124,7 +178,10 @@ fn pty_resize(
 ) -> Result<(), String> {
     let sessions = &state.sessions;
     let session = sessions.get(&pane_id).ok_or("session not found")?;
-    session.resize(cols, rows)
+    // Use debounced resize to coalesce rapid resize events (e.g. window drag)
+    // and avoid blocking the Tauri command thread on the screen mutex.
+    session.resize_debounced(cols, rows);
+    Ok(())
 }
 
 #[tauri::command]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nickelpack/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "Dinotty",
-"version": "0.14.3",
+"version": "0.14.4",
   "identifier": "com.dinotty.terminal",
   "build": {
     "frontendDist": "../frontend/dist",

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -72,6 +72,7 @@ pub fn create_session(
 
     let initial_cwd = home_for_cwd.canonicalize().unwrap_or_else(|_| home_for_cwd.clone());
     let (resize_tx, resize_rx) = tokio::sync::watch::channel(None);
+    let (output_tx, output_rx) = tokio::sync::mpsc::unbounded_channel();
 
     let session = Arc::new(Session {
         writer: std::sync::Mutex::new(writer),
@@ -93,10 +94,15 @@ pub fn create_session(
         sync_buffer: std::sync::Mutex::new(Vec::new()),
         sync_buffer_bytes: std::sync::atomic::AtomicUsize::new(0),
         resize_tx,
+        output_tx,
+        output_rx: std::sync::Mutex::new(Some(output_rx)),
+        pending_results: std::sync::Mutex::new(Vec::new()),
     });
     manager.sessions.insert(pane_id.to_string(), Arc::clone(&session));
 
-    // Spawn resize debounce task: waits 25ms after last change, then applies
+    // Spawn resize debounce task: waits 25ms after last change, then applies.
+    // The actual resize runs in spawn_blocking to avoid blocking the tokio worker
+    // thread when the screen mutex is held by the PTY reader's feed() call.
     {
         let session_weak = Arc::downgrade(&session);
         tokio::spawn(async move {
@@ -109,7 +115,10 @@ pub fn create_session(
                 let size = *rx.borrow_and_update();
                 if let Some((cols, rows)) = size {
                     if let Some(session) = session_weak.upgrade() {
-                        let _ = session.resize(cols, rows);
+                        let _ = tokio::task::spawn_blocking(move || {
+                            let _ = session.resize(cols, rows);
+                        })
+                        .await;
                     } else {
                         break;
                     }
@@ -127,151 +136,225 @@ pub fn create_session(
     let session_clone = Arc::clone(&session);
     let pane_id_clone = pane_id.to_string();
     let manager_clone = Arc::clone(manager);
+
+    // ── PTY reader: reads bytes, feeds VTE, extracts results, notifies ──
+    // Same architecture as mainstream terminals (Alacritty, Kitty, iTerm2):
+    // the reader thread parses directly into screen state. No intermediate channel.
+    // The broadcast task reads the latest screen state at its own pace.
+    let reader_session = Arc::clone(&session);
+    let reader_pane = pane_id.to_string();
+    let reader_manager = Arc::clone(manager);
     tokio::task::spawn_blocking(move || {
         let mut reader = reader;
-        let mut buf = [0u8; 4096];
-        let mut utf8_tail: Vec<u8> = Vec::new();
-        let last_read_at = Arc::new(std::sync::Mutex::new(std::time::Instant::now()));
-        let watchdog_pane = pane_id_clone.clone();
-        let watchdog_session = Arc::clone(&session_clone);
-        let watchdog_read_ts = Arc::clone(&last_read_at);
-        // Watchdog: detect if PTY reader is stuck (no read for >30s)
-        let _watchdog = std::thread::spawn(move || loop {
-            std::thread::sleep(std::time::Duration::from_secs(10));
-            let idle = watchdog_read_ts
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .elapsed();
-            if idle > std::time::Duration::from_secs(30) {
-                let child_alive = !watchdog_session.is_exited();
-                tracing::warn!(
-                    "PTY reader watchdog: no read for {:.0}s, pane={}, child_alive={}",
-                    idle.as_secs(),
-                    watchdog_pane,
-                    child_alive
-                );
-            }
-            if watchdog_session.is_exited() {
-                break;
-            }
-        });
+        let mut buf = vec![0u8; 65536]; // 64KB — fewer read() syscalls
         loop {
             match reader.read(&mut buf) {
                 Ok(0) => {
-                    info!("PTY reader: EOF, pane={}", pane_id_clone);
+                    info!("PTY reader: EOF, pane={}", reader_pane);
                     break;
                 }
                 Err(e) => {
-                    error!("PTY reader: read error: {:?}, pane={}", e, pane_id_clone);
+                    error!("PTY reader: read error: {:?}, pane={}", e, reader_pane);
                     break;
                 }
                 Ok(n) => {
-                    *last_read_at.lock().unwrap_or_else(std::sync::PoisonError::into_inner) =
-                        std::time::Instant::now();
                     let data = &buf[..n];
-                    // Feed to virtual screen and check for command completion
-                    let (command_results, sync_events) = {
-                        let mut screen = session_clone
+
+                    // CWD sniffing (before lock, uses its own cwd_state lock)
+                    reader_session.on_pty_output(data);
+
+                    // Feed to virtual screen + extract command results + handle sync events
+                    {
+                        let mut screen = reader_session
                             .screen
                             .lock()
                             .unwrap_or_else(std::sync::PoisonError::into_inner);
-                        screen.feed(data);
-                        let results = screen.drain_command_results();
-                        // Collect stdout for each result while still holding the lock
-                        let outputs: Vec<String> =
-                            (0..results.len()).map(|_| screen.take_command_output()).collect();
-                        let sync = screen.drain_sync_events();
-                        (results.into_iter().zip(outputs).collect::<Vec<_>>(), sync)
-                    };
-                    // Handle DEC mode 2026 synchronized output events
-                    for event in sync_events {
-                        match event {
-                            crate::vt_screen::SyncEvent::Start => {
-                                session_clone.set_sync_mode(true);
-                                // Start 1-second safety timeout
-                                let sc = Arc::clone(&session_clone);
-                                tokio::runtime::Handle::current().spawn(async move {
-                                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-                                    if sc.sync_active.load(std::sync::atomic::Ordering::Relaxed) {
-                                        sc.set_sync_mode(false);
+                        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                            screen.feed(data);
+                            let results = screen.drain_command_results();
+                            let outputs: Vec<String> =
+                                (0..results.len()).map(|_| screen.take_command_output()).collect();
+                            let sync = screen.drain_sync_events();
+                            (results.into_iter().zip(outputs).collect::<Vec<_>>(), sync)
+                        }));
+                        match result {
+                            Ok((command_results, sync_events)) => {
+                                // Handle sync events immediately (while still holding lock
+                                // prevents race between sync start and broadcast task wakeup)
+                                for event in sync_events {
+                                    match event {
+                                        crate::vt_screen::SyncEvent::Start => {
+                                            reader_session.set_sync_mode(true);
+                                        }
+                                        crate::vt_screen::SyncEvent::Stop => {
+                                            reader_session.set_sync_mode(false);
+                                        }
                                     }
-                                });
+                                }
+                                // Queue command results for broadcast task
+                                if !command_results.is_empty() {
+                                    let mut pending = reader_session
+                                        .pending_results
+                                        .lock()
+                                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                                    for (result, stdout) in command_results {
+                                        pending.push(crate::session::PendingCommandResult {
+                                            exit_code: result.exit_code,
+                                            duration_ms: result.duration_ms,
+                                            stdout,
+                                            method: result.method,
+                                        });
+                                    }
+                                }
                             }
-                            crate::vt_screen::SyncEvent::Stop => {
-                                session_clone.set_sync_mode(false);
+                            Err(e) => {
+                                let msg = e
+                                    .downcast_ref::<String>()
+                                    .map(String::as_str)
+                                    .or_else(|| e.downcast_ref::<&str>().copied())
+                                    .unwrap_or("unknown");
+                                error!("feed() PANICKED: {}, {}B, pane={}", msg, n, reader_pane);
                             }
                         }
                     }
-                    // Publish command_finished events
-                    for (result, stdout) in command_results {
-                        manager_clone.event_bus.publish(BusEvent::CommandFinished {
-                            pane_id: pane_id_clone.clone(),
-                            command: String::new(), // Will be filled by agent API
-                            exit_code: result.exit_code,
-                            duration_ms: result.duration_ms,
-                            stdout,
-                            method: result.method.clone(),
-                        });
-                        manager_clone.broadcast_sync(&SyncMsg::CommandFinished {
-                            pane_id: pane_id_clone.clone(),
-                            command: String::new(),
-                            exit_code: result.exit_code,
-                            duration_ms: result.duration_ms,
-                            stdout: String::new(),
-                            method: result.method,
-                        });
-                    }
-                    session_clone.on_pty_output(data);
 
-                    utf8_tail.extend_from_slice(data);
-                    let valid_up_to = match std::str::from_utf8(&utf8_tail) {
-                        Ok(s) => {
-                            session_clone.broadcast(s);
-                            utf8_tail.clear();
-                            continue;
-                        }
-                        Err(e) => e.valid_up_to(),
-                    };
-                    if valid_up_to > 0 {
-                        let s = unsafe { std::str::from_utf8_unchecked(&utf8_tail[..valid_up_to]) };
-                        session_clone.broadcast(s);
-                    }
-                    utf8_tail.drain(..valid_up_to);
-                    // Keep only the trailing incomplete bytes (max 3 for UTF-8)
-                    if utf8_tail.len() > 3 {
-                        // Invalid sequence — flush as replacement and reset
-                        session_clone.broadcast("\u{FFFD}");
-                        utf8_tail.clear();
-                    }
+                    // Send raw data for xterm.js rendering
+                    let _ = reader_session.output_tx.send(data.to_vec());
                 }
             }
         }
-        // Notify all connected clients before marking as exited,
-        // so the frontend knows the process is dead instead of seeing a frozen terminal.
-        session_clone.notify_exit_and_mark_exited(&pane_id_clone);
-        if manager_clone.sessions.remove(&pane_id_clone).is_some() {
-            // Publish session closed event
-            manager_clone.event_bus.publish(BusEvent::SessionClosed {
-                pane_id: pane_id_clone.clone(),
-                exit_code: None,
-            });
-            // Find the parent tab and clean up its layout; for single-pane tabs
-            // this returns the tab-level pane_id so we broadcast the correct ID.
-            let tab_pane_id = manager_clone
-                .on_pty_exited(&pane_id_clone)
-                .unwrap_or_else(|| pane_id_clone.clone());
-            manager_clone.broadcast_sync(&SyncMsg::TabClosed { pane_id: tab_pane_id });
+        error!("PTY reader exiting, running cleanup, pane={}", reader_pane);
+        reader_session.notify_exit_and_mark_exited(&reader_pane);
+        if reader_manager.sessions.remove(&reader_pane).is_some() {
+            reader_manager
+                .event_bus
+                .publish(BusEvent::SessionClosed { pane_id: reader_pane.clone(), exit_code: None });
+            let tab_pane_id =
+                reader_manager.on_pty_exited(&reader_pane).unwrap_or_else(|| reader_pane.clone());
+            reader_manager.broadcast_sync(&SyncMsg::TabClosed { pane_id: tab_pane_id });
         }
-        info!("PTY exited, session removed: pane={}", pane_id_clone);
-        let cb = session_clone
+        info!("PTY exited, session removed: pane={}", reader_pane);
+        let cb = reader_session
             .tauri_on_exit
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .clone();
         if let Some(f) = cb {
-            f(pane_id_clone);
+            f(reader_pane);
         }
     });
+
+    // ── Broadcast task: forwards raw PTY data + handles commands ──
+    // Reads raw PTY bytes from the output channel and broadcasts to clients
+    // (WS / Tauri forwarders). Also handles sync timeout and command events
+    // that were extracted by the PTY reader during feed().
+    //
+    // The PTY reader does inline feed() (like mainstream terminals), so VTE
+    // parsing and screen updates happen immediately. This task only needs to
+    // forward the raw bytes for xterm.js rendering.
+    {
+        let bcast_session = Arc::clone(&session_clone);
+        let bcast_manager = Arc::clone(&manager_clone);
+        let bcast_pane = pane_id_clone.clone();
+        tokio::spawn(async move {
+            info!("Broadcast task started, pane={}", bcast_pane);
+            let Some(mut output_rx) = bcast_session
+                .output_rx
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .take()
+            else {
+                error!("Broadcast task: output_rx already taken, pane={}", bcast_pane);
+                return;
+            };
+
+            let sync_timeout = std::time::Duration::from_millis(500);
+            let mut sync_started_at: Option<std::time::Instant> = None;
+            let mut utf8_tail: Vec<u8> = Vec::new();
+
+            while let Some(first) = output_rx.recv().await {
+                if bcast_session.is_exited() {
+                    break;
+                }
+
+                // Drain all pending chunks to reduce broadcast frequency.
+                // When the task is behind, this coalesces multiple chunks into
+                // one batch — intermediate states are still forwarded to preserve
+                // escape sequence integrity for xterm.js.
+                let mut batch = first;
+                while let Ok(data) = output_rx.try_recv() {
+                    batch.extend_from_slice(&data);
+                }
+
+                // Sync safety timeout
+                if bcast_session.sync_active.load(std::sync::atomic::Ordering::Relaxed) {
+                    if let Some(started) = sync_started_at {
+                        if started.elapsed() > sync_timeout {
+                            tracing::warn!(
+                                "Sync mode timeout ({}ms), force-flushing, pane={}",
+                                started.elapsed().as_millis(),
+                                bcast_pane
+                            );
+                            bcast_session.set_sync_mode(false);
+                            sync_started_at = None;
+                        }
+                    } else {
+                        sync_started_at = Some(std::time::Instant::now());
+                    }
+                } else {
+                    sync_started_at = None;
+                }
+
+                // Drain pending command results
+                let results: Vec<crate::session::PendingCommandResult> = {
+                    let mut pending = bcast_session
+                        .pending_results
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    std::mem::take(&mut *pending)
+                };
+                for result in results {
+                    bcast_manager.event_bus.publish(BusEvent::CommandFinished {
+                        pane_id: bcast_pane.clone(),
+                        command: String::new(),
+                        exit_code: result.exit_code,
+                        duration_ms: result.duration_ms,
+                        stdout: result.stdout,
+                        method: result.method.clone(),
+                    });
+                    bcast_manager.broadcast_sync(&SyncMsg::CommandFinished {
+                        pane_id: bcast_pane.clone(),
+                        command: String::new(),
+                        exit_code: result.exit_code,
+                        duration_ms: result.duration_ms,
+                        stdout: String::new(),
+                        method: result.method,
+                    });
+                }
+
+                // UTF-8 handling + broadcast to clients
+                utf8_tail.extend_from_slice(&batch);
+                let valid_up_to = match std::str::from_utf8(&utf8_tail) {
+                    Ok(s) => {
+                        bcast_session.broadcast(s);
+                        utf8_tail.clear();
+                        continue;
+                    }
+                    Err(e) => e.valid_up_to(),
+                };
+                if valid_up_to > 0 {
+                    let s = unsafe { std::str::from_utf8_unchecked(&utf8_tail[..valid_up_to]) };
+                    bcast_session.broadcast(s);
+                }
+                utf8_tail.drain(..valid_up_to);
+                if utf8_tail.len() > 3 {
+                    bcast_session.broadcast("\u{FFFD}");
+                    utf8_tail.clear();
+                }
+            }
+            info!("Broadcast task exited, pane={}", bcast_pane);
+        });
+    }
 
     Ok((session, shell_type))
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -32,6 +32,13 @@ pub struct CwdState {
     pub sniff_buf: Vec<u8>,
 }
 
+pub struct PendingCommandResult {
+    pub exit_code: i32,
+    pub duration_ms: u64,
+    pub stdout: String,
+    pub method: String,
+}
+
 pub struct Session {
     pub writer: Mutex<Box<dyn Write + Send>>,
     pub master: Mutex<Box<dyn MasterPty + Send>>,
@@ -55,6 +62,13 @@ pub struct Session {
     pub sync_buffer_bytes: AtomicUsize,
     /// Sender for debounced resize requests (None = no pending resize)
     pub(crate) resize_tx: watch::Sender<Option<(u16, u16)>>,
+    /// Raw PTY output channel: reader sends raw bytes here for xterm.js rendering.
+    /// Unbounded so the PTY reader never blocks on send.
+    pub output_tx: mpsc::UnboundedSender<Vec<u8>>,
+    /// Receiver side, taken once by the broadcast task.
+    pub output_rx: Mutex<Option<mpsc::UnboundedReceiver<Vec<u8>>>>,
+    /// Command results extracted during `feed()`, consumed by the broadcast task.
+    pub pending_results: Mutex<Vec<PendingCommandResult>>,
 }
 
 impl Session {


### PR DESCRIPTION
## Summary
- fix(terminal): fix mobile touch scrolling for TUI apps
- refactor(desktop): decouple PTY reader from broadcast and fix thread leaks

## Test plan
- [ ] Mobile: open a TUI app (e.g. opencode), swipe to scroll — should work
- [ ] Mobile: normal shell scrollback should still work
- [ ] Desktop: mouse wheel scrolling unaffected
- [ ] Verify no thread leaks after closing terminal sessions