### PR TITLE
feat: opt-in Space key confirms dialogs

### DIFF
--- a/frontend/src/components/settings/GeneralTab.vue
+++ b/frontend/src/components/settings/GeneralTab.vue
@@ -382,6 +382,21 @@
         <p class="settings-hint" data-hint="confirm-before-close-tab">
           {{ t('settings.confirmBeforeCloseTabHint') }}
         </p>
+        <div class="settings-row">
+          <label>{{ t('settings.spaceConfirmsDialogs') }}</label>
+          <label class="toggle">
+            <input
+              type="checkbox"
+              v-model="settings.space_confirms_dialogs"
+              @change="saveSettings()"
+              data-setting="space-confirms-dialogs"
+            />
+            <span class="toggle-track"><span class="toggle-thumb"></span></span>
+          </label>
+        </div>
+        <p class="settings-hint" data-hint="space-confirms-dialogs">
+          {{ t('settings.spaceConfirmsDialogsHint') }}
+        </p>
       </section>
     </div>
 

--- a/frontend/src/components/ui/ConfirmModal.vue
+++ b/frontend/src/components/ui/ConfirmModal.vue
@@ -1,7 +1,7 @@
 <template>
   <Teleport to="body">
     <div v-if="visible" class="confirm-backdrop" @click.self="onCancel">
-      <div class="confirm-modal">
+      <div ref="rootEl" class="confirm-modal">
         <div class="confirm-header">
           <span class="confirm-title">{{ title }}</span>
           <button class="confirm-close" @click="onCancel">&times;</button>
@@ -18,8 +18,13 @@
   </Teleport>
 </template>
 
+<script lang="ts">
+const visibleStack: symbol[] = []
+</script>
+
 <script setup lang="ts">
 import { onMounted, onUnmounted, ref, watch } from 'vue'
