### PR TITLE
feat(settings): expand collapsible settings sections by default

### DIFF
--- a/frontend/src/components/settings/AppearanceTab.vue
+++ b/frontend/src/components/settings/AppearanceTab.vue
@@ -38,7 +38,7 @@
       </div>
     </div>
 
-    <CollapsibleSection :title="t('settings.customColors')" level="group">
+    <CollapsibleSection :title="t('settings.customColors')" level="group" default-open>
       <p class="settings-hint">{{ t('settings.customColorsHint') }}</p>
       <div class="custom-colors-grid">
         <label class="color-field">

--- a/frontend/src/components/settings/GeneralTab.vue
+++ b/frontend/src/components/settings/GeneralTab.vue
@@ -402,7 +402,7 @@
       </section>
     </div>
 
-    <CollapsibleSection :title="t('settings.log')" level="group">
+    <CollapsibleSection :title="t('settings.log')" level="group" default-open>
       <section class="settings-section">
         <div class="settings-row">
           <label>{{ t('settings.log.enabled') }}</label>

--- a/frontend/src/components/settings/KeyboardTab.vue
+++ b/frontend/src/components/settings/KeyboardTab.vue
@@ -35,7 +35,7 @@
           </div>
         </div>
 
-        <CollapsibleSection :title="t('keybinding.group.pane')" level="section">
+        <CollapsibleSection :title="t('keybinding.group.pane')" level="section" default-open>
           <div
             v-for="def in paneDefs"
             :key="def.id"
@@ -57,7 +57,7 @@
           </div>
         </CollapsibleSection>
 
-        <CollapsibleSection :title="t('keybinding.group.nav')" level="section">
+        <CollapsibleSection :title="t('keybinding.group.nav')" level="section" default-open>
           <div
             v-for="def in navDefs"
             :key="def.id"
@@ -79,7 +79,7 @@
           </div>
         </CollapsibleSection>
 
-        <CollapsibleSection :title="t('keybinding.group.font')" level="section">
+        <CollapsibleSection :title="t('keybinding.group.font')" level="section" default-open>
           <div
             v-for="def in fontDefs"
             :key="def.id"
@@ -155,7 +155,7 @@
       </div>
     </div>
 
-    <CollapsibleSection :title="t('settings.actionKeyboard')" level="group">
+    <CollapsibleSection :title="t('settings.actionKeyboard')" level="group" default-open>
       <p class="settings-hint">{{ t('settings.akHint') }}</p>
       <div class="ak-wysiwyg">
         <div v-for="(row, ri) in actionRows" :key="ri" class="ak-wyg-row-outer">
@@ -294,7 +294,7 @@
       </div>
     </div>
 
-    <CollapsibleSection :title="t('settings.keyboard.openApi')" level="group">
+    <CollapsibleSection :title="t('settings.keyboard.openApi')" level="group" default-open>
       <p class="settings-hint">{{ t('settings.keyboard.openApiHint') }}</p>
       <div class="settings-row">
         <label>{{ t('settings.keyboard.openApiEnabled') }}</label>

--- a/frontend/src/components/settings/NotificationTab.vue
+++ b/frontend/src/components/settings/NotificationTab.vue
@@ -94,7 +94,7 @@
       </div>
     </div>
 
-    <CollapsibleSection :title="t('notification.hooks')" level="group">
+    <CollapsibleSection :title="t('notification.hooks')" level="group" default-open>
       <p class="hook-hint">{{ t('notification.hookEnvHint') }}</p>
       <div v-for="(hook, idx) in cfg.hooks" :key="idx" class="hook-row">
         <label class="toggle toggle-sm">
@@ -124,7 +124,7 @@
       </button>
     </CollapsibleSection>
 
-    <CollapsibleSection :title="t('notification.test')" level="group">
+    <CollapsibleSection :title="t('notification.test')" level="group" default-open>
       <div class="api-test">
         <div class="api-method-row">
           <span class="method-badge">POST</span>


### PR DESCRIPTION
## What

Add `default-open` to the collapsible settings sections that currently start collapsed, so they open expanded by default.

Sections now expanded by default:
- Appearance → Custom colors
- Keyboard → Pane / Nav / Font / Action keyboard / Open API
- Notification → Hooks / Test
- General → Log

## Why

With most sections collapsed by default, users have to click into each one to discover what settings exist. Opening them by default makes the available options immediately visible while the collapse toggles remain for users who prefer a compact view.

## Scope / deliberately unchanged

- **Advanced security** (General) stays collapsed — it holds lower-frequency, higher-risk options that are better kept tucked away.
- **Files & folders** (General) and **Notification triggers** already default to open; left as-is.

## Verification

- `pnpm build` (`vue-tsc -b && vite build`) passes clean.
- Change is template-only: adds the existing `default-open` prop already supported by `CollapsibleSection`; no logic or component changes.