### PR TITLE
fix: close terminal sessions after shell exit

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -57,7 +57,10 @@ fn spawn_tauri_output_forwarder(
                     loop {
                         match rx.try_recv() {
                             Ok(SessionClientEvent::Output(data)) => batch.push_str(&data),
-                            Ok(event @ SessionClientEvent::Resize { .. }) => {
+                            Ok(
+                                event @ (SessionClientEvent::Resize { .. }
+                                | SessionClientEvent::SessionExit { .. }),
+                            ) => {
                                 pending = Some(event);
                                 break;
                             }
@@ -78,6 +81,10 @@ fn spawn_tauri_output_forwarder(
                     {
                         break;
                     }
+                }
+                SessionClientEvent::SessionExit { pane_id: exit_pane_id } => {
+                    let _ = app.emit("pty-exit", PtyExit { pane_id: exit_pane_id });
+                    break;
                 }
             }
         }

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -98,6 +98,35 @@ pub async fn broadcast_task(session: Arc<Session>, pane_id: String, manager: Arc
     info!("Broadcast task exited, pane={}", pane_id);
 }
 
+fn cleanup_exited_pty_session(
+    session: &Arc<Session>,
+    pane_id: &str,
+    manager: &Arc<SessionManager>,
+    exit_code: Option<i32>,
+) {
+    if !session.notify_exit_and_mark_exited(pane_id) {
+        return;
+    }
+
+    session.input_tx.lock().unwrap_or_else(std::sync::PoisonError::into_inner).take();
+    let _ = session.output_tx.send(Vec::new());
+
+    if manager.sessions.remove(pane_id).is_some() {
+        manager
+            .event_bus
+            .publish(BusEvent::SessionClosed { pane_id: pane_id.to_string(), exit_code });
+        if let Some(tab_pane_id) = manager.on_pty_exited(pane_id) {
+            manager.broadcast_sync(&SyncMsg::TabClosed { pane_id: tab_pane_id });
+        }
+    }
+
+    if let Some(f) =
+        session.tauri_on_exit.lock().unwrap_or_else(std::sync::PoisonError::into_inner).take()
+    {
+        f(pane_id.to_string());
+    }
+}
+
 /// Create a new PTY session and register it with the session manager.
 ///
 /// # Errors
@@ -331,25 +360,68 @@ pub fn create_session(
             }
         }
         error!("PTY reader exiting, running cleanup, pane={}", reader_pane);
-        reader_session.notify_exit_and_mark_exited(&reader_pane);
-        if reader_manager.sessions.remove(&reader_pane).is_some() {
-            reader_manager
-                .event_bus
-                .publish(BusEvent::SessionClosed { pane_id: reader_pane.clone(), exit_code: None });
-            let tab_pane_id =
-                reader_manager.on_pty_exited(&reader_pane).unwrap_or_else(|| reader_pane.clone());
-            reader_manager.broadcast_sync(&SyncMsg::TabClosed { pane_id: tab_pane_id });
-        }
+        cleanup_exited_pty_session(&reader_session, &reader_pane, &reader_manager, None);
         info!("PTY exited, session removed: pane={}", reader_pane);
-        let cb = reader_session
-            .tauri_on_exit
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .clone();
-        if let Some(f) = cb {
-            f(reader_pane);
-        }
     });
