### PR TITLE
docs: star history chart, dynamic install, f32 test fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ AGENTS.md
 .pnpm-store/
 .DS_Store
 ghostty-comparison-optimization.md
+.star-cache

--- a/README.en.md
+++ b/README.en.md
@@ -179,7 +179,7 @@ xattr -cr /Applications/Dinotty.app
 **Linux one-liner install**:
 
 ```bash
-curl -LO https://github.com/xichan96/dinotty/releases/download/v0.16.2/dinotty-server_0.16.2-1_amd64.deb && sudo dpkg -i dinotty-server_0.16.2-1_amd64.deb
+VERSION=$(curl -s https://api.github.com/repos/xichan96/dinotty/releases/latest | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | sed 's/^v//') && curl -LO "https://github.com/xichan96/dinotty/releases/download/v${VERSION}/dinotty-server_${VERSION}-1_amd64.deb" && sudo dpkg -i "dinotty-server_${VERSION}-1_amd64.deb"
 ```
 
 **Linux startup**:

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ xattr -cr /Applications/Dinotty.app
 **Linux 一键下载安装**：
 
 ```bash
-curl -LO https://github.com/xichan96/dinotty/releases/download/v0.16.2/dinotty-server_0.16.2-1_amd64.deb && sudo dpkg -i dinotty-server_0.16.2-1_amd64.deb
+VERSION=$(curl -s https://api.github.com/repos/xichan96/dinotty/releases/latest | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | sed 's/^v//') && curl -LO "https://github.com/xichan96/dinotty/releases/download/v${VERSION}/dinotty-server_${VERSION}-1_amd64.deb" && sudo dpkg -i "dinotty-server_${VERSION}-1_amd64.deb"
 ```
 
 **Linux 启动方式**：
@@ -287,7 +287,7 @@ cargo run
 
 ## Star History
 
