### PR TITLE
feat(shortcuts): Windows Alt-as-Cmd keyboard mapping for web/PWA client

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -240,10 +240,11 @@ import {
 import { isTauri, tauriInvoke } from './composables/useTransport'
 import { isTouchDevice, setActivePaneId } from './composables/useTerminal'
 import { useI18n } from './composables/useI18n'
-import { useKeybindings } from './composables/useKeybindings'
+import { keyEventMatchesBinding, useKeybindings } from './composables/useKeybindings'
 import { useSplitPane } from './composables/useSplitPane'
 import { useSyncWebSocket } from './composables/useSyncWebSocket'
 import { isWebPreviewInput } from './utils/previewRouting'
+import { isWindowsClient } from './utils/clientPlatform'
 import { initMonitorHistory } from './composables/useMonitor'
 import NotificationPanel from './components/notification/NotificationPanel.vue'
 import { useNotification } from './composables/useNotification'
@@ -1126,7 +1127,9 @@ const paletteCommands = computed<Command[]>(() => {
 
 function onGlobalKeydown(e: KeyboardEvent) {
   const cmd = e.metaKey || e.ctrlKey
-  if (!cmd) return
+  const altAsCmd = appSettings.windowsAltAsCmd && isWindowsClient()
+  const appCmd = (cmd || (altAsCmd && e.altKey)) && !(altAsCmd && e.ctrlKey && e.altKey)
+  if (!appCmd) return
 
   const keyActions: Record<string, () => void> = {
     togglePalette: () => paletteRef.value?.toggle(),
@@ -1164,27 +1167,7 @@ function onGlobalKeydown(e: KeyboardEvent) {
 
   for (const [id, action] of Object.entries(keyActions)) {
     const binding = getBinding(id)
-    let matched = false
-    if (binding.key.length === 1) {
-      // Single-char keys: prefer e.code (physical key) to handle Shift correctly.
-      // e.key reports the produced char ('+' for Shift+=), but binding stores '='.
-      const codeToKey: Record<string, string> = {
-        Equal: '=', Minus: '-',
-        BracketLeft: '[', BracketRight: ']', Backslash: '\\',
-        Semicolon: ';', Quote: "'", Comma: ',', Period: '.', Slash: '/',
-        Backquote: '`',
-      }
-      let physicalKey = ''
-      if (e.code.startsWith('Key')) physicalKey = e.code.slice(3).toLowerCase()
-      else if (e.code.startsWith('Digit')) physicalKey = e.code.slice(5)
-      else physicalKey = codeToKey[e.code] ?? ''
-      matched = physicalKey === binding.key.toLowerCase()
-        ? e.shiftKey === binding.shift
-        : e.key.toLowerCase() === binding.key.toLowerCase() && e.shiftKey === binding.shift
-    } else {
-      matched = e.key === binding.key && e.shiftKey === binding.shift
-    }
-    if (matched) {
+    if (keyEventMatchesBinding(e, binding)) {
       e.preventDefault()
       action()
       return
@@ -1192,7 +1175,7 @@ function onGlobalKeydown(e: KeyboardEvent) {
   }
 
   // Cmd+Option+Arrow: focus neighbor pane (spatial navigation)
-  if (e.altKey && !e.shiftKey) {
+  if (cmd && e.altKey && !e.shiftKey) {
     const dirMap: Record<string, 'left' | 'right' | 'up' | 'down'> = {
       ArrowLeft: 'left',
       ArrowRight: 'right',
@@ -1207,7 +1190,7 @@ function onGlobalKeydown(e: KeyboardEvent) {
   }
 
   // Cmd+Option+Shift+Arrow: keyboard resize
-  if (e.altKey && e.shiftKey) {
+  if (cmd && e.altKey && e.shiftKey) {
     const dirMap: Record<string, 'left' | 'right' | 'up' | 'down'> = {
       ArrowLeft: 'left',
       ArrowRight: 'right',

--- a/frontend/src/components/settings/KeyboardTab.vue
+++ b/frontend/src/components/settings/KeyboardTab.vue
@@ -2,6 +2,13 @@
   <div>
     <section class="settings-section">
       <h3>{{ t('keybinding.title') }}</h3>
+      <div v-if="isWindowsClient()" class="settings-row">
+        <label>{{ windowsAltAsCmdLabel }}</label>
+        <label class="toggle">
+          <input type="checkbox" v-model="settings.windowsAltAsCmd" @change="saveSettings()" />
+          <span class="toggle-track"><span class="toggle-thumb"></span></span>
+        </label>
+      </div>
       <div class="kb-group">
         <h4>{{ t('keybinding.appShortcuts') }}</h4>
         <div
@@ -320,12 +327,18 @@ import type { ActionKey } from '../../composables/useSettings'
 import type { KeyBinding } from '../../composables/useKeybindings'
 import { actionKeyToKeyDef } from '../../utils/actionKeyDef'
 import { getApiBase, apiUrl, authFetch } from '../../composables/apiBase'
+import { isWindowsClient } from '../../utils/clientPlatform'
 
 const { settings, saveSettings } = useSettings()
 const { t } = useI18n()
 const { defs, getBinding, formatBinding, isReadOnly } = useKeybindings()
 const appDefs = computed(() => defs.filter((def) => (def.kind ?? 'app') === 'app'))
 const terminalDefs = computed(() => defs.filter((def) => def.kind === 'terminal'))
+const windowsAltAsCmdLabel = computed(() =>
+  settings.locale === 'zh'
+    ? 'Windows 下用 Alt 触发应用快捷键'
+    : 'Use Alt for app shortcuts (Windows)'
+)
 
 const openApiPaneId = ref('')
 const openApiData = ref('')

--- a/frontend/src/composables/useKeybindings.ts
+++ b/frontend/src/composables/useKeybindings.ts
@@ -164,6 +164,28 @@ const defs: KeyBindingDef[] = [
 
 export const keyBindingDefs = defs
 export const terminalKeyBindingDefs = defs.filter((def) => def.kind === 'terminal')
+export const appKeyBindingDefs = defs.filter((def) => def.kind !== 'terminal')
+
+export function keyEventMatchesBinding(e: KeyboardEvent, binding: KeyBinding): boolean {
+  if (binding.key.length === 1) {
+    // Single-char keys: prefer e.code (physical key) to handle Shift correctly.
+    // e.key reports the produced char ('+' for Shift+=), but binding stores '='.
+    const codeToKey: Record<string, string> = {
+      Equal: '=', Minus: '-',
+      BracketLeft: '[', BracketRight: ']', Backslash: '\\',
+      Semicolon: ';', Quote: "'", Comma: ',', Period: '.', Slash: '/',
+      Backquote: '`',
+    }
+    let physicalKey = ''
+    if (e.code.startsWith('Key')) physicalKey = e.code.slice(3).toLowerCase()
+    else if (e.code.startsWith('Digit')) physicalKey = e.code.slice(5)
+    else physicalKey = codeToKey[e.code] ?? ''
+    return physicalKey === binding.key.toLowerCase()
+      ? e.shiftKey === binding.shift
+      : e.key.toLowerCase() === binding.key.toLowerCase() && e.shiftKey === binding.shift
+  }
+  return e.key === binding.key && e.shiftKey === binding.shift
+}
 
 export function useKeybindings() {
   function getBinding(id: string): KeyBinding {
@@ -210,5 +232,14 @@ export function useKeybindings() {
     })
   }
 
-  return { defs, getBinding, formatBinding, getAllWithDisplay, isReadOnly }
+  function isAppShortcut(e: KeyboardEvent): boolean {
+    if (!e.shiftKey && e.key >= '1' && e.key <= '9') return true
+
+    for (const def of appKeyBindingDefs) {
+      if (keyEventMatchesBinding(e, getBinding(def.id))) return true
+    }
+    return false
+  }
+
+  return { defs, getBinding, formatBinding, getAllWithDisplay, isReadOnly, isAppShortcut }
 }

--- a/frontend/src/composables/useSettings.ts
+++ b/frontend/src/composables/useSettings.ts
@@ -4,6 +4,7 @@ import { getApiBase, apiUrl, authFetch, hasAuthToken } from './apiBase'
 import ClaudeLogo from '../components/icons/ClaudeLogo.vue'
 import CodexLogo from '../components/icons/CodexLogo.vue'
 import OpencodeLogo from '../components/icons/OpencodeLogo.vue'
+import { isWindowsClient } from '../utils/clientPlatform'
 import type { KeyBinding } from './useKeybindings'
 export interface SettingsData {
   theme: {
@@ -31,6 +32,7 @@ export interface SettingsData {
   keyboard_sound: boolean
   show_virtual_keyboard: boolean
   confirm_before_close_tab: boolean
+  windowsAltAsCmd: boolean
   locale: string
   panel_position: 'auto' | 'right' | 'left' | 'top' | 'bottom'
   port?: number | null
@@ -200,6 +202,7 @@ export const settings = reactive<SettingsData>({
   keyboard_sound: false,
   show_virtual_keyboard: false,
   confirm_before_close_tab: true,
+  windowsAltAsCmd: isWindowsClient(),
   locale: 'zh',
   panel_position: 'auto',
   monitor: {

--- a/frontend/src/composables/useTerminal.ts
+++ b/frontend/src/composables/useTerminal.ts
@@ -8,6 +8,7 @@ import { isTauri, createTransport, type Transport } from './useTransport'
 import { onThemeChange, saveSettings, settings, onTextChange } from './useSettings'
 import { wsUrlWithToken } from './apiBase'
 import { terminalKeyBindingDefs, useKeybindings, type KeyBinding } from './useKeybindings'
+import { isWindowsClient } from '../utils/clientPlatform'
 
 export function isTouchDevice(): boolean {
   return 'ontouchstart' in window || navigator.maxTouchPoints > 0
@@ -96,17 +97,20 @@ export function isSinglePrintableGrapheme(data: string, allowSpace = false): boo
   return cp <= 0x7e || (cp >= 0xff01 && cp <= 0xff5e)
 }
 
-export function terminalKeybindingMatches(e: KeyboardEvent, binding: KeyBinding): boolean {
+export function terminalKeybindingMatches(e: KeyboardEvent, binding: KeyBinding, virtualMeta = false): boolean {
+  const effMeta = e.metaKey || virtualMeta
+  const effAlt = virtualMeta ? false : e.altKey
   return e.key.toLowerCase() === binding.key.toLowerCase()
     && e.shiftKey === !!binding.shift
-    && e.metaKey === !!binding.meta
+    && effMeta === !!binding.meta
     && e.ctrlKey === !!binding.ctrl
-    && e.altKey === !!binding.alt
+    && effAlt === !!binding.alt
 }
 
 export function handleTerminalShortcutKeydown(
   e: KeyboardEvent,
   sendData: (data: string) => void,
+  virtualMeta = false,
 ): boolean {
   const key = e.key.toLowerCase()
   if (e.ctrlKey && e.shiftKey && !e.metaKey && !e.altKey && (key === 'c' || key === 'v')) return false
@@ -115,7 +119,7 @@ export function handleTerminalShortcutKeydown(
   for (const def of terminalKeyBindingDefs) {
     const sequence = def.sequence
     if (!sequence) continue
-    if (terminalKeybindingMatches(e, getBinding(def.id))) {
+    if (terminalKeybindingMatches(e, getBinding(def.id), virtualMeta)) {
       e.preventDefault()
       e.stopPropagation()
       sendData(sequence)
@@ -259,6 +263,7 @@ export class TerminalInstance {
 
     // Ctrl+Shift+C/V: Linux-style copy/paste (macOS uses Cmd+C/V natively)
     const xt = this.xterm
+    const { isAppShortcut } = useKeybindings()
     xt.attachCustomKeyEventHandler((e: KeyboardEvent) => {
       if (e.type === 'keydown') {
         if (e.isComposing || (e as any).keyCode === 229 || e.key === 'Process') return true
@@ -278,9 +283,27 @@ export class TerminalInstance {
           }
         }
 
-        if (handleTerminalShortcutKeydown(e, (data) => this.sendData(data))) {
-          return false
+        const virtualMeta = settings.windowsAltAsCmd && isWindowsClient() && e.altKey && !e.ctrlKey
+        if (virtualMeta && !e.shiftKey) {
+          if (e.code === 'KeyC' && xt.hasSelection()) {
+            navigator.clipboard.writeText(xt.getSelection())
+            e.preventDefault()
+            e.stopPropagation()
+            return false
+          }
+          if (e.code === 'KeyV') {
+            navigator.clipboard.readText().then((text) => {
+              if (text) xt.paste(text)
+            }).catch(() => {})
+            e.preventDefault()
+            e.stopPropagation()
+            return false
+          }
         }
+
+        if (handleTerminalShortcutKeydown(e, (data) => this.sendData(data), virtualMeta)) return false
+
+        if (virtualMeta && isAppShortcut(e)) return false
       }
       return true
     })

--- a/frontend/src/utils/clientPlatform.ts
+++ b/frontend/src/utils/clientPlatform.ts
@@ -1,0 +1,7 @@
+export function isWindowsClient(): boolean {
+  if (typeof navigator === 'undefined') return false
+  const platform =
+    (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData?.platform ||
+    navigator.platform
+  return /Win/i.test(platform)
+}

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -16,6 +16,7 @@ use zeroize::Zeroize;
 use crate::session::SessionManager;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct Settings {
     #[serde(default)]
     pub theme: ThemeConfig,
@@ -39,6 +40,8 @@ pub struct Settings {
     pub keyboard_sound: bool,
     #[serde(default)]
     pub show_virtual_keyboard: bool,
+    #[serde(default, rename = "windowsAltAsCmd")]
+    pub windows_alt_as_cmd: bool,
     #[serde(default = "default_true")]
     pub confirm_before_close_tab: bool,
     #[serde(default = "default_locale")]
@@ -494,6 +497,7 @@ impl Default for Settings {
             action_keyboard: None,
             keyboard_sound: false,
             show_virtual_keyboard: false,
+            windows_alt_as_cmd: false,
             confirm_before_close_tab: true,
             locale: default_locale(),
             panel_position: PanelPosition::default(),


### PR DESCRIPTION
## Problem

On the web / installed-PWA client, a Windows user has no **Cmd** key, so every Cmd-bound action (command palette, tab management, split-pane, the custom terminal keybinds, copy/paste) is simply unreachable from the keyboard. The web client currently only listens for `metaKey`/`ctrlKey`.

## What this does

When the **client** is detected as Windows, map **Alt** to a *virtual Meta*, so Alt reaches the same actions Cmd reaches on macOS. It is user-toggleable in **Settings → Keyboard** and default-on only when the client looks like Windows; macOS/Linux clients are unaffected.

Coverage when Alt is held (= virtual Meta):
- **App shortcuts** — command palette, new/close tab, split-pane, digit tab-switch
- **The 4 custom terminal keybinds** — line start / line end / delete-line / submit
- **Terminal copy / paste** — Alt+C / Alt+V

Un-bound Alt still passes straight through to the shell (so readline word-navigation etc. keeps working). **AltGr (Ctrl+Alt) is explicitly excluded** so European keyboard layouts keep producing characters.

## How

- `utils/clientPlatform.ts` — `isWindowsClient()` (`navigator.userAgentData.platform`, falling back to `navigator.platform`)
- **settings** — new persisted `windowsAltAsCmd` (frontend `SettingsData` + backend `Settings` struct), default = `isWindowsClient()`
- `App.vue` — `appCmd` gate = `metaKey || ctrlKey || (altAsCmd && altKey)`; bare `Alt+Arrow` no longer triggers pane navigation; the `Cmd+Option` branches keep the real `cmd` gate
- `useKeybindings` — `keyEventMatchesBinding` + `isAppShortcut` helpers (physical `e.code` resolution for single-char keys)
- `useTerminal` — `virtualMeta` threaded through the xterm key handler; app-shortcut Alt combos `return false` so they bubble up to `App.vue`'s global handler instead of being swallowed by xterm

## Scope / notes

- Web/PWA client only. No native Windows build exists today, so the toggle has no effect there.
- `Cmd+Shift+*` app shortcuts become `Alt+Shift+*` on Windows, which the OS reserves for keyboard-layout switching — those specific combos remain unreachable at the web layer (documented, not worked around).
- Terminal clipboard uses `navigator.clipboard`, which requires a secure context — over plain-http LAN, paste is blocked by the browser (works over HTTPS / localhost). This is a pre-existing browser constraint, orthogonal to this change.

## Testing

- `vue-tsc -b` clean, `cargo check` clean.
- Real-device verified on Windows Chrome (app/PWA mode): app shortcuts, the 4 terminal keybinds, and Alt+arrow/Alt+delete line-editing all behave as the Cmd equivalents; Mac client unchanged.