+
+    // On Windows ConPTY may leave the reader blocked after the shell process
+    // exits. Poll the child handle so `exit` closes the tab even without EOF.
+    {
+        let watcher_session = Arc::clone(&session);
+        let watcher_manager = Arc::clone(manager);
+        let watcher_pane = pane_id.to_string();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_millis(200));
+            loop {
+                interval.tick().await;
+                if watcher_session.is_exited() {
+                    break;
+                }
+
+                let mut should_stop = false;
+                let status = {
+                    let mut backend = watcher_session.backend.lock().await;
+                    let status = match &mut *backend {
+                        SessionBackend::Local { child, .. } => {
+                            match child.try_wait() {
+                                Ok(Some(status)) => Some(status),
+                                Ok(None) => None,
+                                Err(e) => {
+                                    error!("PTY child watcher: try_wait failed: {e}, pane={watcher_pane}");
+                                    should_stop = true;
+                                    None
+                                }
+                            }
+                        }
+                        SessionBackend::Ssh | SessionBackend::Exited => {
+                            should_stop = true;
+                            None
+                        }
+                    };
+                    if status.is_some() {
+                        *backend = SessionBackend::Exited;
+                    }
+                    status
+                };
+
+                if let Some(status) = status {
+                    let exit_code = i32::try_from(status.exit_code()).ok();
+                    info!("PTY child exited: status={status:?}, pane={watcher_pane}");
+                    cleanup_exited_pty_session(
+                        &watcher_session,
+                        &watcher_pane,
+                        &watcher_manager,
+                        exit_code,
+                    );
+                    break;
+                }
+
+                if should_stop {
+                    break;
+                }
+            }
+        });
+    }
 
     // ── Broadcast task: forwards raw PTY data + handles commands ──
     // Reads raw PTY bytes from the output channel and broadcasts to clients

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -42,6 +42,8 @@ pub enum SessionBackend {
     },
     /// SSH 远程连接 — channel 已移至 reader task，此处仅保留标记
     Ssh,
+    /// Backend resources were already dropped after the child exited.
+    Exited,
 }
 
 /// Commands sent from Session methods to the SSH reader/writer task.
@@ -80,6 +82,7 @@ pub struct PendingCommandResult {
 pub enum SessionClientEvent {
     Output(String),
     Resize { cols: u16, rows: u16 },
+    SessionExit { pane_id: String },
 }
 
 pub struct ClientEndpoint {
@@ -189,6 +192,7 @@ impl Session {
                 self.mark_exited();
                 info!("SSH session marked as exited");
             }
+            SessionBackend::Exited => {}
         }
     }
 
@@ -234,6 +238,7 @@ impl Session {
                 Ok(())
             }
             SessionBackend::Ssh => Err("use write_input_async for SSH sessions".into()),
+            SessionBackend::Exited => Err("session exited".into()),
         }
     }
 
