### PR TITLE
fix(workspace): restore delete on macOS by replacing native confirm() with in-app modal

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -168,6 +168,16 @@
     <ConfirmCloseDialog @confirm="onConfirmClose" />
 
     <ConfirmModal
+      :visible="confirmState.visible"
+      :title="confirmState.title"
+      :message="confirmState.message"
+      :confirm-text="confirmState.confirmText"
+      :cancel-text="confirmState.cancelText"
+      @confirm="confirmResolve"
+      @cancel="confirmCancel"
+    />
+
+    <ConfirmModal
       :visible="windowCloseConfirmVisible"
       :title="t('confirm.closeWindowTitle')"
       :message="t('confirm.closeWindowMessage')"
@@ -241,6 +251,7 @@ import KbToggleButton from './components/keyboard/KbToggleButton.vue'
 import SettingsPanel from './components/SettingsPanel.vue'
 import ConfirmCloseDialog from './components/ui/ConfirmCloseDialog.vue'
 import ConfirmModal from './components/ui/ConfirmModal.vue'
+import { confirmState, uiConfirm, confirmResolve, confirmCancel } from './composables/useConfirm'
 import PreviewPanel from './components/preview/PreviewPanel.vue'
 import CommandBookmarks from './components/command/CommandBookmarks.vue'
 import ServerList from './components/ServerList.vue'
@@ -1160,7 +1171,7 @@ window.__dinotty_ui_notify = (message: string, level?: 'info' | 'warn' | 'error'
   if (level === 'error') console.error('[plugin]', message)
   else console.log('[plugin]', message)
 }
