### PR TITLE
fix(terminal): converge fit on refresh/reconnect + cross-client resize follow

### DIFF
--- a/frontend/src/composables/useTerminal.ts
+++ b/frontend/src/composables/useTerminal.ts
@@ -229,7 +229,18 @@ export class TerminalInstance {
   selStartCol = 0
   private _visibilityHandler: (() => void) | null = null
   private _dragDropCleanup: (() => void) | null = null
-  private _initialResizeTimer: ReturnType<typeof setInterval> | null = null
+  private _settleTimeouts: ReturnType<typeof setTimeout>[] = []
+  private _settleRaf: number = 0
+  private _settleGeneration: number = 0
+  private _transportConnected = false
+  private _lastSentCols = 0
+  private _lastSentRows = 0
+  private _followingPeer = false
+  private _peerFollowGen = 0
+  private _peerFollowTimer: ReturnType<typeof setTimeout> | null = null
+  private _pendingLocalRefit = false
+  private _authWrapperW = 0
+  private _authWrapperH = 0
   onFileUpload?: (files: File[]) => void
 
   onTitleChange: ((title: string) => void) | null = null
@@ -504,10 +515,8 @@ export class TerminalInstance {
       },
     })
 
-    // Retry the initial resize until it actually reaches the server.
-    // On new tabs the WebGL renderer and WebSocket may not be ready when the
-    // first RAF fires, so we loop until _doFitAndResize successfully sends.
-    this._scheduleInitialResize()
+    // Sample a short settle series while the renderer and DOM layout converge.
+    this._scheduleSettleResize()
 
     this.xterm.onTitleChange((title) => {
       if (this._suppressTitleChange) return
@@ -659,7 +668,16 @@ export class TerminalInstance {
     if (this._destroyed) return
     this._destroyed = true
     if (this._reconnectTimer) clearTimeout(this._reconnectTimer)
-    if (this._initialResizeTimer) clearInterval(this._initialResizeTimer)
+    for (const h of this._settleTimeouts) clearTimeout(h)
+    this._settleTimeouts = []
+    if (this._settleRaf) cancelAnimationFrame(this._settleRaf)
+    if (this._peerFollowTimer) {
+      clearTimeout(this._peerFollowTimer)
+      this._peerFollowTimer = null
+    }
+    this._settleGeneration++
+    this._peerFollowGen++
+    this._followingPeer = false
     if (this._refitRaf) cancelAnimationFrame(this._refitRaf)
     if (this._resizeDebounce) clearTimeout(this._resizeDebounce)
     this._resizeObserver?.disconnect()
@@ -695,11 +713,14 @@ export class TerminalInstance {
   }
 
   private _connectViaTransport() {
+    this._transportConnected = false
     this._transport = createTransport(this.paneId)
 
     this._transport.onConnect(() => {
+      this._transportConnected = true
       this.onConnect?.()
       this._doFitAndResize(true)
+      this._scheduleSettleResize()
     })
 
     this._transport.onMessage((msg) => {
@@ -717,12 +738,16 @@ export class TerminalInstance {
         this._writeQueue = []
         this._writing = false
         this._doFitAndResize(true)
+        this._scheduleSettleResize()
+      } else if (msg.type === 'resize') {
+        this._followPeerResize(msg.cols, msg.rows)
       } else if (msg.type === 'session_exit') {
         this._handleSessionExit()
       }
     })
 
     this._transport.onDisconnect(() => {
+      this._transportConnected = false
       this.onDisconnect?.()
     })
 
@@ -746,6 +771,7 @@ export class TerminalInstance {
       this._hideOverlay()
       this.onConnect?.()
       this._doFitAndResize(true)
+      this._scheduleSettleResize()
     }
 
     this.ws.onmessage = (e) => {
@@ -764,12 +790,15 @@ export class TerminalInstance {
         this._reconnectAttempts = 0
         this._hideOverlay()
         this._doFitAndResize(true)
+        this._scheduleSettleResize()
       } else if (msg.type === 'output') {
         this._enqueueWrite(msg.data)
         this.onRawOutput?.(msg.data)
       } else if (msg.type === 'shell_info') {
         this._shellType = msg.shell_type
         this.onShellInfo?.(msg.shell_type)
+      } else if (msg.type === 'resize') {
+        this._followPeerResize(msg.cols, msg.rows)
       } else if (msg.type === 'session_exit') {
         this._handleSessionExit()
       }
@@ -950,6 +979,10 @@ export class TerminalInstance {
   }
 
   _refit() {
+    if (this._followingPeer) {
+      if (this._wrapperChanged()) this._pendingLocalRefit = true
+      return
+    }
     if (!this.fitAddon || !this._wrapper) return
     if (this._refitRaf) return
     this._refitRaf = requestAnimationFrame(() => {
@@ -958,35 +991,131 @@ export class TerminalInstance {
     })
   }
 
-  /**
-   * Retry the initial resize in a loop until it succeeds.
-   * Handles the race where the WebGL renderer, DOM layout, or WebSocket
-   * aren't ready when the first attempt fires.
-   */
-  private _scheduleInitialResize() {
-    if (this._initialResizeTimer) return
-    let attempts = 0
-    const MAX_ATTEMPTS = 40 // 40 × 50ms = 2s max
-    this._initialResizeTimer = setInterval(() => {
-      attempts++
-      if (this._destroyed || attempts > MAX_ATTEMPTS) {
-        if (this._initialResizeTimer) {
-          clearInterval(this._initialResizeTimer)
-          this._initialResizeTimer = null
-        }
-        return
+  private _sendResize(cols: number, rows: number): boolean {
+    const resizeMsg: ClientMsg = { type: 'resize', cols, rows }
+    if (this._transport) {
+      if (!this._transportConnected) return false
+      this._transport.send(resizeMsg)
+    } else if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(resizeMsg))
+    } else {
+      return false
+    }
+    this._lastSentCols = cols
+    this._lastSentRows = rows
+    return true
+  }
+
+  private _wrapperChanged(): boolean {
+    if (!this._wrapper) return false
+    const r = this._wrapper.getBoundingClientRect()
+    return Math.round(r.width) !== this._authWrapperW || Math.round(r.height) !== this._authWrapperH
+  }
+
+  private _followPeerResize(cols: number, rows: number) {
+    if (this._destroyed || !this.xterm || !this.fitAddon) return
+    if (cols < 2 || rows < 2) return
+    if (this._refitRaf) {
+      cancelAnimationFrame(this._refitRaf)
+      this._refitRaf = 0
+    }
+    if (this._resizeDebounce) {
+      clearTimeout(this._resizeDebounce)
+      this._resizeDebounce = 0
+    }
+    for (const h of this._settleTimeouts) clearTimeout(h)
+    this._settleTimeouts = []
+    if (this._settleRaf) {
+      cancelAnimationFrame(this._settleRaf)
+      this._settleRaf = 0
+    }
+    this._settleGeneration++
+    try {
+      this.xterm.resize(cols, rows)
+    } catch {
+      return
+    }
+    const heightChanged = rows !== this._lastRows
+    this._lastCols = cols
+    this._lastRows = rows
+    if (heightChanged && !this.isMouseModeEnabled()) this.xterm.scrollToBottom()
+    const gen = ++this._peerFollowGen
+    this._followingPeer = true
+    this._pendingLocalRefit = false
+    const rect = this._wrapper?.getBoundingClientRect()
+    this._authWrapperW = rect ? Math.round(rect.width) : 0
+    this._authWrapperH = rect ? Math.round(rect.height) : 0
+    if (this._peerFollowTimer) {
+      clearTimeout(this._peerFollowTimer)
+      this._peerFollowTimer = null
+    }
+    this._peerFollowTimer = window.setTimeout(() => {
+      this._peerFollowTimer = null
+      if (this._destroyed || gen !== this._peerFollowGen) return
+      this._followingPeer = false
+      if (this._pendingLocalRefit) {
+        this._pendingLocalRefit = false
+        this._doFitAndResize(true)
       }
-      // If we've already sent a resize (lastCols/lastRows are non-zero), stop.
-      if (this._lastCols > 0 && this._lastRows > 0) {
-        clearInterval(this._initialResizeTimer!)
-        this._initialResizeTimer = null
-        return
+    }, 500) as unknown as ReturnType<typeof setTimeout>
+  }
+
+  private _settleRefit(): { cols: number; rows: number } | null {
+    if (this._followingPeer) {
+      if (this._wrapperChanged()) this._pendingLocalRefit = true
+      return null
+    }
+    if (this._destroyed || !this.fitAddon || !this.xterm || !this._wrapper) return null
+    const rect = this._wrapper.getBoundingClientRect()
+    if (rect.width === 0 || rect.height === 0) return null
+    try {
+      this.fitAddon.fit()
+    } catch {
+      return null
+    }
+    const cols = this.xterm.cols
+    const rows = this.xterm.rows
+    if (cols < 2 || rows < 2) return null
+    const heightChanged = rows !== this._lastRows
+    this._lastCols = cols
+    this._lastRows = rows
+    if (heightChanged && !this.isMouseModeEnabled()) {
+      this.xterm.scrollToBottom()
+    }
+    if (cols !== this._lastSentCols || rows !== this._lastSentRows) {
+      if (this._resizeDebounce) {
+        clearTimeout(this._resizeDebounce)
+        this._resizeDebounce = 0
       }
-      this._doFitAndResize(true)
-    }, 50)
+      this._sendResize(cols, rows)
+    }
+    return { cols, rows }
+  }
+
+  private _scheduleSettleResize() {
+    for (const h of this._settleTimeouts) clearTimeout(h)
+    this._settleTimeouts = []
+    if (this._settleRaf) cancelAnimationFrame(this._settleRaf)
+    this._settleRaf = 0
+    const generation = ++this._settleGeneration
+    const sample = () => {
+      if (this._destroyed || generation !== this._settleGeneration) return
+      this._settleRefit()
+    }
+    this._settleRaf = requestAnimationFrame(() => {
+      this._settleRaf = 0
+      sample()
+    })
+    for (const delay of [50, 120, 250, 450, 700]) {
+      this._settleTimeouts.push(setTimeout(sample, delay))
+    }
   }
 
   private _doFitAndResize(force = false) {
+    if (this._followingPeer) {
+      if (this._wrapperChanged()) this._pendingLocalRefit = true
+      return
+    }
     if (!this.fitAddon || !this.xterm || !this._wrapper) return
     const rect = this._wrapper.getBoundingClientRect()
     if (rect.width === 0 || rect.height === 0) return
@@ -1006,23 +1135,13 @@ export class TerminalInstance {
     if (heightChanged && !this.isMouseModeEnabled()) {
       this.xterm.scrollToBottom()
     }
-    const sendResize = () => {
-      const resizeMsg: ClientMsg = { type: 'resize', cols, rows }
-      if (this._transport) {
-        this._transport.send(resizeMsg)
-      } else if (this.ws && this.ws.readyState === WebSocket.OPEN) {
-        this.ws.send(JSON.stringify(resizeMsg))
-      }
-    }
     if (force) {
-      // Initial resize: send immediately
-      sendResize()
+      this._sendResize(cols, rows)
     } else {
-      // Debounce: coalesce rapid resize events during window drag
       if (this._resizeDebounce) clearTimeout(this._resizeDebounce)
       this._resizeDebounce = window.setTimeout(() => {
         this._resizeDebounce = 0
-        sendResize()
+        this._sendResize(cols, rows)
       }, 25)
     }
   }

--- a/frontend/src/composables/useTransport.ts
+++ b/frontend/src/composables/useTransport.ts
@@ -141,6 +141,14 @@ export class TauriIpcTransport implements Transport {
       })
     )
     this._unlistenFns.push(
+      await listen('pty-resize', (e: any) => {
+        const p = e.payload
+        if (p.pane_id === this.paneId) {
+          this._messageHandler?.({ type: 'resize', cols: p.cols, rows: p.rows })
+        }
+      })
+    )
+    this._unlistenFns.push(
       await listen('pty-exit', (e: any) => {
         if (e.payload.pane_id === this.paneId) {
           this._disconnectHandler?.()

--- a/frontend/src/types/protocol.ts
+++ b/frontend/src/types/protocol.ts
@@ -27,12 +27,18 @@ export interface ReconnectedMsg {
   rows: number
 }
 
+export interface ResizeServerMsg {
+  type: 'resize'
+  cols: number
+  rows: number
+}
+
 export interface SessionExitMsg {
   type: 'session_exit'
   pane_id: string
 }
 
-export type ServerMsg = OutputMsg | ShellInfoMsg | ReconnectedMsg | SessionExitMsg
+export type ServerMsg = OutputMsg | ShellInfoMsg | ReconnectedMsg | ResizeServerMsg | SessionExitMsg
 
 // Sync WS messages
 export interface SyncTabList {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,6 +1,6 @@
 use base64::Engine;
 use dinotty_server::pty;
-use dinotty_server::session::{SessionManager, SessionStatus, SyncMsg};
+use dinotty_server::session::{SessionClientEvent, SessionManager, SessionStatus, SyncMsg};
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
 use std::sync::{Arc, OnceLock};
@@ -20,6 +20,13 @@ struct PtyOutput {
 }
 
 #[derive(Clone, Serialize)]
+struct PtyResize {
+    pane_id: String,
+    cols: u16,
+    rows: u16,
+}
+
+#[derive(Clone, Serialize)]
 struct PtyExit {
     pane_id: String,
 }
@@ -29,28 +36,57 @@ fn spawn_tauri_output_forwarder(
     pane_id: String,
     session: Arc<dinotty_server::session::Session>,
 ) {
-    let mut rx = session.add_client();
+    let (client_id, mut rx) = session.add_client();
+    *session.tauri_client_id.lock().unwrap_or_else(|e| e.into_inner()) = Some(client_id);
+    let fwd_session = Arc::clone(&session);
     // Use a dedicated OS thread instead of tokio async task.
     // app.emit() may block when the WKWebView IPC queue is full — if this
     // happened on a tokio worker thread it would freeze the entire runtime,
     // killing all terminals and the embedded Axum server.
-    std::thread::Builder::new()
+    match std::thread::Builder::new()
         .name(format!("fwd-{}", pane_id))
         .spawn(move || {
-            while let Some(first) = rx.blocking_recv() {
-                let mut batch = first;
-                while let Ok(data) = rx.try_recv() {
-                    batch.push_str(&data);
-                }
-                if app
-                    .emit("pty-output", PtyOutput { pane_id: pane_id.clone(), data: batch })
-                    .is_err()
-                {
-                    break;
+            let mut pending = None;
+            while let Some(event) = pending.take().or_else(|| rx.blocking_recv()) {
+                match event {
+                    SessionClientEvent::Output(mut batch) => {
+                        loop {
+                            match rx.try_recv() {
+                                Ok(SessionClientEvent::Output(data)) => batch.push_str(&data),
+                                Ok(event @ SessionClientEvent::Resize { .. }) => {
+                                    pending = Some(event);
+                                    break;
+                                }
+                                Err(_) => break,
+                            }
+                        }
+                        if app
+                            .emit("pty-output", PtyOutput { pane_id: pane_id.clone(), data: batch })
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
+                    SessionClientEvent::Resize { cols, rows } => {
+                        if app
+                            .emit("pty-resize", PtyResize { pane_id: pane_id.clone(), cols, rows })
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
                 }
             }
+            fwd_session.remove_client(client_id);
+            fwd_session.clear_tauri_client_if(client_id);
         })
-        .ok();
+    {
+        Ok(_) => {}
+        Err(_) => {
+            session.remove_client(client_id);
+            session.clear_tauri_client_if(client_id);
+        }
+    }
 }
 
 /// Spawn a dedicated write task for the session that reads from the input channel
@@ -127,8 +163,12 @@ fn pty_spawn(
                 *g = Some(Arc::clone(&exit_cb));
             }
         }
-        // Clear old output forwarders to prevent duplicate output on reconnection
-        session.clear_clients();
+        // Remove only the prior Tauri forwarder; WebSocket clients remain attached.
+        if let Some(client_id) =
+            session.tauri_client_id.lock().unwrap_or_else(|e| e.into_inner()).take()
+        {
+            session.remove_client(client_id);
+        }
         emit_join_sync(&app, &pane_id, &session);
         spawn_tauri_output_forwarder(app.clone(), pane_id.clone(), Arc::clone(&session));
         // Set up channel-based write task (replaces old input channel, if any)
@@ -178,7 +218,12 @@ fn pty_resize(
     let session = sessions.get(&pane_id).ok_or("session not found")?;
     // Use debounced resize to coalesce rapid resize events (e.g. window drag)
     // and avoid blocking the Tauri command thread on the screen mutex.
-    session.resize_debounced(cols, rows);
+    let origin_id = session
+        .tauri_client_id
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .ok_or("tauri client not connected")?;
+    session.resize_debounced(origin_id, cols, rows);
     Ok(())
 }
 

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -177,6 +177,8 @@ pub fn create_session(
         ssh_params: None,
         screen: std::sync::Mutex::new(VirtualScreen::new(80, 24)),
         clients: std::sync::Mutex::new(Vec::new()),
+        next_client_id: std::sync::atomic::AtomicU64::new(1),
+        tauri_client_id: std::sync::Mutex::new(None),
         input_tx: std::sync::Mutex::new(None),
         status: std::sync::Mutex::new(SessionStatus::Connected),
         size: std::sync::Mutex::new((80, 24)),
@@ -211,16 +213,19 @@ pub fn create_session(
                 if rx.changed().await.is_err() {
                     break;
                 }
+                let pending = *rx.borrow_and_update();
                 tokio::time::sleep(std::time::Duration::from_millis(25)).await;
-                let size = *rx.borrow_and_update();
-                if let Some((cols, rows)) = size {
-                    if let Some(session) = session_weak.upgrade() {
-                        let _ = tokio::task::spawn_blocking(move || {
-                            let _ = session.resize(cols, rows);
-                        })
-                        .await;
-                    } else {
-                        break;
+                let latest = *rx.borrow();
+                if latest == pending {
+                    if let Some((origin, cols, rows)) = pending {
+                        if let Some(session) = session_weak.upgrade() {
+                            let _ = tokio::task::spawn_blocking(move || {
+                                session.apply_and_broadcast_resize(origin, cols, rows);
+                            })
+                            .await;
+                        } else {
+                            break;
+                        }
                     }
                 }
             }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -9,7 +9,7 @@ use std::{
     io::Write,
     path::{Path, PathBuf},
     sync::{
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
         Arc, Mutex,
     },
     time::Instant,
@@ -77,13 +77,25 @@ pub struct PendingCommandResult {
     pub method: String,
 }
 
+pub enum SessionClientEvent {
+    Output(String),
+    Resize { cols: u16, rows: u16 },
+}
+
+pub struct ClientEndpoint {
+    pub id: u64,
+    pub tx: mpsc::Sender<SessionClientEvent>,
+}
+
 pub struct Session {
     /// 传输后端（本地 PTY 或 SSH）
     pub backend: tokio::sync::Mutex<SessionBackend>,
     /// SSH 会话参数（分屏时复用），None 表示本地会话
     pub ssh_params: Option<SshSessionParams>,
     pub screen: Mutex<VirtualScreen>,
-    pub clients: Mutex<Vec<mpsc::Sender<String>>>,
+    pub clients: Mutex<Vec<ClientEndpoint>>,
+    pub next_client_id: AtomicU64,
+    pub tauri_client_id: Mutex<Option<u64>>,
     pub input_tx: Mutex<Option<mpsc::UnboundedSender<String>>>,
     pub status: Mutex<SessionStatus>,
     pub size: Mutex<(u16, u16)>,
@@ -100,7 +112,7 @@ pub struct Session {
     /// Running byte count of `sync_buffer` to avoid O(n) sum on every broadcast
     pub sync_buffer_bytes: AtomicUsize,
     /// Sender for debounced resize requests (None = no pending resize)
-    pub(crate) resize_tx: watch::Sender<Option<(u16, u16)>>,
+    pub(crate) resize_tx: watch::Sender<Option<(u64, u16, u16)>>,
     /// Channel to send commands (input/resize/close) to the SSH reader task.
     /// None for local sessions.
     pub ssh_cmd_tx: Mutex<Option<mpsc::UnboundedSender<SshCmd>>>,
@@ -300,9 +312,51 @@ impl Session {
     /// Debounced resize: coalesces rapid calls (e.g. window drag) and applies
     /// the latest size after a 25ms quiet period. Ensures the final resize is
     /// always applied even if no further calls arrive.
-    pub fn resize_debounced(&self, cols: u16, rows: u16) {
+    pub fn resize_debounced(&self, origin_id: u64, cols: u16, rows: u16) {
         tracing::debug!("resize_debounced: {cols}x{rows}");
-        let _ = self.resize_tx.send(Some((cols, rows)));
+        let _ = self.resize_tx.send(Some((origin_id, cols, rows)));
+    }
+
+    pub fn resize_from(&self, origin_id: u64, cols: u16, rows: u16) {
+        let mut clients = self.clients.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        clients.retain(|client| !client.tx.is_closed());
+        if !clients.iter().any(|client| client.id == origin_id) {
+            return; // stale/removed origin - do not echo back
+        }
+        for client in clients.iter().filter(|client| client.id != origin_id) {
+            if client.tx.try_send(SessionClientEvent::Resize { cols, rows }).is_err() {
+                tracing::debug!("broadcast: client channel full, dropping resize {cols}x{rows}");
+            }
+        }
+    }
+
+    pub fn apply_and_broadcast_resize(&self, origin_id: u64, cols: u16, rows: u16) {
+        {
+            let mut clients =
+                self.clients.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            clients.retain(|client| !client.tx.is_closed());
+            if !clients.iter().any(|client| client.id == origin_id) {
+                return;
+            }
+        }
+        if self.resize(cols, rows).is_err() {
+            return;
+        }
+        let mut clients = self.clients.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        clients.retain(|client| !client.tx.is_closed());
+        for client in clients.iter().filter(|client| client.id != origin_id) {
+            if client.tx.try_send(SessionClientEvent::Resize { cols, rows }).is_err() {
+                tracing::debug!("broadcast: client channel full, dropping resize {cols}x{rows}");
+            }
+        }
+    }
+
+    pub fn clear_tauri_client_if(&self, id: u64) {
+        let mut tauri_client_id =
+            self.tauri_client_id.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        if *tauri_client_id == Some(id) {
+            *tauri_client_id = None;
+        }
     }
 
     pub fn on_pty_output(&self, data: &[u8]) {
@@ -323,28 +377,32 @@ impl Session {
         rx
     }
 
-    pub fn add_client(&self) -> mpsc::Receiver<String> {
+    pub fn add_client(&self) -> (u64, mpsc::Receiver<SessionClientEvent>) {
         // Bounded channel with non-blocking try_send: messages are dropped when
         // full rather than blocking the PTY reader. Keeps the shell responsive.
         let (tx, rx) = mpsc::channel(10240);
-        self.clients.lock().unwrap_or_else(std::sync::PoisonError::into_inner).push(tx);
-        rx
+        let id = self.next_client_id.fetch_add(1, Ordering::Relaxed);
+        self.clients
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(ClientEndpoint { id, tx });
+        (id, rx)
     }
 
-    /// Remove all existing clients so old forwarder tasks exit cleanly.
-    /// Must be called before `add_client` on reconnection to prevent
-    /// duplicate output delivery.
-    pub fn clear_clients(&self) {
-        self.clients.lock().unwrap_or_else(std::sync::PoisonError::into_inner).clear();
+    pub fn remove_client(&self, id: u64) {
+        self.clients
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .retain(|client| client.id != id);
     }
 
     /// Send a chunk to all clients via non-blocking `try_send`.
     /// Channel-full messages are dropped (not the client) to keep the PTY reader
     /// non-blocking. Closed channels are pruned.
-    fn send_chunk_to_clients(clients: &mut Vec<mpsc::Sender<String>>, chunk: &str) {
-        clients.retain(|tx| !tx.is_closed());
-        for tx in clients.iter() {
-            if tx.try_send(chunk.to_string()).is_err() {
+    fn send_chunk_to_clients(clients: &mut Vec<ClientEndpoint>, chunk: &str) {
+        clients.retain(|client| !client.tx.is_closed());
+        for client in clients.iter() {
+            if client.tx.try_send(SessionClientEvent::Output(chunk.to_string())).is_err() {
                 tracing::debug!(
                     "broadcast: client channel full, dropping chunk ({}B)",
                     chunk.len()
@@ -419,7 +477,7 @@ impl Session {
 
     pub fn has_clients(&self) -> bool {
         let mut clients = self.clients.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-        clients.retain(|tx| !tx.is_closed());
+        clients.retain(|client| !client.tx.is_closed());
         !clients.is_empty()
     }
 }

--- a/src/ssh/mod.rs
+++ b/src/ssh/mod.rs
@@ -315,6 +315,8 @@ pub async fn create_ssh_session(
         ssh_params: Some(params.clone()),
         screen: std::sync::Mutex::new(VirtualScreen::new(80, 24)),
         clients: std::sync::Mutex::new(Vec::new()),
+        next_client_id: std::sync::atomic::AtomicU64::new(1),
+        tauri_client_id: std::sync::Mutex::new(None),
         input_tx: std::sync::Mutex::new(None),
         status: std::sync::Mutex::new(SessionStatus::Connected),
         size: std::sync::Mutex::new((80, 24)),
@@ -541,7 +543,7 @@ async fn ssh_reader_task(
 /// the drag stops (no new values for 300ms) do we apply the final size.
 async fn resize_debounce_task(
     session: Arc<Session>,
-    mut resize_rx: watch::Receiver<Option<(u16, u16)>>,
+    mut resize_rx: watch::Receiver<Option<(u64, u16, u16)>>,
     pane_id: String,
 ) {
     loop {
@@ -549,14 +551,16 @@ async fn resize_debounce_task(
             break;
         }
         let size = *resize_rx.borrow();
-        if let Some((cols, rows)) = size {
+        if let Some((origin, cols, rows)) = size {
             tokio::time::sleep(Duration::from_millis(300)).await;
             let latest = *resize_rx.borrow();
-            if latest == Some((cols, rows)) {
+            if latest == Some((origin, cols, rows)) {
                 debug!("SSH resize debounce: applying {cols}x{rows}, pane={pane_id}");
-                if let Err(e) = session.resize_async(cols, rows).await {
-                    error!("SSH resize failed: {}, pane={}", e, pane_id);
-                }
+                let session = Arc::clone(&session);
+                let _ = tokio::task::spawn_blocking(move || {
+                    session.apply_and_broadcast_resize(origin, cols, rows);
+                })
+                .await;
             }
         }
     }
@@ -621,7 +625,7 @@ mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    /// Test: borrow() + conditional apply with 300ms debounce.
+    /// Test: `borrow()` + conditional apply with 300ms debounce.
     /// Simulates rapid frontend resize messages during a divider drag,
     /// then verifies only one resize is applied after the drag stops.
     #[tokio::test]
@@ -700,7 +704,7 @@ mod tests {
         });
 
         // Simulate a3-second drag: resize every 25ms, cols from80 to200
-        let total_steps = (3000 / 25) as u16; //120 steps
+        let total_steps = 3000_u16 / 25; //120 steps
         for i in 0..total_steps {
             let cols = 80 + i;
             let _ = tx.send(Some((cols, 24)));
@@ -764,7 +768,7 @@ mod tests {
         println!("Return to original - apply count: {count}, final size: {final_size:?}");
 
         // tmux also applies twice for the "return to original" edge case
-        assert!(count >= 1 && count <= 2, "Expected 1-2 applies, got {count}");
+        assert!((1..=2).contains(&count), "Expected 1-2 applies, got {count}");
         assert_eq!(final_size, Some((100, 24)));
     }
 }

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -20,7 +20,7 @@ use tracing::{error, info};
 
 use crate::history::HistoryState;
 use crate::notification::NotificationBroadcast;
-use crate::session::{SessionManager, SessionStatus, SyncMsg};
+use crate::session::{SessionClientEvent, SessionManager, SessionStatus, SyncMsg};
 use crate::settings::SettingsState;
 use crate::workspace_mgmt::WorkspacesState;
 
@@ -73,6 +73,10 @@ pub enum SyncClientMsg {
 pub enum ServerMsg<'a> {
     Output {
         data: &'a str,
+    },
+    Resize {
+        cols: u16,
+        rows: u16,
     },
     ShellInfo {
         shell_type: &'a str,
@@ -497,13 +501,13 @@ async fn handle_socket(
         // Snapshot screen state and register for broadcast atomically
         // (holding the screen lock prevents PTY output from being both in the
         // snapshot AND queued to the broadcast channel)
-        let (cols, rows, scrollback_chunks, snapshot, mut rx) = {
+        let (cols, rows, scrollback_chunks, snapshot, client_id, mut rx) = {
             let screen = session.screen.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
             let (cols, rows) =
                 *session.size.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
             let chunks = screen.snapshot_scrollback_chunks(200);
             let snap = screen.snapshot();
-            let rx = session.add_client();
+            let (client_id, rx) = session.add_client();
             info!(
                 "Snapshot for pane={}: cols={}, rows={}, scrollback_chunks={}, snapshot_len={}",
                 pane_id,
@@ -512,7 +516,7 @@ async fn handle_socket(
                 chunks.len(),
                 snap.len()
             );
-            (cols, rows, chunks, snap, rx)
+            (cols, rows, chunks, snap, client_id, rx)
         };
 
         // Send reconnected message
@@ -543,9 +547,16 @@ async fn handle_socket(
         let fwd_ws_out_tx = ws_out_tx.clone();
         let fwd_pane = pane_id.clone();
         let fwd = tokio::spawn(async move {
-            while let Some(data) = rx.recv().await {
-                let msg = serde_json::to_string(&ServerMsg::Output { data: &data })
-                    .expect("serialization is infallible");
+            while let Some(event) = rx.recv().await {
+                let msg = match event {
+                    SessionClientEvent::Output(data) => {
+                        serde_json::to_string(&ServerMsg::Output { data: &data })
+                    }
+                    SessionClientEvent::Resize { cols, rows } => {
+                        serde_json::to_string(&ServerMsg::Resize { cols, rows })
+                    }
+                }
+                .expect("serialization is infallible");
                 if fwd_ws_out_tx.send(Message::Text(msg)).is_err() {
                     info!("WS forwarder (reconnect): send failed, exiting pane={}", fwd_pane);
                     break;
@@ -621,7 +632,7 @@ async fn handle_socket(
                         }
                     }
                     Ok(ClientMsg::Resize { cols, rows }) => {
-                        session.resize_debounced(cols, rows);
+                        session.resize_debounced(client_id, cols, rows);
                     }
                     Err(e) => error!("parse msg: {}", e),
                 },
@@ -639,6 +650,7 @@ async fn handle_socket(
         fwd.abort();
         writer_task.abort();
         ping_task.abort();
+        session.remove_client(client_id);
 
         if !session.has_clients() {
             *session.status.lock().unwrap_or_else(std::sync::PoisonError::into_inner) =
@@ -670,7 +682,7 @@ async fn handle_socket(
         }
     };
 
-    let mut rx = session.add_client();
+    let (client_id, mut rx) = session.add_client();
 
     // Send shell info
     let shell_info = serde_json::to_string(&ServerMsg::ShellInfo { shell_type: &shell_type })
@@ -681,9 +693,16 @@ async fn handle_socket(
     let fwd_ws_out_tx = ws_out_tx.clone();
     let fwd_pane = pane_id.clone();
     let fwd = tokio::spawn(async move {
-        while let Some(data) = rx.recv().await {
-            let msg = serde_json::to_string(&ServerMsg::Output { data: &data })
-                .expect("serialization is infallible");
+        while let Some(event) = rx.recv().await {
+            let msg = match event {
+                SessionClientEvent::Output(data) => {
+                    serde_json::to_string(&ServerMsg::Output { data: &data })
+                }
+                SessionClientEvent::Resize { cols, rows } => {
+                    serde_json::to_string(&ServerMsg::Resize { cols, rows })
+                }
+            }
+            .expect("serialization is infallible");
             if fwd_ws_out_tx.send(Message::Text(msg)).is_err() {
                 info!("WS forwarder: send failed, exiting pane={}", fwd_pane);
                 break;
@@ -757,7 +776,7 @@ async fn handle_socket(
                     }
                 }
                 Ok(ClientMsg::Resize { cols, rows }) => {
-                    session.resize_debounced(cols, rows);
+                    session.resize_debounced(client_id, cols, rows);
                 }
                 Err(e) => error!("parse msg: {}", e),
             },
@@ -775,6 +794,7 @@ async fn handle_socket(
     fwd.abort();
     writer_task.abort();
     ping_task.abort();
+    session.remove_client(client_id);
 
     if !session.has_clients() {
         *session.status.lock().unwrap_or_else(std::sync::PoisonError::into_inner) =
@@ -942,15 +962,22 @@ pub async fn handle_open_api_ws(socket: WebSocket, manager: Arc<SessionManager>,
     });
 
     // Register as broadcast client
-    let mut rx = session.add_client();
+    let (client_id, mut rx) = session.add_client();
 
     // Forward broadcast output to WS
     let fwd_ws_out_tx = ws_out_tx.clone();
     let fwd_pane = pane_id.clone();
     let fwd = tokio::spawn(async move {
-        while let Some(data) = rx.recv().await {
-            let msg = serde_json::to_string(&ServerMsg::Output { data: &data })
-                .expect("serialization is infallible");
+        while let Some(event) = rx.recv().await {
+            let msg = match event {
+                SessionClientEvent::Output(data) => {
+                    serde_json::to_string(&ServerMsg::Output { data: &data })
+                }
+                SessionClientEvent::Resize { cols, rows } => {
+                    serde_json::to_string(&ServerMsg::Resize { cols, rows })
+                }
+            }
+            .expect("serialization is infallible");
             if fwd_ws_out_tx.send(Message::Text(msg)).is_err() {
                 info!("WS forwarder (open_api): send failed, exiting pane={}", fwd_pane);
                 break;
@@ -1003,7 +1030,7 @@ pub async fn handle_open_api_ws(socket: WebSocket, manager: Arc<SessionManager>,
                             let _ = pty_in_tx.send(data);
                         }
                         ClientMsg::Resize { cols, rows } => {
-                            session.resize_debounced(cols, rows);
+                            session.resize_debounced(client_id, cols, rows);
                         }
                     }
                 }
@@ -1019,6 +1046,7 @@ pub async fn handle_open_api_ws(socket: WebSocket, manager: Arc<SessionManager>,
     fwd.abort();
     writer_task.abort();
     ping_task.abort();
+    session.remove_client(client_id);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem
After a hard reload (e.g. the desktop app's refresh button = full page reload), the
terminal's cols×rows no longer match the window — content is misaligned/underfilled and
only snaps back after a manual window drag triggers a real ResizeObserver pixel change.
Under WKWebView the post-reload layout settles in stages, so the existing
stop-on-first-non-zero fit poll can capture a transitional size and report it as final.

## Fix
**Part 1 — frontend fit convergence (`useTerminal.ts`)**
Replace the stop-on-first-non-zero initial-resize poll with a bounded settle ladder
(rAF + 50/120/250/450/700ms). Each sample re-fits and, via a single wire-send owner with
an explicit last-sent tracker, only sends when the stable cols×rows actually changed — so
a hard reload converges to the correct grid without a manual drag, while already-correct
ends stay no-op (zero extra traffic on web).

**Part 2 — cross-client resize follow (backend + wiring)**
Broadcast each applied resize to the session's other clients so every end follows the
refreshing end (whichever end refreshes wins — shared-terminal WYSIWYG). Adds
server-assigned per-client endpoint ids, `apply_and_broadcast_resize` (origin validated as
still-registered before the PTY apply, self excluded from broadcast), a new
`ServerMsg::Resize` variant with typed WS/Tauri forwarders, and Tauri per-pane client-id
lifecycle (exit / spawn-failure conditionally clear the stored id).

## Testing
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo test`: 184 passed / 0 failed
- frontend `npm run lint` (no new errors) + `npm run build`: pass
- Real-device: desktop app refresh now aligns immediately (no drag); web unchanged;
  two connected clients — refreshing one makes the other follow its size.

## Notes
Part 2 changes the wire protocol (adds `ServerMsg::Resize` + per-client ids). Happy to
split into two PRs (Part 1 bug-fix / Part 2 follow feature) if you'd prefer to review them
separately.