@@ -279,11 +284,14 @@ impl Session {
             }
         } else {
             let mut backend = self.backend.lock().await;
-            if let SessionBackend::Local { master, .. } = &mut *backend {
-                use portable_pty::PtySize;
-                master
-                    .resize(PtySize { rows, cols, pixel_width: 0, pixel_height: 0 })
-                    .map_err(|e| e.to_string())?;
+            match &mut *backend {
+                SessionBackend::Local { master, .. } => {
+                    use portable_pty::PtySize;
+                    master
+                        .resize(PtySize { rows, cols, pixel_width: 0, pixel_height: 0 })
+                        .map_err(|e| e.to_string())?;
+                }
+                SessionBackend::Ssh | SessionBackend::Exited => {}
             }
         }
         *self.size.lock().unwrap_or_else(std::sync::PoisonError::into_inner) = (cols, rows);
@@ -311,9 +319,13 @@ impl Session {
             return Err("SSH session not initialized".into());
         }
         let mut backend = self.backend.lock().await;
-        if let SessionBackend::Local { writer, .. } = &mut *backend {
-            writer.write_all(data).map_err(|e| e.to_string())?;
-            writer.flush().map_err(|e| e.to_string())?;
+        match &mut *backend {
+            SessionBackend::Local { writer, .. } => {
+                writer.write_all(data).map_err(|e| e.to_string())?;
+                writer.flush().map_err(|e| e.to_string())?;
+            }
+            SessionBackend::Ssh => {}
+            SessionBackend::Exited => return Err("session exited".into()),
         }
         Ok(())
     }
@@ -466,12 +478,27 @@ impl Session {
     }
 
     /// Notify all connected clients that the session is exiting, then mark as exited.
-    pub fn notify_exit_and_mark_exited(&self, pane_id: &str) {
-        let exit_msg = serde_json::json!({"type": "session_exit", "pane_id": pane_id}).to_string();
+    /// Returns false when another cleanup path already handled the exit.
+    pub fn notify_exit_and_mark_exited(&self, pane_id: &str) -> bool {
+        {
+            let mut exited = self.exited.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            if *exited {
+                return false;
+            }
+            *exited = true;
+        }
         let mut clients = self.clients.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-        Self::send_chunk_to_clients(&mut clients, &exit_msg);
-        drop(clients);
-        self.mark_exited();
+        clients.retain(|client| !client.tx.is_closed());
+        for client in clients.iter() {
+            if client
+                .tx
+                .try_send(SessionClientEvent::SessionExit { pane_id: pane_id.to_string() })
+                .is_err()
+            {
+                tracing::debug!("broadcast: client channel full, dropping session_exit");
+            }
+        }
+        true
     }
 
     pub fn has_clients(&self) -> bool {

--- a/src/ssh/mod.rs
+++ b/src/ssh/mod.rs
@@ -716,13 +716,15 @@ async fn ssh_reader_task(
     // 清理：清除 ssh_cmd_tx 以防止后续发送
     *session.ssh_cmd_tx.lock().unwrap_or_else(std::sync::PoisonError::into_inner) = None;
 
-    session.notify_exit_and_mark_exited(&pane_id);
-    manager.sessions.remove(&pane_id);
-    manager
-        .event_bus
-        .publish(BusEvent::SessionClosed { pane_id: pane_id.clone(), exit_code: None });
-    manager.on_pty_exited(&pane_id);
-    manager.broadcast_sync(&SyncMsg::TabClosed { pane_id: pane_id.clone() });
+    if session.notify_exit_and_mark_exited(&pane_id) {
+        manager.sessions.remove(&pane_id);
+        manager
+            .event_bus
+            .publish(BusEvent::SessionClosed { pane_id: pane_id.clone(), exit_code: None });
+        if let Some(tab_pane_id) = manager.on_pty_exited(&pane_id) {
+            manager.broadcast_sync(&SyncMsg::TabClosed { pane_id: tab_pane_id });
+        }
+    }
     if let Some(cb) =
         session.tauri_on_exit.lock().unwrap_or_else(std::sync::PoisonError::into_inner).take()
     {

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -555,6 +555,9 @@ async fn handle_socket(
                     SessionClientEvent::Resize { cols, rows } => {
                         serde_json::to_string(&ServerMsg::Resize { cols, rows })
                     }
+                    SessionClientEvent::SessionExit { pane_id: _ } => {
+                        serde_json::to_string(&ServerMsg::SessionExit)
+                    }
                 }
                 .expect("serialization is infallible");
                 if fwd_ws_out_tx.send(Message::Text(msg)).is_err() {
@@ -700,6 +703,9 @@ async fn handle_socket(
                 }
                 SessionClientEvent::Resize { cols, rows } => {
                     serde_json::to_string(&ServerMsg::Resize { cols, rows })
+                }
+                SessionClientEvent::SessionExit { pane_id: _ } => {
+                    serde_json::to_string(&ServerMsg::SessionExit)
                 }
             }
             .expect("serialization is infallible");
@@ -975,6 +981,9 @@ pub async fn handle_open_api_ws(socket: WebSocket, manager: Arc<SessionManager>,
                 }
                 SessionClientEvent::Resize { cols, rows } => {
                     serde_json::to_string(&ServerMsg::Resize { cols, rows })
+                }
+                SessionClientEvent::SessionExit { pane_id: _ } => {
+                    serde_json::to_string(&ServerMsg::SessionExit)
                 }
             }
             .expect("serialization is infallible");

--- a/tests/terminal_exit_regression.rs
+++ b/tests/terminal_exit_regression.rs
@@ -1,0 +1,366 @@
+use futures_util::{SinkExt, StreamExt};
+use serde_json::Value;
+use std::error::Error;
+use std::fs;
+use std::io;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::http::{header::COOKIE, HeaderValue};
+use tokio_tungstenite::tungstenite::Message;
+
+#[cfg(any(unix, windows))]
+type TestResult<T = ()> = Result<T, Box<dyn Error + Send + Sync>>;
+
+#[cfg(any(unix, windows))]
+struct ChildGuard(Child);
+
+#[cfg(any(unix, windows))]
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+#[cfg(any(unix, windows))]
+fn test_error(message: impl Into<String>) -> Box<dyn Error + Send + Sync> {
+    io::Error::other(message.into()).into()
+}
+
+#[cfg(any(unix, windows))]
+fn free_loopback_port() -> TestResult<u16> {
+    let listener = TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))?;
+    Ok(listener.local_addr()?.port())
+}
+
+#[cfg(any(unix, windows))]
+fn create_dir(path: &Path) -> TestResult {
+    fs::create_dir_all(path).map_err(|err| test_error(format!("create {}: {err}", path.display())))
+}
+
+#[cfg(any(unix, windows))]
+fn test_shell() -> TestResult<PathBuf> {
+    #[cfg(windows)]
+    {
+        resolve_command("pwsh.exe")
+            .or_else(|| resolve_command("powershell.exe"))
+            .or_else(|| resolve_command("cmd.exe"))
+            .ok_or_else(|| test_error("no Windows shell found in PATH"))
+    }
+
+    #[cfg(unix)]
+    {
+        for candidate in ["/bin/sh", "/usr/bin/sh", "/bin/bash", "/usr/bin/bash"] {
+            let path = PathBuf::from(candidate);
+            if path.is_file() {
+                return Ok(path);
+            }
+        }
+        Err(test_error("no POSIX shell found"))
+    }
+}
+
+#[cfg(windows)]
+fn resolve_command(program: &str) -> Option<PathBuf> {
+    let path = PathBuf::from(program);
+    if path.is_absolute() {
+        return path.is_file().then_some(path);
+    }
+
+    let candidates = command_candidates(program);
+    std::env::var_os("PATH").and_then(|paths| {
+        std::env::split_paths(&paths)
+            .flat_map(|dir| candidates.iter().map(move |candidate| dir.join(candidate)))
+            .find(|candidate| candidate.is_file())
+    })
+}
+
+#[cfg(windows)]
+fn command_candidates(program: &str) -> Vec<String> {
+    if Path::new(program).extension().is_some() {
+        return vec![program.to_string()];
+    }
+
+    let mut candidates = vec![program.to_string()];
+    let pathext = std::env::var("PATHEXT").unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".to_string());
+    candidates.extend(
+        pathext.split(';').filter(|ext| !ext.is_empty()).map(|ext| format!("{program}{ext}")),
+    );
+    candidates
+}
+
+#[cfg(any(unix, windows))]
+#[allow(clippy::too_many_arguments)]
+fn spawn_server(
+    server: &str,
+    port: u16,
+    cwd: &Path,
+    tmp: &TempDir,
+    appdata: &Path,
+    localappdata: &Path,
+    userprofile: &Path,
+    shell: &Path,
+) -> TestResult<ChildGuard> {
+    let stdout = fs::File::create(tmp.path().join("server.out.log"))?;
+    let stderr = fs::File::create(tmp.path().join("server.err.log"))?;
+
+    let mut cmd = Command::new(server);
+    cmd.args(["--port", &port.to_string()])
+        .current_dir(cwd)
+        .env("APPDATA", appdata)
+        .env("LOCALAPPDATA", localappdata)
+        .env("USERPROFILE", userprofile)
+        .env("HOME", userprofile)
+        .env("XDG_CONFIG_HOME", tmp.path().join("xdg-config"))
+        .env("XDG_DATA_HOME", tmp.path().join("xdg-data"))
+        .env("DINOTTY_SHELL", shell)
+        .env("DINOTTY_TOKEN", "regression-token")
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr));
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(0x0800_0000 | 0x0000_0008); // CREATE_NO_WINDOW | DETACHED_PROCESS
+    }
+
+    Ok(ChildGuard(cmd.spawn()?))
+}
+
+#[cfg(any(unix, windows))]
+async fn wait_until_ready(
+    client: &reqwest::Client,
+    base: &str,
+    port: u16,
+    child: &mut ChildGuard,
+    log_dir: &Path,
+) -> TestResult {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let mut last_error = String::new();
+
+    while Instant::now() < deadline {
+        if let Some(status) = child.0.try_wait()? {
+            return Err(test_error(format!(
+                "server exited early with {status}; stderr:\n{}",
+                read_log(log_dir, "server.err.log")
+            )));
+        }
+
+        match client.get(format!("{base}/api/info")).bearer_auth("regression-token").send().await {
+            Ok(resp) => match resp.error_for_status() {
+                Ok(resp) => match resp.json::<Value>().await {
+                    Ok(info) => {
+                        let actual = info.get("port").and_then(Value::as_u64);
+                        if actual == Some(u64::from(port)) {
+                            return Ok(());
+                        }
+                        return Err(test_error(format!("unexpected /api/info port: {actual:?}")));
+                    }
+                    Err(err) => last_error = err.to_string(),
+                },
+                Err(err) => last_error = err.to_string(),
+            },
+            Err(err) => last_error = err.to_string(),
+        }
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    Err(test_error(format!(
+        "server did not become ready: {last_error}; stderr:\n{}",
+        read_log(log_dir, "server.err.log")
+    )))
+}
+
+#[cfg(any(unix, windows))]
+async fn login_cookie(client: &reqwest::Client, base: &str) -> TestResult<String> {
+    let resp = client
+        .post(format!("{base}/api/auth"))
+        .json(&serde_json::json!({ "token": "regression-token" }))
+        .send()
+        .await?
+        .error_for_status()?;
+    let set_cookie = resp
+        .headers()
+        .get(reqwest::header::SET_COOKIE)
+        .ok_or_else(|| test_error("login response missing Set-Cookie"))?
+        .to_str()?;
+    Ok(set_cookie.split(';').next().unwrap_or(set_cookie).to_string())
+}
+
+#[cfg(any(unix, windows))]
+async fn wait_for_shell_prompt(
+    ws: &mut tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+) -> TestResult {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut saw_output = false;
+    let mut collected = String::new();
+
+    while Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let wait = if saw_output { Duration::from_millis(750) } else { remaining };
+        match tokio::time::timeout(wait.min(remaining), ws.next()).await {
+            Ok(Some(Ok(Message::Text(text)))) => {
+                if let Ok(msg) = serde_json::from_str::<Value>(&text) {
+                    if msg.get("type").and_then(Value::as_str) == Some("output") {
+                        saw_output = true;
+                        if let Some(data) = msg.get("data").and_then(Value::as_str) {
+                            collected.push_str(data);
+                            if looks_like_prompt(&collected) {
+                                return Ok(());
+                            }
+                        }
+                    }
+                }
+            }
+            Ok(Some(Ok(Message::Close(_)))) => {
+                return Err(test_error("websocket closed before prompt"))
+            }
+            Ok(Some(Ok(_))) => {}
+            Ok(Some(Err(err))) => return Err(err.into()),
+            Ok(None) => return Err(test_error("websocket stream ended before prompt")),
+            Err(_) if saw_output => return Ok(()),
+            Err(_) => break,
+        }
+    }
+
+    Err(test_error(format!("shell prompt was not observed; output so far: {collected:?}")))
+}
+
+#[cfg(any(unix, windows))]
+fn looks_like_prompt(output: &str) -> bool {
+    output.contains("\u{1b}]133;A")
+        || output.contains("> ")
+        || output.ends_with("$ ")
+        || output.ends_with("# ")
+}
+
+#[cfg(any(unix, windows))]
+async fn wait_for_session_exit(
+    ws: &mut tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+) -> TestResult {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut messages = Vec::new();
+
+    while Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        match tokio::time::timeout(remaining, ws.next()).await {
+            Ok(Some(Ok(Message::Text(text)))) => {
+                if let Ok(msg) = serde_json::from_str::<Value>(&text) {
+                    if msg.get("type").and_then(Value::as_str) == Some("session_exit") {
+                        return Ok(());
+                    }
+                }
+                messages.push(text);
+            }
+            Ok(Some(Ok(Message::Close(_))) | None) | Err(_) => break,
+            Ok(Some(Ok(_))) => {}
+            Ok(Some(Err(err))) => return Err(err.into()),
+        }
+    }
+
+    Err(test_error(format!("session_exit was not received; messages: {messages:?}")))
+}
+
+#[cfg(any(unix, windows))]
+async fn wait_until_tab_removed(client: &reqwest::Client, base: &str, tab_id: &str) -> TestResult {
+    let deadline = Instant::now() + Duration::from_secs(5);
+
+    while Instant::now() < deadline {
+        let tabs: Value = client
+            .get(format!("{base}/api/tabs"))
+            .bearer_auth("regression-token")
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        let still_present = tabs.get("tabs").and_then(Value::as_array).is_some_and(|tabs| {
+            tabs.iter().any(|tab| tab.get("tab_id").and_then(Value::as_str) == Some(tab_id))
+        });
+        if !still_present {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    Err(test_error(format!("tab {tab_id} was not removed after shell exit")))
+}
+
+#[cfg(any(unix, windows))]
+fn read_log(dir: &Path, name: &str) -> String {
+    fs::read_to_string(dir.join(name)).unwrap_or_else(|_| "<missing log>".to_string())
+}
+
+#[cfg(any(unix, windows))]
+#[tokio::test]
+async fn shell_exit_notifies_ws_and_removes_tab() -> TestResult {
+    let server = env!("CARGO_BIN_EXE_dinotty-server");
+    let port = free_loopback_port()?;
+    let tmp = tempfile::Builder::new().prefix("dinotty-exit-regression-").tempdir()?;
+
+    let appdata = tmp.path().join("AppData").join("Roaming");
+    let localappdata = tmp.path().join("AppData").join("Local");
+    let userprofile = tmp.path().join("User");
+    create_dir(&appdata)?;
+    create_dir(&localappdata)?;
+    create_dir(&userprofile)?;
+
+    let shell = test_shell()?;
+    let mut child = spawn_server(
+        server,
+        port,
+        &userprofile,
+        &tmp,
+        &appdata,
+        &localappdata,
+        &userprofile,
+        &shell,
+    )?;
+
+    let client = reqwest::Client::builder().timeout(Duration::from_secs(3)).build()?;
+    let base = format!("http://127.0.0.1:{port}");
+    wait_until_ready(&client, &base, port, &mut child, tmp.path()).await?;
+
+    let created: Value = client
+        .post(format!("{base}/api/tabs"))
+        .bearer_auth("regression-token")
+        .json(&serde_json::json!({ "cwd": null }))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    let tab_id = created
+        .get("tab_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| test_error("create tab response missing tab_id"))?
+        .to_string();
+    let pane_id = created
+        .get("pane_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| test_error("create tab response missing pane_id"))?;
+
+    let cookie = login_cookie(&client, &base).await?;
+    let ws_url = format!("ws://127.0.0.1:{port}/ws?paneId={pane_id}");
+    let mut request = ws_url.into_client_request()?;
+    request.headers_mut().insert(COOKIE, HeaderValue::from_str(&cookie)?);
+    let (mut ws, _) = tokio_tungstenite::connect_async(request).await?;
+    wait_for_shell_prompt(&mut ws).await?;
+
+    ws.send(Message::Text(serde_json::json!({ "type": "input", "data": "exit\r" }).to_string()))
+        .await?;
+
+    wait_for_session_exit(&mut ws).await?;
+    wait_until_tab_removed(&client, &base, &tab_id).await?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- detect local PTY child process exits even when the PTY reader does not receive EOF
- send a real `session_exit` event to WebSocket/Tauri clients
- add a cross-platform regression test that creates a tab, sends `exit`, and verifies the tab is removed

## Verification
- local tests passed
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --workspace`
- `cargo clippy --test terminal_exit_regression -- -D warnings`
- `cargo test --test terminal_exit_regression`