-window.__dinotty_ui_confirm = async (message: string) => window.confirm(message)
+window.__dinotty_ui_confirm = (message: string) => uiConfirm(message)
 window.__dinotty_open_plugin = openPlugin
 
 const paletteCommands = computed<Command[]>(() => {

--- a/frontend/src/components/overview/WorkspaceList.vue
+++ b/frontend/src/components/overview/WorkspaceList.vue
@@ -46,6 +46,7 @@
 import { ref } from 'vue'
 import { Plus, Pencil, Trash2 } from 'lucide-vue-next'
 import { useI18n } from '../../composables/useI18n'
+import { uiConfirm } from '../../composables/useConfirm'
 import { useWorkspaces } from '../../composables/useWorkspaces'
 import type { Workspace } from '../../types/workspace'
 import ContextMenu from '../ui/ContextMenu.vue'
@@ -89,7 +90,11 @@ function openCtx(e: MouseEvent, ws: Workspace) {
       icon: Trash2,
       danger: true,
       action: async () => {
-        if (!confirm(t('workspace.confirmDelete').replace('{name}', ws.name))) return
+        if (!(await uiConfirm(t('workspace.confirmDelete').replace('{name}', ws.name), {
+          title: t('workspace.delete'),
+          confirmText: t('workspace.delete'),
+          cancelText: t('filePreview.cancel'),
+        }))) return
         try {
           await deleteWorkspace(ws.id)
         } catch (err) {

--- a/frontend/src/components/overview/WorkspaceListView.vue
+++ b/frontend/src/components/overview/WorkspaceListView.vue
@@ -72,6 +72,7 @@ import { ref } from 'vue'
 import { Motion } from 'motion-v'
 import { Plus, Pencil, Trash2, X } from 'lucide-vue-next'
 import { useI18n } from '../../composables/useI18n'
+import { uiConfirm } from '../../composables/useConfirm'
 import { useWorkspaces } from '../../composables/useWorkspaces'
 import type { Workspace } from '../../types/workspace'
 import ContextMenu from '../ui/ContextMenu.vue'
@@ -115,7 +116,11 @@ function showCtx(ws: Workspace, x: number, y: number) {
       icon: Trash2,
       danger: true,
       action: async () => {
-        if (!confirm(t('workspace.confirmDelete').replace('{name}', ws.name))) return
+        if (!(await uiConfirm(t('workspace.confirmDelete').replace('{name}', ws.name), {
+          title: t('workspace.delete'),
+          confirmText: t('workspace.delete'),
+          cancelText: t('filePreview.cancel'),
+        }))) return
         try {
           await deleteWorkspace(ws.id)
         } catch (err) {

--- a/frontend/src/components/overview/WorkspaceOverview.vue
+++ b/frontend/src/components/overview/WorkspaceOverview.vue
@@ -74,6 +74,7 @@ import { Motion, AnimatePresence } from 'motion-v'
 import { Plus, X } from 'lucide-vue-next'
 import { useWorkspaces } from '../../composables/useWorkspaces'
 import { useI18n } from '../../composables/useI18n'
+import { uiConfirm } from '../../composables/useConfirm'
 import { useSessionStore } from '../../stores/sessionStore'
 import { useNotification } from '../../composables/useNotification'
 import { useTabPreview, type TabCard } from '../../composables/useTabPreview'
@@ -322,8 +323,14 @@ function onKeydown(e: KeyboardEvent) {
         const wsId = selectedWorkspaceId.value
         if (wsId !== null && wsId !== '__all__') {
           const ws = workspaces.value.find((w) => w.id === wsId)
-          if (ws && confirm(`${t('workspace.delete')} "${ws.name}"?`)) {
-            deleteWorkspace(wsId).catch((e) => console.error('Failed to delete workspace:', e))
+          if (ws) {
+            uiConfirm(t('workspace.confirmDelete').replace('{name}', ws.name), {
+              title: t('workspace.delete'),
+              confirmText: t('workspace.delete'),
+              cancelText: t('filePreview.cancel'),
+            }).then((ok) => {
+              if (ok) deleteWorkspace(wsId).catch((e) => console.error('Failed to delete workspace:', e))
+            })
           }
         }
       }

--- a/frontend/src/components/settings/GeneralTab.vue
+++ b/frontend/src/components/settings/GeneralTab.vue
@@ -468,6 +468,7 @@ import { Eye, EyeOff, Copy, Check, Pencil, RefreshCw, Save, X, FolderOpen } from
 import { invoke } from '@tauri-apps/api/core'
 import { useSettings } from '../../composables/useSettings'
 import { useI18n } from '../../composables/useI18n'
+import { uiConfirm } from '../../composables/useConfirm'
 import CollapsibleSection from './CollapsibleSection.vue'
 import { copyToClipboard } from '../../utils/clipboard'
 import { useToast } from 'vue-toastification'
@@ -726,7 +727,11 @@ async function saveToken() {
 }
 
 async function regenerateToken() {
-  if (!confirm(t('settings.token.confirmRegenerate'))) return
+  if (!(await uiConfirm(t('settings.token.confirmRegenerate'), {
+    title: t('settings.token.regenerate'),
+    confirmText: t('settings.token.regenerate'),
+    cancelText: t('filePreview.cancel'),
+  }))) return
   const buf = new Uint8Array(32)
   crypto.getRandomValues(buf)
   const token = Array.from(buf)

--- a/frontend/src/composables/useConfirm.ts
+++ b/frontend/src/composables/useConfirm.ts
@@ -1,0 +1,52 @@
+import { reactive } from 'vue'
+
+type ConfirmOptions = {
+  title?: string
+  confirmText?: string
+  cancelText?: string
+}
+
+export const confirmState = reactive<{
+  visible: boolean
+  title: string
+  message: string
+  confirmText: string
+  cancelText: string
+  resolve: ((ok: boolean) => void) | null
+}>({
+  visible: false,
+  title: '',
+  message: '',
+  confirmText: 'OK',
+  cancelText: 'Cancel',
+  resolve: null,
+})
+
+function settle(ok: boolean) {
+  const resolve = confirmState.resolve
+  confirmState.visible = false
+  confirmState.resolve = null
+  resolve?.(ok)
+}
+
+export function uiConfirm(message: string, opts: ConfirmOptions = {}): Promise<boolean> {
+  if (confirmState.resolve) settle(false)
+
+  confirmState.title = opts.title ?? ''
+  confirmState.message = message
+  confirmState.confirmText = opts.confirmText ?? 'OK'
+  confirmState.cancelText = opts.cancelText ?? 'Cancel'
+  confirmState.visible = true
+
+  return new Promise<boolean>((resolve) => {
+    confirmState.resolve = resolve
+  })
+}
+
+export function confirmResolve() {
+  settle(true)
+}
+
+export function confirmCancel() {
+  settle(false)
+}

--- a/frontend/src/composables/useFileOperations.ts
+++ b/frontend/src/composables/useFileOperations.ts
@@ -1,5 +1,6 @@
 import { ref, computed, type Ref } from 'vue'
 import { getApiBase, apiUrl, authFetch, getAuthToken } from './apiBase'
+import { uiConfirm } from './useConfirm'
 import { isTauri, tauriInvoke } from './useTransport'
 import { isInternalDragActive, getInternalDragRel, clearInternalDrag } from './internalDragState'
 import type { DirEntry } from '../components/workspace/TreeRows'
@@ -357,7 +358,11 @@ export function useFileOperations(opts: {
     opts.inlineCreate.value = null
     const wasDir = opts.selectedIsDir.value
     const msg = wasDir ? t('filePreview.confirmDeleteFolder') : t('filePreview.confirmDeleteFile')
-    if (!skipConfirm && !confirm(msg)) return false
+    if (!skipConfirm && !(await uiConfirm(msg, {
+      title: t('filePreview.delete'),
+      confirmText: t('filePreview.delete'),
+      cancelText: t('filePreview.cancel'),
+    }))) return false
     await getApiBase()
     const q = new URLSearchParams({ pane_id: opts.paneId(), path: rel })
     if (opts.cwdLabel.value) q.set('cwd', opts.cwdLabel.value)


### PR DESCRIPTION
## Problem
On the macOS desktop build (Tauri v2 / WKWebView), user-created workspaces (partitions) could not be deleted: no confirmation dialog appeared and nothing was deleted. The web build worked normally.

## Root cause
Delete actions gate on the native `window.confirm(...)`:

```js
if (!confirm(...)) return
```

On macOS WKWebView, native `window.confirm()` returns `false` **without showing a dialog**, so the guard always early-returns — no dialog, no deletion. Regular browsers implement `confirm()` normally, so the web build was unaffected.

## Fix
Replace the 5 destructive native `confirm()` sites with a small Promise-based helper (`composables/useConfirm.ts`) that drives the existing pure-Vue `ConfirmModal` component (works in both web and Tauri):

- workspace delete — context menu, mobile long-press, keyboard Delete
- file/folder delete
- regenerate-token confirm
- plugin `__dinotty_ui_confirm` path routed through the same helper

## Verification
- `pnpm build` (vue-tsc + vite) passes
- `cargo tauri build` produces a working macOS app
- Manual E2E on the macOS build: confirmation dialog now appears and deletion succeeds

## Known follow-up (not in this PR)
Two navigation guards still use synchronous native `confirm()` for the "discard unsaved changes" prompt (`useTreeContextMenu.ts`, `FileWorkspacePreview.vue`); they share the same WKWebView limitation but need an async refactor of the guards, so they are left for a separate change.

Frontend-only; no Rust changes.