+import { settings } from '../../composables/useSettings'
 
 const props = defineProps<{
   visible: boolean
@@ -35,8 +40,27 @@ const emit = defineEmits<{
 }>()
 
 const focusIndex = ref(0)
+const rootEl = ref<HTMLElement | null>(null)
+const stackId = Symbol()
+const spaceConfirmIssued = ref(false)
 
-watch(() => props.visible, (v) => { if (v) focusIndex.value = 0 })
+function removeFromVisibleStack() {
+  const index = visibleStack.indexOf(stackId)
+  if (index !== -1) visibleStack.splice(index, 1)
+}
+
+watch(
+  () => props.visible,
+  (visible) => {
+    removeFromVisibleStack()
+    if (visible) {
+      focusIndex.value = 0
+      spaceConfirmIssued.value = false
+      visibleStack.push(stackId)
+    }
+  },
+  { immediate: true }
+)
 
 function onConfirm() {
   emit('confirm')
@@ -48,6 +72,36 @@ function onCancel() {
 
 function onKey(e: KeyboardEvent) {
   if (!props.visible) return
+  const isIme = e.isComposing || e.keyCode === 229 || e.key === 'Process'
+  if (
+    settings.space_confirms_dialogs &&
+    e.key === ' ' &&
+    !isIme &&
+    !e.shiftKey &&
+    !e.ctrlKey &&
+    !e.altKey &&
+    !e.metaKey
+  ) {
+    if (visibleStack[visibleStack.length - 1] !== stackId) return
+
+    const activeElement = document.activeElement
+    if (
+      activeElement instanceof HTMLElement &&
+      rootEl.value?.contains(activeElement) &&
+      (activeElement.matches('button, input, textarea, select, [contenteditable]') ||
+        activeElement.isContentEditable)
+    ) {
+      return
+    }
+
+    e.preventDefault()
+    e.stopImmediatePropagation()
+    if (!spaceConfirmIssued.value) {
+      spaceConfirmIssued.value = true
+      onConfirm()
+    }
+    return
+  }
   if (e.key === 'Escape') {
     e.preventDefault()
     e.stopPropagation()
@@ -65,7 +119,10 @@ function onKey(e: KeyboardEvent) {
 }
 
 onMounted(() => window.addEventListener('keydown', onKey, true))
-onUnmounted(() => window.removeEventListener('keydown', onKey, true))
+onUnmounted(() => {
+  removeFromVisibleStack()
+  window.removeEventListener('keydown', onKey, true)
+})
 </script>
 
 <style scoped>

--- a/frontend/src/composables/useI18n.ts
+++ b/frontend/src/composables/useI18n.ts
@@ -431,6 +431,8 @@ const messages: Record<Locale, Record<string, string>> = {
     'settings.confirmBeforeCloseTab': 'Confirm before closing terminal tab',
     'settings.confirmBeforeCloseTabHint':
       'Show a confirmation dialog before closing a terminal tab',
+    'settings.spaceConfirmsDialogs': 'Use Space to confirm dialogs',
+    'settings.spaceConfirmsDialogsHint': 'Applies to all confirmation dialogs',
     'settings.behavior': 'Behavior',
     'confirm.closeTabTitle': 'Close session?',
     'confirm.closeTabMessage': 'Closing this session will terminate all running processes. Close',
@@ -943,6 +945,8 @@ const messages: Record<Locale, Record<string, string>> = {
     'settings.about.repository': '仓库',
     'settings.confirmBeforeCloseTab': '关闭终端 tab 前显示确认',
     'settings.confirmBeforeCloseTabHint': '关闭终端 tab 前弹出确认对话框',
+    'settings.spaceConfirmsDialogs': '使用空格键确认对话框',
+    'settings.spaceConfirmsDialogsHint': '适用于所有确认对话框',
     'settings.behavior': '行为',
     'confirm.closeTabTitle': '关闭会话？',
     'confirm.closeTabMessage': '关闭此会话将终止所有正在运行的进程。仍要关闭',

--- a/frontend/src/composables/useSettings.ts
+++ b/frontend/src/composables/useSettings.ts
@@ -36,6 +36,7 @@ export interface SettingsData {
   keyboard_sound: boolean
   show_virtual_keyboard: boolean
   confirm_before_close_tab: boolean
+  space_confirms_dialogs: boolean
   windowsAltAsCmd: boolean
   locale: string
   panel_position: 'auto' | 'right' | 'left' | 'top' | 'bottom'
@@ -229,6 +230,7 @@ export const settings = reactive<SettingsData>({
   keyboard_sound: false,
   show_virtual_keyboard: false,
   confirm_before_close_tab: true,
+  space_confirms_dialogs: false,
   windowsAltAsCmd: isWindowsClient,
   locale: 'zh',
   panel_position: 'auto',

--- a/frontend/src/test/ConfirmModal.test.ts
+++ b/frontend/src/test/ConfirmModal.test.ts
@@ -1,98 +1,224 @@
-import { describe, it, expect, vi } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
 import { nextTick } from 'vue'
 import ConfirmModal from '../components/ui/ConfirmModal.vue'
+import { settings } from '../composables/useSettings'
 
-describe('ConfirmModal Esc 键支持', () => {
-  it('visible=true + 按 Esc → emit cancel', async () => {
-    const wrapper = mount(ConfirmModal, {
-      props: {
-        visible: true,
-        title: '关闭标签页',
-        message: '是否关闭此标签页?',
-        confirmText: '关闭',
-        cancelText: '取消',
-      },
-    })
+const wrappers: VueWrapper[] = []
 
-    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+function mountModal(visible = true) {
+  const wrapper = mount(ConfirmModal, {
+    props: {
+      visible,
+      title: 'Close tab',
+      message: 'Close this tab?',
+      confirmText: 'Close',
+      cancelText: 'Cancel',
+    },
+  })
+  wrappers.push(wrapper)
+  return wrapper
+}
 
-    // 等待 microtask
-    await wrapper.vm.$nextTick()
+function dispatchKey(init: KeyboardEventInit & { keyCode?: number }) {
+  const event = new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init })
+  if (init.keyCode !== undefined) {
+    Object.defineProperty(event, 'keyCode', { value: init.keyCode })
+  }
+  window.dispatchEvent(event)
+  return event
+}
 
-    const cancelEmits = wrapper.emitted('cancel')
-    expect(cancelEmits).toBeDefined()
-    expect(cancelEmits!.length).toBe(1)
+describe('ConfirmModal keyboard support', () => {
+  beforeEach(() => {
+    settings.space_confirms_dialogs = false
   })
 
-  it('visible=false + 按 Esc → 不 emit cancel', async () => {
-    const wrapper = mount(ConfirmModal, {
-      props: {
-        visible: false,
-        title: '关闭标签页',
-        message: '是否关闭此标签页?',
-        confirmText: '关闭',
-        cancelText: '取消',
-      },
-    })
-
-    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
-
-    await wrapper.vm.$nextTick()
-
-    const cancelEmits = wrapper.emitted('cancel')
-    expect(cancelEmits).toBeUndefined()
+  afterEach(() => {
+    while (wrappers.length > 0) wrappers.pop()!.unmount()
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
   })
 
-  it('visible=true + 按 Enter → 触发当前聚焦的取消按钮', async () => {
-    const wrapper = mount(ConfirmModal, {
-      props: {
-        visible: true,
-        title: '关闭标签页',
-        message: '是否关闭此标签页?',
-        confirmText: '关闭',
-        cancelText: '取消',
-      },
-    })
+  it('visible=true + Escape emits cancel', async () => {
+    const wrapper = mountModal()
 
-    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }))
-
-    await wrapper.vm.$nextTick()
-
-    const cancelEmits = wrapper.emitted('cancel')
-    expect(cancelEmits).toBeDefined()
-    expect(cancelEmits!.length).toBe(1)
-  })
-
-  it('onUnmounted 移除 keydown listener', () => {
-    const removeSpy = vi.spyOn(window, 'removeEventListener')
-    const wrapper = mount(ConfirmModal, {
-      props: {
-        visible: false,
-        title: '关闭标签页',
-        message: '是否关闭此标签页?',
-        confirmText: '关闭',
-        cancelText: '取消',
-      },
-    })
-    wrapper.unmount()
-    expect(removeSpy).toHaveBeenCalledWith('keydown', expect.any(Function), true)
-    removeSpy.mockRestore()
-  })
-
-  it('visible: false→true 切换后 Esc 正常 emit', async () => {
-    const wrapper = mount(ConfirmModal, {
-      props: {
-        visible: false,
-        title: '关闭标签页',
-        message: '是否关闭此标签页?',
-        confirmText: '关闭',
-        cancelText: '取消',
-      },
-    })
-    await wrapper.setProps({ visible: true })
-    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    dispatchKey({ key: 'Escape' })
     await nextTick()
-    expect(wrapper.emitted('cancel')?.length).toBe(1)
+
+    expect(wrapper.emitted('cancel')).toHaveLength(1)
+  })
+
+  it('visible=false + Escape does not emit cancel', async () => {
+    const wrapper = mountModal(false)
+
+    dispatchKey({ key: 'Escape' })
+    await nextTick()
+
+    expect(wrapper.emitted('cancel')).toBeUndefined()
+  })
+
+  it('Enter activates the initially highlighted cancel button', async () => {
+    const wrapper = mountModal()
+
+    dispatchKey({ key: 'Enter' })
+    await nextTick()
+
+    expect(wrapper.emitted('cancel')).toHaveLength(1)
+  })
+
+  it('removes the keydown listener on unmount', () => {
+    const removeSpy = vi.spyOn(window, 'removeEventListener')
+    const wrapper = mountModal(false)
+
+    wrapper.unmount()
+    wrappers.splice(wrappers.indexOf(wrapper), 1)
+
+    expect(removeSpy).toHaveBeenCalledWith('keydown', expect.any(Function), true)
+  })
+
+  it('handles Escape after visible changes from false to true', async () => {
+    const wrapper = mountModal(false)
+
+    await wrapper.setProps({ visible: true })
+    dispatchKey({ key: 'Escape' })
+    await nextTick()
+
+    expect(wrapper.emitted('cancel')).toHaveLength(1)
+  })
+
+  it('does not intercept Space when the setting is off', () => {
+    const wrapper = mountModal()
+
+    const event = dispatchKey({ key: ' ' })
+
+    expect(wrapper.emitted('confirm')).toBeUndefined()
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  it('confirms once and prevents every repeated Space while visible', () => {
+    settings.space_confirms_dialogs = true
+    const wrapper = mountModal()
+
+    const first = dispatchKey({ key: ' ' })
+    const repeated = dispatchKey({ key: ' ', repeat: true })
+
+    expect(wrapper.emitted('confirm')).toHaveLength(1)
+    expect(first.defaultPrevented).toBe(true)
+    expect(repeated.defaultPrevented).toBe(true)
+  })
+
+  it('Space confirms directly even when cancel is highlighted', () => {
+    settings.space_confirms_dialogs = true
+    const wrapper = mountModal()
+
+    dispatchKey({ key: ' ' })
+
+    expect(wrapper.emitted('confirm')).toHaveLength(1)
+    expect(wrapper.emitted('cancel')).toBeUndefined()
+  })
+
+  it.each([
+    ['Shift', { shiftKey: true }],
+    ['Control', { ctrlKey: true }],
+    ['Alt', { altKey: true }],
+    ['Meta', { metaKey: true }],
+  ])('does not intercept %s+Space', (_name, modifier) => {
+    settings.space_confirms_dialogs = true
+    const wrapper = mountModal()
+
+    const event = dispatchKey({ key: ' ', ...modifier })
+
+    expect(wrapper.emitted('confirm')).toBeUndefined()
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  it.each([
+    ['isComposing', { key: ' ', isComposing: true }],
+    ['keyCode 229', { key: ' ', keyCode: 229 }],
+    ['Process key', { key: 'Process' }],
+  ])('does not intercept Space during IME composition via %s', (_name, keyInit) => {
+    settings.space_confirms_dialogs = true
+    const wrapper = mountModal()
+
+    const event = dispatchKey(keyInit)
+
+    expect(wrapper.emitted('confirm')).toBeUndefined()
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  it('resets the one-shot latch on the next visible cycle', async () => {
+    settings.space_confirms_dialogs = true
+    const wrapper = mountModal()
+
+    dispatchKey({ key: ' ' })
+    await wrapper.setProps({ visible: false })
+    await wrapper.setProps({ visible: true })
+    dispatchKey({ key: ' ' })
+
+    expect(wrapper.emitted('confirm')).toHaveLength(2)
+  })
+
+  it('reads a live setting change while the dialog is open', () => {
+    const wrapper = mountModal()
+
+    settings.space_confirms_dialogs = true
+    dispatchKey({ key: ' ' })
+
+    expect(wrapper.emitted('confirm')).toHaveLength(1)
+  })
+
+  it('only confirms the last-opened visible modal', () => {
+    settings.space_confirms_dialogs = true
+    const lower = mountModal()
+    const top = mountModal()
+
+    dispatchKey({ key: ' ' })
+
+    expect(lower.emitted('confirm')).toBeUndefined()
+    expect(top.emitted('confirm')).toHaveLength(1)
+  })
+
+  it('confirms the previous modal after the top modal unmounts', () => {
+    const lower = mountModal()
+    const top = mountModal()
+
+    top.unmount()
+    settings.space_confirms_dialogs = true
+    dispatchKey({ key: ' ' })
+
+    expect(lower.emitted('confirm')).toHaveLength(1)
+  })
+
+  it('does not intercept Space on buttons or editable elements inside the modal', () => {
+    settings.space_confirms_dialogs = true
+    const wrapper = mountModal()
+    const root = document.querySelector<HTMLElement>('.confirm-modal')!
+    const editable = document.createElement('div')
+    editable.setAttribute('contenteditable', 'true')
+    editable.tabIndex = 0
+    root.appendChild(editable)
+
+    const controls = [...root.querySelectorAll<HTMLElement>('button'), editable]
+    for (const control of controls) {
+      control.focus()
+      const event = dispatchKey({ key: ' ' })
+      expect(event.defaultPrevented).toBe(false)
+    }
+
+    expect(wrapper.emitted('confirm')).toBeUndefined()
+  })
+
+  it('stops a later competing window capture listener', () => {
+    settings.space_confirms_dialogs = true
+    const wrapper = mountModal()
+    const competingListener = vi.fn()
+    window.addEventListener('keydown', competingListener, true)
+
+    dispatchKey({ key: ' ' })
+
+    expect(wrapper.emitted('confirm')).toHaveLength(1)
+    expect(competingListener).not.toHaveBeenCalled()
+    window.removeEventListener('keydown', competingListener, true)
   })
 })

--- a/frontend/src/test/GeneralTab.test.ts
+++ b/frontend/src/test/GeneralTab.test.ts
@@ -49,6 +49,7 @@ describe('GeneralTab - confirm-before-close-tab toggle', () => {
   beforeEach(() => {
     // Reset the shared reactive settings to the documented default.
     settings.confirm_before_close_tab = true
+    settings.space_confirms_dialogs = false
     settings.upload_dir = ''
     generalMocks.uploadStatus = 200
     generalMocks.defaultDir = '/tmp/dinotty'
@@ -135,6 +136,34 @@ describe('GeneralTab - confirm-before-close-tab toggle', () => {
     settings.confirm_before_close_tab = true
     await nextTick()
     expect(input.element.checked).toBe(true)
+  })
+
+  it('renders the Space-confirm toggle defaulted off with its hint', () => {
+    const wrapper = mount(GeneralTab)
+    const input = wrapper.find<HTMLInputElement>(
+      'input[type="checkbox"][data-setting="space-confirms-dialogs"]'
+    )
+
+    expect(input.exists()).toBe(true)
+    expect(input.element.checked).toBe(false)
+    expect(wrapper.find('[data-hint="space-confirms-dialogs"]').text().trim()).not.toBe('')
+  })
+
+  it('persists space_confirms_dialogs when its toggle is enabled', async () => {
+    const wrapper = mount(GeneralTab)
+    const input = wrapper.find<HTMLInputElement>('[data-setting="space-confirms-dialogs"]')
+
+    await input.setValue(true)
+    await flush()
+
+    expect(settings.space_confirms_dialogs).toBe(true)
+    const putCall = generalMocks.authFetch.mock.calls.find(
+      ([url, init]) => url === '/api/settings' && init?.method === 'PUT'
+    )
+    expect(putCall).toBeDefined()
+    expect(JSON.parse(putCall![1]!.body as string)).toMatchObject({
+      space_confirms_dialogs: true,
+    })
   })
 
   it('shows an inline upload_dir error when status validation returns 400', async () => {

--- a/frontend/src/test/useSettings.test.ts
+++ b/frontend/src/test/useSettings.test.ts
@@ -14,4 +14,10 @@ describe('useSettings - confirm_before_close_tab mirror', () => {
     // set to true out of the box, matching the backend serde default.
     expect(settings.confirm_before_close_tab).toBe(true)
   })
+
+  it('defaults space_confirms_dialogs to false', () => {
+    // The reactive settings object should have space_confirms_dialogs
+    // set to false out of the box, matching the backend serde default.
+    expect(settings.space_confirms_dialogs).toBe(false)
+  })
 })

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -57,6 +57,8 @@ pub struct Settings {
     pub windows_alt_as_cmd: bool,
     #[serde(default = "default_true")]
     pub confirm_before_close_tab: bool,
+    #[serde(default)]
+    pub space_confirms_dialogs: bool,
     #[serde(default = "default_locale")]
     pub locale: String,
     #[serde(default)]
@@ -646,6 +648,7 @@ impl Default for Settings {
             show_virtual_keyboard: false,
             windows_alt_as_cmd: false,
             confirm_before_close_tab: true,
+            space_confirms_dialogs: false,
             locale: default_locale(),
             panel_position: PanelPosition::default(),
             monitor: MonitorConfig::default(),
@@ -1004,3 +1007,25 @@ pub async fn get_log(
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod space_confirms_dialogs_tests {
+    use super::Settings;
+
+    #[test]
+    fn space_confirms_dialogs_defaults_to_false() {
+        let settings: Settings = serde_json::from_str(r"{}").unwrap();
+        assert!(!settings.space_confirms_dialogs);
+    }
+
+    #[test]
+    fn space_confirms_dialogs_round_trips() {
+        let settings: Settings =
+            serde_json::from_str(r#"{"space_confirms_dialogs":true}"#).unwrap();
+        assert!(settings.space_confirms_dialogs);
+
+        let serialized = serde_json::to_string(&settings).unwrap();
+        let round_tripped: Settings = serde_json::from_str(&serialized).unwrap();
+        assert!(round_tripped.space_confirms_dialogs);
+    }
+}


### PR DESCRIPTION
## What
Adds an opt-in setting (default **OFF**): when enabled, pressing an unmodified Space confirms the currently visible confirmation dialog — same action as clicking Confirm / pressing Enter. Example: close-tab confirmation can be confirmed with a single Space press.

## How
- New setting `space_confirms_dialogs` (Rust `#[serde(default)]` bool + frontend schema, default false; OFF = behavior unchanged).
- `ConfirmModal.vue`: a guarded Space branch at the head of the existing capture-phase `onKey`:
  - only when the setting is ON, key is unmodified Space, and not during IME composition (`isComposing || keyCode 229 || key 'Process'`);
  - a module-level visible-stack ensures only the topmost dialog reacts when several are open (`stopImmediatePropagation` guarantees at most one confirm per press);
  - if focus is on a button/editable element inside the dialog, native semantics win (no interception);
  - `preventDefault` keeps the Space from leaking into the terminal;
  - a per-open latch makes key-repeat safe (one confirm per dialog open).
  - Existing Escape/Arrow/Tab/Enter handling untouched.
- Settings UI toggle in General tab next to the close-tab-confirm option; en/zh i18n included.
- Applies uniformly to all ConfirmModal consumers (tab/pane close, window close, file move/delete, plugin uninstall).

## Tests
- Rust: settings default + serde round-trip.
- Vitest: 30+ new assertions — default-off, direct confirm, latch/key-repeat, IME guard, modifiers, dual-dialog topmost arbitration, top-dialog-unmount fallback, focused-control guard, competing capture listener. Full suite 224/224 green; `cargo clippy --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)