-[👉 查看 Star History](https://star-history.com/#xichan96/dinotty&Date)
+![Star History](docs/images/star-history.svg)
 
 ## 许可证
 

--- a/docs/images/star-history.svg
+++ b/docs/images/star-history.svg
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 300" width="800" height="300">
+  <defs>
+    <linearGradient id="fill" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FFD700" stop-opacity="0.3"/>
+      <stop offset="100%" stop-color="#FFD700" stop-opacity="0.02"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="300" rx="8" fill="#0d1117"/>
+
+  <!-- Title -->
+  <text x="400.0" y="22" text-anchor="middle" fill="#e6edf3" font-family="system-ui,sans-serif" font-size="14" font-weight="600">
+    Star History - 372 stars
+  </text>
+
+  <!-- Y-axis grid + labels -->
+  <line x1="55" y1="250.0" x2="780" y2="250.0" stroke="#21262d" stroke-width="0.5"/>
+  <text x="47" y="254.0" text-anchor="end" fill="#8b949e" font-family="system-ui,sans-serif" font-size="10">0</text>
+  <line x1="55" y1="208.2" x2="780" y2="208.2" stroke="#21262d" stroke-width="0.5"/>
+  <text x="47" y="212.2" text-anchor="end" fill="#8b949e" font-family="system-ui,sans-serif" font-size="10">74</text>
+  <line x1="55" y1="166.5" x2="780" y2="166.5" stroke="#21262d" stroke-width="0.5"/>
+  <text x="47" y="170.5" text-anchor="end" fill="#8b949e" font-family="system-ui,sans-serif" font-size="10">148</text>
+  <line x1="55" y1="124.1" x2="780" y2="124.1" stroke="#21262d" stroke-width="0.5"/>
+  <text x="47" y="128.1" text-anchor="end" fill="#8b949e" font-family="system-ui,sans-serif" font-size="10">223</text>
+  <line x1="55" y1="82.3" x2="780" y2="82.3" stroke="#21262d" stroke-width="0.5"/>
+  <text x="47" y="86.3" text-anchor="end" fill="#8b949e" font-family="system-ui,sans-serif" font-size="10">297</text>
+  <line x1="55" y1="40.0" x2="780" y2="40.0" stroke="#21262d" stroke-width="0.5"/>
+  <text x="47" y="44.0" text-anchor="end" fill="#8b949e" font-family="system-ui,sans-serif" font-size="10">372</text>
+
+  <!-- Area fill -->
+  <polygon points="55.0,245.5 67.7,242.7 80.4,235.3 93.2,231.4 105.9,230.2 118.6,229.1 131.3,228.0 144.0,227.4 156.8,226.9 169.5,225.7 182.2,225.7 194.9,222.3 207.6,216.7 220.4,212.7 233.1,211.6 245.8,208.2 258.5,206.5 271.2,203.7 283.9,202.0 296.7,199.2 309.4,199.2 322.1,196.9 334.8,193.5 347.5,190.2 360.3,187.3 373.0,186.8 385.7,185.1 398.4,183.4 411.1,182.8 423.9,181.1 436.6,180.0 449.3,178.9 462.0,177.2 474.7,174.9 487.5,174.9 500.2,173.8 512.9,173.2 525.6,172.7 538.3,163.6 551.1,136.0 563.8,125.2 576.5,115.6 589.2,111.7 601.9,101.5 614.6,89.1 627.4,78.4 640.1,69.4 652.8,65.4 665.5,62.0 678.2,58.6 691.0,54.1 703.7,51.9 716.4,49.0 729.1,45.6 741.8,44.0 754.6,43.4 767.3,41.1 780.0,40.0 780.0,250.0 55.0,250.0" fill="url(#fill)"/>
+
+  <!-- Line -->
+  <polyline points="55.0,245.5 67.7,242.7 80.4,235.3 93.2,231.4 105.9,230.2 118.6,229.1 131.3,228.0 144.0,227.4 156.8,226.9 169.5,225.7 182.2,225.7 194.9,222.3 207.6,216.7 220.4,212.7 233.1,211.6 245.8,208.2 258.5,206.5 271.2,203.7 283.9,202.0 296.7,199.2 309.4,199.2 322.1,196.9 334.8,193.5 347.5,190.2 360.3,187.3 373.0,186.8 385.7,185.1 398.4,183.4 411.1,182.8 423.9,181.1 436.6,180.0 449.3,178.9 462.0,177.2 474.7,174.9 487.5,174.9 500.2,173.8 512.9,173.2 525.6,172.7 538.3,163.6 551.1,136.0 563.8,125.2 576.5,115.6 589.2,111.7 601.9,101.5 614.6,89.1 627.4,78.4 640.1,69.4 652.8,65.4 665.5,62.0 678.2,58.6 691.0,54.1 703.7,51.9 716.4,49.0 729.1,45.6 741.8,44.0 754.6,43.4 767.3,41.1 780.0,40.0" fill="none" stroke="#FFD700" stroke-width="2.5" stroke-linejoin="round" stroke-linecap="round"/>
+
+  <!-- X-axis labels -->
+  <text x="55.0" y="268" text-anchor="middle" fill="#8b949e" font-family="system-ui,sans-serif" font-size="10">05-16</text>
+  <text x="194.9" y="268" text-anchor="middle" fill="#8b949e" font-family="system-ui,sans-serif" font-size="10">05-27</text>
+  <text x="334.8" y="268" text-anchor="middle" fill="#8b949e" font-family="system-ui,sans-serif" font-size="10">06-07</text>
+  <text x="474.7" y="268" text-anchor="middle" fill="#8b949e" font-family="system-ui,sans-serif" font-size="10">06-18</text>
+  <text x="614.6" y="268" text-anchor="middle" fill="#8b949e" font-family="system-ui,sans-serif" font-size="10">06-29</text>
+  <text x="754.6" y="268" text-anchor="middle" fill="#8b949e" font-family="system-ui,sans-serif" font-size="10">07-10</text>
+  <text x="780.0" y="268" text-anchor="middle" fill="#8b949e" font-family="system-ui,sans-serif" font-size="10">07-12</text>
+
+  <!-- End dot -->
+  <circle cx="780.0" cy="40.0" r="4" fill="#FFD700"/>
+  <text x="778.0" y="30.0" text-anchor="end" fill="#FFD700" font-family="system-ui,sans-serif" font-size="12" font-weight="600">372</text>
+</svg>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -168,6 +168,16 @@
     <ConfirmCloseDialog @confirm="onConfirmClose" />
 
     <ConfirmModal
+      :visible="confirmState.visible"
+      :title="confirmState.title"
+      :message="confirmState.message"
+      :confirm-text="confirmState.confirmText"
+      :cancel-text="confirmState.cancelText"
+      @confirm="confirmResolve"
+      @cancel="confirmCancel"
+    />
+
+    <ConfirmModal
       :visible="windowCloseConfirmVisible"
       :title="t('confirm.closeWindowTitle')"
       :message="t('confirm.closeWindowMessage')"
@@ -241,6 +251,7 @@ import KbToggleButton from './components/keyboard/KbToggleButton.vue'
 import SettingsPanel from './components/SettingsPanel.vue'
 import ConfirmCloseDialog from './components/ui/ConfirmCloseDialog.vue'
 import ConfirmModal from './components/ui/ConfirmModal.vue'
+import { confirmState, uiConfirm, confirmResolve, confirmCancel } from './composables/useConfirm'
 import PreviewPanel from './components/preview/PreviewPanel.vue'
 import CommandBookmarks from './components/command/CommandBookmarks.vue'
 import ServerList from './components/ServerList.vue'
@@ -1160,7 +1171,7 @@ window.__dinotty_ui_notify = (message: string, level?: 'info' | 'warn' | 'error'
   if (level === 'error') console.error('[plugin]', message)
   else console.log('[plugin]', message)
 }
-window.__dinotty_ui_confirm = async (message: string) => window.confirm(message)
+window.__dinotty_ui_confirm = (message: string) => uiConfirm(message)
 window.__dinotty_open_plugin = openPlugin
 
 const paletteCommands = computed<Command[]>(() => {

--- a/frontend/src/components/overview/WorkspaceList.vue
+++ b/frontend/src/components/overview/WorkspaceList.vue
@@ -46,6 +46,7 @@
 import { ref } from 'vue'
 import { Plus, Pencil, Trash2 } from 'lucide-vue-next'
 import { useI18n } from '../../composables/useI18n'
+import { uiConfirm } from '../../composables/useConfirm'
 import { useWorkspaces } from '../../composables/useWorkspaces'
 import type { Workspace } from '../../types/workspace'
 import ContextMenu from '../ui/ContextMenu.vue'
@@ -89,7 +90,11 @@ function openCtx(e: MouseEvent, ws: Workspace) {
       icon: Trash2,
       danger: true,
       action: async () => {
-        if (!confirm(t('workspace.confirmDelete').replace('{name}', ws.name))) return
+        if (!(await uiConfirm(t('workspace.confirmDelete').replace('{name}', ws.name), {
+          title: t('workspace.delete'),
+          confirmText: t('workspace.delete'),
+          cancelText: t('filePreview.cancel'),
+        }))) return
         try {
           await deleteWorkspace(ws.id)
         } catch (err) {

--- a/frontend/src/components/overview/WorkspaceListView.vue
+++ b/frontend/src/components/overview/WorkspaceListView.vue
@@ -72,6 +72,7 @@ import { ref } from 'vue'
 import { Motion } from 'motion-v'
 import { Plus, Pencil, Trash2, X } from 'lucide-vue-next'
 import { useI18n } from '../../composables/useI18n'
+import { uiConfirm } from '../../composables/useConfirm'
 import { useWorkspaces } from '../../composables/useWorkspaces'
 import type { Workspace } from '../../types/workspace'
 import ContextMenu from '../ui/ContextMenu.vue'
@@ -115,7 +116,11 @@ function showCtx(ws: Workspace, x: number, y: number) {
       icon: Trash2,
       danger: true,
       action: async () => {
-        if (!confirm(t('workspace.confirmDelete').replace('{name}', ws.name))) return
+        if (!(await uiConfirm(t('workspace.confirmDelete').replace('{name}', ws.name), {
+          title: t('workspace.delete'),
+          confirmText: t('workspace.delete'),
+          cancelText: t('filePreview.cancel'),
+        }))) return
         try {
           await deleteWorkspace(ws.id)
         } catch (err) {

--- a/frontend/src/components/overview/WorkspaceOverview.vue
+++ b/frontend/src/components/overview/WorkspaceOverview.vue
@@ -74,6 +74,7 @@ import { Motion, AnimatePresence } from 'motion-v'
 import { Plus, X } from 'lucide-vue-next'
 import { useWorkspaces } from '../../composables/useWorkspaces'
 import { useI18n } from '../../composables/useI18n'
+import { uiConfirm } from '../../composables/useConfirm'
 import { useSessionStore } from '../../stores/sessionStore'
 import { useNotification } from '../../composables/useNotification'
 import { useTabPreview, type TabCard } from '../../composables/useTabPreview'
@@ -322,8 +323,14 @@ function onKeydown(e: KeyboardEvent) {
         const wsId = selectedWorkspaceId.value
         if (wsId !== null && wsId !== '__all__') {
           const ws = workspaces.value.find((w) => w.id === wsId)
-          if (ws && confirm(`${t('workspace.delete')} "${ws.name}"?`)) {
-            deleteWorkspace(wsId).catch((e) => console.error('Failed to delete workspace:', e))
+          if (ws) {
+            uiConfirm(t('workspace.confirmDelete').replace('{name}', ws.name), {
+              title: t('workspace.delete'),
+              confirmText: t('workspace.delete'),
+              cancelText: t('filePreview.cancel'),
+            }).then((ok) => {
+              if (ok) deleteWorkspace(wsId).catch((e) => console.error('Failed to delete workspace:', e))
+            })
           }
         }
       }

--- a/frontend/src/components/settings/GeneralTab.vue
+++ b/frontend/src/components/settings/GeneralTab.vue
@@ -468,6 +468,7 @@ import { Eye, EyeOff, Copy, Check, Pencil, RefreshCw, Save, X, FolderOpen } from
 import { invoke } from '@tauri-apps/api/core'
 import { useSettings } from '../../composables/useSettings'
 import { useI18n } from '../../composables/useI18n'
+import { uiConfirm } from '../../composables/useConfirm'
 import CollapsibleSection from './CollapsibleSection.vue'
 import { copyToClipboard } from '../../utils/clipboard'
 import { useToast } from 'vue-toastification'
@@ -726,7 +727,11 @@ async function saveToken() {
 }
 
 async function regenerateToken() {
-  if (!confirm(t('settings.token.confirmRegenerate'))) return
+  if (!(await uiConfirm(t('settings.token.confirmRegenerate'), {
+    title: t('settings.token.regenerate'),
+    confirmText: t('settings.token.regenerate'),
+    cancelText: t('filePreview.cancel'),
+  }))) return
   const buf = new Uint8Array(32)
   crypto.getRandomValues(buf)
   const token = Array.from(buf)

--- a/frontend/src/composables/useConfirm.ts
+++ b/frontend/src/composables/useConfirm.ts
@@ -1,0 +1,52 @@
+import { reactive } from 'vue'
+
+type ConfirmOptions = {
+  title?: string
+  confirmText?: string
+  cancelText?: string
+}
+
+export const confirmState = reactive<{
+  visible: boolean
+  title: string
+  message: string
+  confirmText: string
+  cancelText: string
+  resolve: ((ok: boolean) => void) | null
+}>({
+  visible: false,
+  title: '',
+  message: '',
+  confirmText: 'OK',
+  cancelText: 'Cancel',
+  resolve: null,
+})
+
+function settle(ok: boolean) {
+  const resolve = confirmState.resolve
+  confirmState.visible = false
+  confirmState.resolve = null
+  resolve?.(ok)
+}
+
+export function uiConfirm(message: string, opts: ConfirmOptions = {}): Promise<boolean> {
+  if (confirmState.resolve) settle(false)
+
+  confirmState.title = opts.title ?? ''
+  confirmState.message = message
+  confirmState.confirmText = opts.confirmText ?? 'OK'
+  confirmState.cancelText = opts.cancelText ?? 'Cancel'
+  confirmState.visible = true
+
+  return new Promise<boolean>((resolve) => {
+    confirmState.resolve = resolve
+  })
+}
+
+export function confirmResolve() {
+  settle(true)
+}
+
+export function confirmCancel() {
+  settle(false)
+}

--- a/frontend/src/composables/useFileOperations.ts
+++ b/frontend/src/composables/useFileOperations.ts
@@ -1,5 +1,6 @@
 import { ref, computed, type Ref } from 'vue'
 import { getApiBase, apiUrl, authFetch, getAuthToken } from './apiBase'
+import { uiConfirm } from './useConfirm'
 import { isTauri, tauriInvoke } from './useTransport'
 import { isInternalDragActive, getInternalDragRel, clearInternalDrag } from './internalDragState'
 import type { DirEntry } from '../components/workspace/TreeRows'
@@ -357,7 +358,11 @@ export function useFileOperations(opts: {
     opts.inlineCreate.value = null
     const wasDir = opts.selectedIsDir.value
     const msg = wasDir ? t('filePreview.confirmDeleteFolder') : t('filePreview.confirmDeleteFile')
-    if (!skipConfirm && !confirm(msg)) return false
+    if (!skipConfirm && !(await uiConfirm(msg, {
+      title: t('filePreview.delete'),
+      confirmText: t('filePreview.delete'),
+      cancelText: t('filePreview.cancel'),
+    }))) return false
     await getApiBase()
     const q = new URLSearchParams({ pane_id: opts.paneId(), path: rel })
     if (opts.cwdLabel.value) q.set('cwd', opts.cwdLabel.value)

--- a/scripts/gen-star-history.sh
+++ b/scripts/gen-star-history.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# Generate a star history SVG chart from GitHub stargazers data.
+# Incremental: caches daily star counts locally, only fetches new pages on subsequent runs.
+# Requires: gh (GitHub CLI) authenticated, python3
+# Output: docs/images/star-history.svg
+
+set -euo pipefail
+
+REPO="xichan96/dinotty"
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+OUT_DIR="$ROOT_DIR/docs/images"
+OUT_FILE="$OUT_DIR/star-history.svg"
+CACHE_FILE="$ROOT_DIR/.star-cache"
+PER_PAGE=100
+
+mkdir -p "$OUT_DIR"
+
+# Get current star count from repo metadata (1 API call)
+CURRENT_COUNT=$(gh api "repos/$REPO" --jq '.stargazers_count' 2>/dev/null)
+if [ -z "$CURRENT_COUNT" ] || [ "$CURRENT_COUNT" -eq 0 ]; then
+  echo "Error: failed to get repo info" >&2
+  exit 1
+fi
+
+# Count total entries in cache (sum of daily counts)
+CACHED_COUNT=0
+if [ -f "$CACHE_FILE" ]; then
+  CACHED_COUNT=$(awk '{s+=$2} END{print s+0}' "$CACHE_FILE")
+fi
+
+# ── Determine fetch strategy ──
+
+if [ ! -f "$CACHE_FILE" ] || [ "$CACHED_COUNT" -eq 0 ]; then
+  # Cold start: full fetch
+  echo "No cache, fetching all $CURRENT_COUNT stars..."
+  RAW=$(gh api "repos/$REPO/stargazers?per_page=$PER_PAGE" \
+    --header 'Accept: application/vnd.github.v3.star+json' \
+    --paginate -q '.[].starred_at' 2>/dev/null | cut -dT -f1)
+  echo "$RAW" | sort | uniq -c | awk '{printf "%s %d\n", $2, $1}' > "$CACHE_FILE"
+
+elif [ "$CACHED_COUNT" -eq "$CURRENT_COUNT" ]; then
+  echo "Cache hit: $CACHED_COUNT stars, no fetch needed"
+
+elif [ "$CACHED_COUNT" -gt "$CURRENT_COUNT" ]; then
+  # Stars removed, refetch
+  echo "Cache stale ($CACHED_COUNT > $CURRENT_COUNT), full refetch..."
+  RAW=$(gh api "repos/$REPO/stargazers?per_page=$PER_PAGE" \
+    --header 'Accept: application/vnd.github.v3.star+json' \
+    --paginate -q '.[].starred_at' 2>/dev/null | cut -dT -f1)
+  echo "$RAW" | sort | uniq -c | awk '{printf "%s %d\n", $2, $1}' > "$CACHE_FILE"
+
+else
+  # Incremental: fetch only new entries
+  DELTA=$((CURRENT_COUNT - CACHED_COUNT))
+  START_PAGE=$(( (CACHED_COUNT / PER_PAGE) + 1 ))
+  SKIP=$((CACHED_COUNT - (START_PAGE - 1) * PER_PAGE))
+
+  echo "Fetching $DELTA new stars from page $START_PAGE (skip $SKIP)..."
+  RAW=$(gh api "repos/$REPO/stargazers?per_page=$PER_PAGE&page=$START_PAGE" \
+    --header 'Accept: application/vnd.github.v3.star+json' \
+    -q '.[].starred_at' 2>/dev/null | cut -dT -f1)
+
+  if [ -n "$RAW" ]; then
+    # Trim: skip already-cached entries on first page, keep exactly DELTA new ones
+    NEW_DATES=$(echo "$RAW" | tail -n +$((SKIP + 1)) | head -n "$DELTA")
+    if [ -n "$NEW_DATES" ]; then
+      # Aggregate new entries by date
+      NEW_COUNTS=$(echo "$NEW_DATES" | sort | uniq -c | awk '{printf "%s %d\n", $2, $1}')
+      # Merge: sum counts for matching dates
+      MERGED=$(cat "$CACHE_FILE" <(echo "$NEW_COUNTS") | sort | awk '
+        { key=$1; val=$2 }
+        key==prev { sum+=val; next }
+        prev!=""  { printf "%s %d\n", prev, sum }
+        { prev=key; sum=val }
+        END { if (prev!="") printf "%s %d\n", prev, sum }
+      ')
+      echo "$MERGED" > "$CACHE_FILE"
+    fi
+  fi
+  echo "Cache updated: $(awk '{s+=$2} END{print s+0}' "$CACHE_FILE") stars"
+fi
+
+# Read final cache
+TOTAL=$(awk '{s+=$2} END{print s+0}' "$CACHE_FILE")
+if [ "$TOTAL" -eq 0 ]; then
+  echo "Error: no star data available" >&2
+  exit 1
+fi
+
+python3 - "$CACHE_FILE" "$TOTAL" "$OUT_FILE" << 'PYEOF'
+import sys
+from collections import OrderedDict
+from datetime import datetime, timedelta
+
+cache_file = sys.argv[1]
+total = int(sys.argv[2])
+out_file = sys.argv[3]
+
+# Read daily counts from cache
+daily = OrderedDict()
+with open(cache_file) as f:
+    for line in f:
+        parts = line.strip().split()
+        if len(parts) == 2:
+            daily[parts[0]] = int(parts[1])
+
+# Fill gaps and build cumulative
+cumulative = OrderedDict()
+cum = 0
+start = datetime.strptime(min(daily.keys()), '%Y-%m-%d')
+end = datetime.strptime(max(daily.keys()), '%Y-%m-%d')
+current = start
+while current <= end:
+    ds = current.strftime('%Y-%m-%d')
+    cum += daily.get(ds, 0)
+    cumulative[ds] = cum
+    current += timedelta(days=1)
+
+dates = list(cumulative.keys())
+values = list(cumulative.values())
+n = len(dates)
+
+# SVG dimensions
+width = 800
+height = 300
+pad_left = 55
+pad_right = 20
+pad_top = 40
+pad_bottom = 50
+chart_w = width - pad_left - pad_right
+chart_h = height - pad_top - pad_bottom
+
+max_val = max(values)
+
+def x_pos(i):
+    return pad_left + (i / max(n - 1, 1)) * chart_w
+
+def y_pos(v):
+    return pad_top + chart_h - (v / max(max_val, 1)) * chart_h
+
+# Build polyline points
+points = ' '.join(f'{x_pos(i):.1f},{y_pos(v):.1f}' for i, v in enumerate(values))
+
+# Gradient fill area
+area_points = points + f' {x_pos(n-1):.1f},{y_pos(0):.1f} {x_pos(0):.1f},{y_pos(0):.1f}'
+
+# Y-axis ticks (5 ticks)
+y_ticks = []
+for i in range(6):
+    v = int(max_val * i / 5)
+    y = y_pos(v)
+    y_ticks.append((v, y))
+
+# X-axis labels (pick ~6 dates)
+x_label_indices = []
+step = max(1, (n - 1) // 5)
+for i in range(0, n, step):
+    x_label_indices.append(i)
+if x_label_indices[-1] != n - 1:
+    x_label_indices.append(n - 1)
+
+svg = f'''<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" width="{width}" height="{height}">
+  <defs>
+    <linearGradient id="fill" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FFD700" stop-opacity="0.3"/>
+      <stop offset="100%" stop-color="#FFD700" stop-opacity="0.02"/>
+    </linearGradient>
+  </defs>
+  <rect width="{width}" height="{height}" rx="8" fill="#0d1117"/>
+
+  <!-- Title -->
+  <text x="{width/2}" y="22" text-anchor="middle" fill="#e6edf3" font-family="system-ui,sans-serif" font-size="14" font-weight="600">
+    Star History - {total} stars
+  </text>
+
+  <!-- Y-axis grid + labels -->
+'''
+
+for v, y in y_ticks:
+    svg += f'  <line x1="{pad_left}" y1="{y:.1f}" x2="{width - pad_right}" y2="{y:.1f}" stroke="#21262d" stroke-width="0.5"/>\n'
+    svg += f'  <text x="{pad_left - 8}" y="{y + 4:.1f}" text-anchor="end" fill="#8b949e" font-family="system-ui,sans-serif" font-size="10">{v}</text>\n'
+
+svg += f'''
+  <!-- Area fill -->
+  <polygon points="{area_points}" fill="url(#fill)"/>
+
+  <!-- Line -->
+  <polyline points="{points}" fill="none" stroke="#FFD700" stroke-width="2.5" stroke-linejoin="round" stroke-linecap="round"/>
+
+  <!-- X-axis labels -->
+'''
+
+for i in x_label_indices:
+    x = x_pos(i)
+    short = dates[i][5:]  # MM-DD
+    svg += f'  <text x="{x:.1f}" y="{height - pad_bottom + 18}" text-anchor="middle" fill="#8b949e" font-family="system-ui,sans-serif" font-size="10">{short}</text>\n'
+
+last_x = x_pos(n - 1)
+last_y = y_pos(values[-1])
+svg += f'''
+  <!-- End dot -->
+  <circle cx="{last_x:.1f}" cy="{last_y:.1f}" r="4" fill="#FFD700"/>
+  <text x="{last_x - 2}" y="{last_y - 10}" text-anchor="end" fill="#FFD700" font-family="system-ui,sans-serif" font-size="12" font-weight="600">{values[-1]}</text>
+</svg>'''
+
+with open(out_file, 'w') as f:
+    f.write(svg)
+
+print(f"Generated {out_file} ({total} stars, {n} days)")
+PYEOF

--- a/src/settings/tests.rs
+++ b/src/settings/tests.rs
@@ -234,8 +234,8 @@ fn clamp_text_config_reports_whether_it_mutated() {
         ..TextConfig::default()
     };
     assert!(clamp_text_config(&mut changed));
-    assert_eq!(changed.scroll_sensitivity, 2.0);
-    assert_eq!(changed.scroll_acceleration, default_scroll_acceleration());
+    assert!((changed.scroll_sensitivity - 2.0).abs() < f32::EPSILON);
+    assert!((changed.scroll_acceleration - default_scroll_acceleration()).abs() < f32::EPSILON);
     assert_eq!(changed.scrollbar_width, 4);
     assert_eq!(changed.custom_fonts, Some(vec!["Monaco".into()]));
     assert!(!clamp_text_config(&mut changed));


### PR DESCRIPTION
## Summary
- Add local SVG star history chart with incremental caching script
- Replace hardcoded version in Linux install command with dynamic latest version fetch
- Embed star history SVG in README instead of external link
- Fix f32 approximate comparison in clamp_text_config test
- Restore delete on macOS by replacing native confirm() with in-app modal

## Test plan
- [ ] Verify star history SVG renders correctly in README
- [ ] Test Linux install command fetches latest version
- [ ] Confirm `gen-star-history.sh` runs without errors
- [ ] Verify macOS delete works with in-app modal