### PR TITLE
feat: per-device font override via localStorage layer

### DIFF
--- a/frontend/src/components/SettingsPanel.vue
+++ b/frontend/src/components/SettingsPanel.vue
@@ -599,6 +599,24 @@ const tabs = computed(() => [
   min-width: 40px;
   text-align: right;
 }
+.setting-reset {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  color: var(--fg-muted);
+  cursor: pointer;
+  opacity: 0.7;
+  transition: color 0.15s ease, opacity 0.15s ease, background 0.15s ease;
+}
+.setting-reset:hover {
+  color: var(--fg);
+  opacity: 1;
+  background: var(--border);
+}
 
 .toggle {
   position: relative;

--- a/frontend/src/components/settings/AppearanceTab.vue
+++ b/frontend/src/components/settings/AppearanceTab.vue
@@ -82,13 +82,25 @@
         <div class="range-wrap">
           <input
             type="range"
-            v-model.number="settings.text.font_size"
-            min="8"
-            max="32"
+            v-model.number="fontSize"
+            :min="FONT_SIZE_MIN"
+            :max="FONT_SIZE_MAX"
             step="1"
-            @input="onTextSettingChange"
           />
-          <span class="range-val">{{ settings.text.font_size }}px</span>
+          <span class="range-val">{{ fontSize }}px</span>
+          <button
+            v-if="hasOverride('font_size')"
+            type="button"
+            class="setting-reset"
+            title="reset to default"
+            aria-label="reset to default"
+            @click="resetOverride('font_size')"
+          >
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+              <path d="M3 3v5h5" />
+            </svg>
+          </button>
         </div>
       </div>
 
@@ -97,7 +109,7 @@
         <div class="font-dropdown">
           <div
             class="font-dropdown-trigger shortcut-input"
-            :style="{ fontFamily: settings.text.font_family || 'inherit' }"
+            :style="{ fontFamily: fontFamily || 'inherit' }"
             @click="toggleFontDropdown"
           >
             <span>{{ currentFontLabel }}</span>
@@ -146,6 +158,19 @@
             <div v-if="addFontError" class="font-add-error">{{ addFontError }}</div>
           </div>
         </div>
+        <button
+          v-if="hasOverride('font_family')"
+          type="button"
+          class="setting-reset"
+          title="reset to default"
+          aria-label="reset to default"
+          @click="resetOverride('font_family')"
+        >
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+            <path d="M3 3v5h5" />
+          </svg>
+        </button>
       </div>
 
       <div class="settings-row">
@@ -153,13 +178,25 @@
         <div class="range-wrap">
           <input
             type="range"
-            v-model.number="settings.text.line_height"
+            v-model.number="lineHeight"
             min="0.8"
             max="2.0"
             step="0.1"
-            @input="onTextSettingChange"
           />
-          <span class="range-val">{{ settings.text.line_height.toFixed(1) }}</span>
+          <span class="range-val">{{ lineHeight.toFixed(1) }}</span>
+          <button
+            v-if="hasOverride('line_height')"
+            type="button"
+            class="setting-reset"
+            title="reset to default"
+            aria-label="reset to default"
+            @click="resetOverride('line_height')"
+          >
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+              <path d="M3 3v5h5" />
+            </svg>
+          </button>
         </div>
       </div>
 
@@ -168,13 +205,25 @@
         <div class="range-wrap">
           <input
             type="range"
-            v-model.number="settings.text.letter_spacing"
+            v-model.number="letterSpacing"
             min="0"
             max="4"
             step="0.5"
-            @input="onTextSettingChange"
           />
-          <span class="range-val">{{ settings.text.letter_spacing }}px</span>
+          <span class="range-val">{{ letterSpacing }}px</span>
+          <button
+            v-if="hasOverride('letter_spacing')"
+            type="button"
+            class="setting-reset"
+            title="reset to default"
+            aria-label="reset to default"
+            @click="resetOverride('letter_spacing')"
+          >
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+              <path d="M3 3v5h5" />
+            </svg>
+          </button>
         </div>
       </div>
 
@@ -292,8 +341,21 @@ import {
   type AddFontError,
 } from '../../utils/fontList'
 import { isFontAvailable, clearNegativeFontCache } from '../../utils/fontAvailability'
+import {
+  FONT_SIZE_MAX,
+  FONT_SIZE_MIN,
+  useDeviceTextSettings,
+} from '../../composables/useDeviceTextSettings'
 
 const { settings, saveSettings, applyCurrentTheme } = useSettings()
+const {
+  fontSize,
+  fontFamily,
+  lineHeight,
+  letterSpacing,
+  hasOverride,
+  resetOverride,
+} = useDeviceTextSettings()
 const { t, themeLabel } = useI18n()
 
 // ── Theme ──
@@ -422,7 +484,7 @@ const customFonts = computed<string[]>(() => settings.text.custom_fonts ?? [])
 interface DecoratedItem extends FontItem { available: boolean }
 
 const fontList = computed<DecoratedItem[]>(() =>
-  buildFontList(settings.text.font_family || '', customFonts.value).map((it) => {
+  buildFontList(fontFamily.value || '', customFonts.value).map((it) => {
     let available = true
     if (it.kind !== 'default') {
       const id = fontIdentity(it.family)
@@ -433,7 +495,7 @@ const fontList = computed<DecoratedItem[]>(() =>
 )
 
 const currentFontLabel = computed(() =>
-  settings.text.font_family ? primaryFamily(settings.text.font_family) : t('settings.text.fontFamilyDefault'),
+  fontFamily.value ? primaryFamily(fontFamily.value) : t('settings.text.fontFamilyDefault'),
 )
 
 function fontItemLabel(item: FontItem): string {
@@ -453,7 +515,7 @@ async function runProbes() {
   } catch { /* ignore */ }
   clearNegativeFontCache()
   for (const key of Object.keys(availability)) delete availability[key]
-  for (const it of buildFontList(settings.text.font_family || '', customFonts.value)) {
+  for (const it of buildFontList(fontFamily.value || '', customFonts.value)) {
     if (it.kind !== 'default') probe(it.family)
   }
 }
@@ -478,9 +540,8 @@ function closeFontDropdown() {
 }
 
 function selectFontItem(item: FontItem) {
-  settings.text.font_family = item.kind === 'default' ? '' : toFontFamilyStack(item.family)
+  fontFamily.value = item.kind === 'default' ? '' : toFontFamilyStack(item.family)
   fontDropdownOpen.value = false
-  onTextSettingChange()
 }
 
 const ADD_ERR_KEY: Record<Exclude<AddFontError, ''>, string> = {
@@ -510,8 +571,8 @@ function removeFontItem(item: FontItem) {
   if (!item.removable) return
   const id = fontIdentity(item.family)
   settings.text.custom_fonts = normalizeCustomFonts(customFonts.value.filter((c) => fontIdentity(c) !== id))
-  if (fontIdentity(settings.text.font_family || '') === id) {
-    settings.text.font_family = 'monospace'
+  if (fontIdentity(fontFamily.value || '') === id) {
+    fontFamily.value = 'monospace'
   }
   onTextSettingChange()
 }

--- a/frontend/src/composables/useDeviceTextSettings.ts
+++ b/frontend/src/composables/useDeviceTextSettings.ts
@@ -1,0 +1,188 @@
+import { computed, reactive, readonly, watch, type WritableComputedRef } from 'vue'
+import { settings, type TextConfig } from './useSettings'
+
+export const FONT_SIZE_MIN = 8
+export const FONT_SIZE_MAX = 72
+
+const LINE_HEIGHT_MIN = 0.8
+const LINE_HEIGHT_MAX = 2
+const LETTER_SPACING_MIN = 0
+const LETTER_SPACING_MAX = 4
+const STORAGE_KEY = 'dinotty_device_text_overrides_v1'
+
+type DeviceTextField = 'font_size' | 'font_family' | 'line_height' | 'letter_spacing'
+type DeviceTextOverrides = Partial<Pick<TextConfig, DeviceTextField>>
+
+const overrides = reactive<DeviceTextOverrides>({})
+let loaded = false
+
+function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value))
+}
+
+function normalizeOverride(field: DeviceTextField, value: unknown): number | string | undefined {
+  if (field === 'font_family') return typeof value === 'string' ? value : undefined
+  if (typeof value !== 'number' || !Number.isFinite(value)) return undefined
+  if (field === 'font_size') return clamp(value, FONT_SIZE_MIN, FONT_SIZE_MAX)
+  if (field === 'line_height') return clamp(value, LINE_HEIGHT_MIN, LINE_HEIGHT_MAX)
+  return clamp(value, LETTER_SPACING_MIN, LETTER_SPACING_MAX)
+}
+
+function clearOverrides() {
+  for (const field of Object.keys(overrides) as DeviceTextField[]) delete overrides[field]
+}
+
+function removeStoredOverrides() {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.removeItem(STORAGE_KEY)
+  } catch {}
+}
+
+function persistOverrides() {
+  if (typeof window === 'undefined') return
+  try {
+    if (Object.keys(overrides).length === 0) {
+      window.localStorage.removeItem(STORAGE_KEY)
+    } else {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ version: 1, overrides: { ...overrides } }))
+    }
+  } catch {}
+}
+
+function loadStoredOverrides() {
+  clearOverrides()
+  if (typeof window === 'undefined') return
+
+  let raw: string | null
+  try {
+    raw = window.localStorage.getItem(STORAGE_KEY)
+  } catch {
+    return
+  }
+  if (raw === null) return
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    removeStoredOverrides()
+    return
+  }
+
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    Array.isArray(parsed) ||
+    (parsed as { version?: unknown }).version !== 1 ||
+    typeof (parsed as { overrides?: unknown }).overrides !== 'object' ||
+    (parsed as { overrides?: unknown }).overrides === null ||
+    Array.isArray((parsed as { overrides?: unknown }).overrides)
+  ) {
+    removeStoredOverrides()
+    return
+  }
+
+  const stored = (parsed as { overrides: Record<string, unknown> }).overrides
+  for (const field of ['font_size', 'font_family', 'line_height', 'letter_spacing'] as const) {
+    const value = normalizeOverride(field, stored[field])
+    if (value !== undefined) (overrides as Record<DeviceTextField, number | string>)[field] = value
+  }
+  persistOverrides()
+}
+
+function ensureLoaded() {
+  if (loaded) return
+  loaded = true
+  loadStoredOverrides()
+}
+
+ensureLoaded()
+
+const effectiveText = computed<TextConfig>(() => ({
+  ...settings.text,
+  font_size: overrides.font_size ?? settings.text.font_size,
+  font_family: overrides.font_family ?? settings.text.font_family,
+  line_height: overrides.line_height ?? settings.text.line_height,
+  letter_spacing: overrides.letter_spacing ?? settings.text.letter_spacing,
+}))
+
+const listeners = new Set<(text: TextConfig) => void>()
+
+watch(
+  effectiveText,
+  (text) => {
+    listeners.forEach((fn) => fn(text))
+  },
+  { flush: 'sync' },
+)
+
+export function setOverride(field: 'font_family', value: string): void
+export function setOverride(
+  field: Exclude<DeviceTextField, 'font_family'>,
+  value: number,
+): void
+export function setOverride(field: DeviceTextField, value: unknown) {
+  const normalized = normalizeOverride(field, value)
+  if (normalized === undefined) return
+  ;(overrides as Record<DeviceTextField, number | string>)[field] = normalized
+  persistOverrides()
+}
+
+export function hasOverride(field: DeviceTextField) {
+  return Object.prototype.hasOwnProperty.call(overrides, field)
+}
+
+export function resetOverride(field: DeviceTextField) {
+  delete overrides[field]
+  persistOverrides()
+}
+
+export function resetAllOverrides() {
+  clearOverrides()
+  persistOverrides()
+}
+
+export function reloadOverrides() {
+  loaded = true
+  loadStoredOverrides()
+}
+
+export function onEffectiveTextChange(fn: (text: TextConfig) => void) {
+  listeners.add(fn)
+  return () => listeners.delete(fn)
+}
+
+export function getEffectiveText() {
+  ensureLoaded()
+  return effectiveText.value
+}
+
+function writableField<K extends DeviceTextField>(field: K): WritableComputedRef<TextConfig[K]> {
+  return computed({
+    get: () => effectiveText.value[field],
+    set: (value) => setOverride(field as never, value as never),
+  })
+}
+
+const fontSize = writableField('font_size')
+const fontFamily = writableField('font_family')
+const lineHeight = writableField('line_height')
+const letterSpacing = writableField('letter_spacing')
+
+export function useDeviceTextSettings() {
+  ensureLoaded()
+  return {
+    overrides: readonly(overrides),
+    effectiveText,
+    fontSize,
+    fontFamily,
+    lineHeight,
+    letterSpacing,
+    hasOverride,
+    setOverride,
+    resetOverride,
+    resetAllOverrides,
+    reloadOverrides,
+  }
+}

--- a/frontend/src/composables/useTerminal.ts
+++ b/frontend/src/composables/useTerminal.ts
@@ -5,7 +5,15 @@ import { WebglAddon } from '@xterm/addon-webgl'
 import { SearchAddon } from '@xterm/addon-search'
 import type { ClientMsg, ServerMsg } from '../types/protocol'
 import { isTauri, createTransport, type Transport } from './useTransport'
-import { onThemeChange, saveSettings, settings, onTextChange } from './useSettings'
+import { onThemeChange, settings } from './useSettings'
+import {
+  FONT_SIZE_MAX,
+  FONT_SIZE_MIN,
+  getEffectiveText,
+  onEffectiveTextChange,
+  resetOverride,
+  setOverride,
+} from './useDeviceTextSettings'
 import {
   computeWheelPlan,
   type TrackingWheelState,
@@ -265,16 +273,17 @@ export class TerminalInstance {
     const s = getComputedStyle(document.documentElement)
     const v = (name: string) => s.getPropertyValue(name).trim()
 
-    const fontFamily = settings.text.font_family || v('--font-mono')
+    const text = getEffectiveText()
+    const fontFamily = text.font_family || v('--font-mono')
 
     this.xterm = new XTerm({
-      cursorBlink: settings.text.cursor_blink,
-      cursorStyle: settings.text.cursor_style as any,
-      scrollback: settings.text.scrollback,
-      fontSize: settings.text.font_size,
+      cursorBlink: text.cursor_blink,
+      cursorStyle: text.cursor_style as any,
+      scrollback: text.scrollback,
+      fontSize: text.font_size,
       fontFamily,
-      lineHeight: settings.text.line_height,
-      letterSpacing: settings.text.letter_spacing,
+      lineHeight: text.line_height,
+      letterSpacing: text.letter_spacing,
       allowProposedApi: true,
       linkHandler: {
         activate: (_event, text) => {
@@ -554,8 +563,21 @@ export class TerminalInstance {
       if (this.xterm) this.xterm.options.theme = xtermTheme
     })
 
-    this._textUnsub = onTextChange((text) => {
+    let lastLayout = {
+      font_size: text.font_size,
+      font_family: text.font_family,
+      line_height: text.line_height,
+      letter_spacing: text.letter_spacing,
+      scrollback: text.scrollback,
+    }
+    this._textUnsub = onEffectiveTextChange((text) => {
       if (!this.xterm) return
+      const layoutChanged =
+        text.font_size !== lastLayout.font_size ||
+        text.font_family !== lastLayout.font_family ||
+        text.line_height !== lastLayout.line_height ||
+        text.letter_spacing !== lastLayout.letter_spacing ||
+        text.scrollback !== lastLayout.scrollback
       this.xterm.options.fontSize = text.font_size
       this.xterm.options.fontFamily =
         text.font_family ||
@@ -565,7 +587,16 @@ export class TerminalInstance {
       this.xterm.options.cursorBlink = text.cursor_blink
       this.xterm.options.cursorStyle = text.cursor_style as any
       this.xterm.options.scrollback = text.scrollback
-      this._refit()
+      if (layoutChanged) {
+        lastLayout = {
+          font_size: text.font_size,
+          font_family: text.font_family,
+          line_height: text.line_height,
+          letter_spacing: text.letter_spacing,
+          scrollback: text.scrollback,
+        }
+        this._refit()
+      }
     })
   }
 
@@ -583,22 +614,17 @@ export class TerminalInstance {
   }
 
   adjustFontSize(delta: number) {
-    const xt = this.xterm
-    if (!xt) return
-    const newSize = Math.max(8, Math.min(72, (xt.options.fontSize ?? 14) + delta))
-    xt.options.fontSize = newSize
-    settings.text.font_size = newSize
-    saveSettings()
-    this._refit()
+    if (!this.xterm) return
+    const newSize = Math.max(
+      FONT_SIZE_MIN,
+      Math.min(FONT_SIZE_MAX, getEffectiveText().font_size + delta),
+    )
+    setOverride('font_size', newSize)
   }
 
   resetFontSize() {
     if (!this.xterm) return
-    const defaultSize = 14
-    this.xterm.options.fontSize = defaultSize
-    settings.text.font_size = defaultSize
-    saveSettings()
-    this._refit()
+    resetOverride('font_size')
   }
 
   sendData(data: string, force = false) {

--- a/frontend/src/test/AppearanceTab.test.ts
+++ b/frontend/src/test/AppearanceTab.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import AppearanceTab from '../components/settings/AppearanceTab.vue'
+import { settings, saveSettings } from '../composables/useSettings'
+import {
+  getEffectiveText,
+  resetAllOverrides,
+  setOverride,
+} from '../composables/useDeviceTextSettings'
+
+const appearanceMocks = vi.hoisted(() => ({ authFetch: vi.fn(), isFontAvailable: vi.fn(() => true) }))
+
+vi.mock('../composables/apiBase', () => ({
+  apiUrl: (path: string) => path,
+  authFetch: appearanceMocks.authFetch,
+  getApiBase: vi.fn(async () => ''),
+  hasAuthToken: () => false,
+}))
+
+vi.mock('../utils/fontAvailability', () => ({
+  isFontAvailable: appearanceMocks.isFontAvailable,
+  clearNegativeFontCache: vi.fn(),
+}))
+
+class MemoryStorage implements Storage {
+  private data = new Map<string, string>()
+  get length() { return this.data.size }
+  clear() { this.data.clear() }
+  getItem(key: string) { return this.data.get(key) ?? null }
+  key(index: number) { return [...this.data.keys()][index] ?? null }
+  removeItem(key: string) { this.data.delete(key) }
+  setItem(key: string, value: string) { this.data.set(key, String(value)) }
+}
+
+describe('AppearanceTab device text overrides', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    const storage = new MemoryStorage()
+    Object.defineProperty(window, 'localStorage', { value: storage, configurable: true })
+    vi.stubGlobal('localStorage', storage)
+    localStorage.clear()
+    appearanceMocks.authFetch.mockReset()
+    appearanceMocks.isFontAvailable.mockClear()
+    appearanceMocks.authFetch.mockResolvedValue(new Response('{}', { status: 200 }))
+    resetAllOverrides()
+    settings.text.font_size = 14
+    settings.text.font_family = 'server-font'
+    settings.text.line_height = 1.2
+    settings.text.letter_spacing = 1
+    settings.text.cursor_style = 'block'
+    settings.text.custom_fonts = ['Fira Code']
+  })
+
+  it('renders effective values, including a font size above the old max, and writes no PUT on sliders', async () => {
+    setOverride('font_size', 50)
+    const wrapper = mount(AppearanceTab)
+    const ranges = wrapper.findAll<HTMLInputElement>('input[type="range"]')
+    expect(ranges[0].element.value).toBe('50')
+    expect(ranges[0].attributes('min')).toBe('8')
+    expect(ranges[0].attributes('max')).toBe('72')
+    expect(wrapper.findAll('.range-val')[0].text()).toBe('50px')
+
+    await ranges[0].setValue(51)
+    await ranges[1].setValue(1.5)
+    await ranges[2].setValue(2)
+    vi.runAllTimers()
+    expect(getEffectiveText()).toMatchObject({ font_size: 51, line_height: 1.5, letter_spacing: 2 })
+    expect(localStorage.getItem('dinotty_device_text_overrides_v1')).toContain('51')
+    expect(appearanceMocks.authFetch).not.toHaveBeenCalled()
+  })
+
+  it('selects and highlights the effective font without mutating the server font', async () => {
+    setOverride('font_family', 'Fira Code, monospace')
+    const wrapper = mount(AppearanceTab)
+    await wrapper.find('.font-dropdown-trigger').trigger('click')
+    await Promise.resolve()
+    const active = wrapper.find('.font-dropdown-item.active')
+    expect(active.text()).toContain('Fira Code')
+    expect(appearanceMocks.isFontAvailable).toHaveBeenCalledWith('Fira Code')
+    expect(settings.text.font_family).toBe('server-font')
+
+    const menlo = wrapper.findAll('.font-dropdown-item').find((item) => item.text().includes('Menlo'))!
+    await menlo.trigger('click')
+    expect(getEffectiveText().font_family).toContain('Menlo')
+    expect(settings.text.font_family).toBe('server-font')
+    vi.runAllTimers()
+    expect(appearanceMocks.authFetch).not.toHaveBeenCalled()
+  })
+
+  it('keeps removeFontItem hybrid: local fallback plus server custom-font save', async () => {
+    setOverride('font_family', 'Fira Code, monospace')
+    const wrapper = mount(AppearanceTab)
+    await wrapper.find('.font-dropdown-trigger').trigger('click')
+    await Promise.resolve()
+    const row = wrapper.findAll('.font-dropdown-item').find((item) => item.text().includes('Fira Code'))!
+    await row.find('.font-item-remove').trigger('click')
+    vi.advanceTimersByTime(100)
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(getEffectiveText().font_family).toBe('monospace')
+    expect(settings.text.font_family).toBe('server-font')
+    expect(settings.text.custom_fonts).toEqual([])
+    expect(appearanceMocks.authFetch).toHaveBeenCalledWith(
+      '/api/settings',
+      expect.objectContaining({ method: 'PUT' }),
+    )
+  })
+
+  it('keeps server defaults in an unrelated settings PUT', async () => {
+    setOverride('font_size', 50)
+    setOverride('font_family', 'Fira Code, monospace')
+    setOverride('line_height', 1.8)
+    setOverride('letter_spacing', 3)
+    const defaults = { ...settings.text }
+    settings.text.cursor_style = 'bar'
+    await saveSettings()
+    const put = appearanceMocks.authFetch.mock.calls[appearanceMocks.authFetch.mock.calls.length - 1]!
+    const body = JSON.parse(put[1].body as string)
+    expect(body.text).toMatchObject({
+      font_size: defaults.font_size,
+      font_family: defaults.font_family,
+      line_height: defaults.line_height,
+      letter_spacing: defaults.letter_spacing,
+    })
+    expect(settings.text).toMatchObject({
+      font_size: defaults.font_size,
+      font_family: defaults.font_family,
+      line_height: defaults.line_height,
+      letter_spacing: defaults.letter_spacing,
+      cursor_style: 'bar',
+    })
+  })
+
+  it('reset links return to the current server default and cursor_style still PUTs', async () => {
+    setOverride('font_size', 30)
+    const wrapper = mount(AppearanceTab)
+    settings.text.font_size = 18
+    const reset = wrapper.findAll('button.setting-reset').find((button) => button.attributes('title') === 'reset to default')!
+    await reset.trigger('click')
+    expect(getEffectiveText().font_size).toBe(18)
+
+    const cursorSelect = wrapper.find<HTMLSelectElement>('select')
+    await cursorSelect.setValue('underline')
+    vi.advanceTimersByTime(100)
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(appearanceMocks.authFetch).toHaveBeenCalledWith(
+      '/api/settings',
+      expect.objectContaining({ method: 'PUT' }),
+    )
+  })
+})

--- a/frontend/src/test/useDeviceTextSettings.test.ts
+++ b/frontend/src/test/useDeviceTextSettings.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { settings } from '../composables/useSettings'
+import {
+  FONT_SIZE_MAX,
+  getEffectiveText,
+  reloadOverrides,
+  resetAllOverrides,
+  resetOverride,
+  setOverride,
+  useDeviceTextSettings,
+} from '../composables/useDeviceTextSettings'
+
+const KEY = 'dinotty_device_text_overrides_v1'
+
+class MemoryStorage implements Storage {
+  private data = new Map<string, string>()
+  get length() { return this.data.size }
+  clear() { this.data.clear() }
+  getItem(key: string) { return this.data.get(key) ?? null }
+  key(index: number) { return [...this.data.keys()][index] ?? null }
+  removeItem(key: string) { this.data.delete(key) }
+  setItem(key: string, value: string) { this.data.set(key, String(value)) }
+}
+
+describe('useDeviceTextSettings', () => {
+  beforeEach(() => {
+    const storage = new MemoryStorage()
+    Object.defineProperty(window, 'localStorage', { value: storage, configurable: true })
+    vi.stubGlobal('localStorage', storage)
+    localStorage.clear()
+    resetAllOverrides()
+    settings.text.font_size = 14
+    settings.text.font_family = 'server-font'
+    settings.text.line_height = 1.2
+    settings.text.letter_spacing = 1
+  })
+
+  it('inherits server text without an override and performs no storage write', () => {
+    const setItem = vi.spyOn(localStorage, 'setItem')
+    reloadOverrides()
+    expect(getEffectiveText()).toMatchObject(settings.text)
+    expect(setItem).not.toHaveBeenCalled()
+  })
+
+  it('supports partial overrides, local precedence, reset, and valid falsy values', () => {
+    const device = useDeviceTextSettings()
+    setOverride('font_size', 50)
+    setOverride('font_family', '')
+    setOverride('letter_spacing', 0)
+    expect(getEffectiveText()).toMatchObject({ font_size: 50, font_family: '', letter_spacing: 0 })
+
+    settings.text.font_size = 16
+    settings.text.line_height = 1.5
+    expect(getEffectiveText()).toMatchObject({ font_size: 50, line_height: 1.5 })
+    expect(device.hasOverride('font_size')).toBe(true)
+
+    resetOverride('font_size')
+    expect(getEffectiveText().font_size).toBe(16)
+    expect(JSON.parse(localStorage.getItem(KEY)!)).toEqual({
+      version: 1,
+      overrides: { font_family: '', letter_spacing: 0 },
+    })
+    resetAllOverrides()
+    expect(localStorage.getItem(KEY)).toBeNull()
+  })
+
+  it('clamps valid numeric fields and ignores invalid siblings and unknown keys', () => {
+    localStorage.setItem(KEY, JSON.stringify({
+      version: 1,
+      overrides: {
+        font_size: 500,
+        font_family: ['bad'],
+        line_height: '1.5',
+        letter_spacing: 2,
+        unknown: 123,
+      },
+    }))
+    reloadOverrides()
+    expect(getEffectiveText()).toMatchObject({
+      font_size: FONT_SIZE_MAX,
+      font_family: 'server-font',
+      line_height: 1.2,
+      letter_spacing: 2,
+    })
+    expect(JSON.parse(localStorage.getItem(KEY)!)).toEqual({
+      version: 1,
+      overrides: { font_size: FONT_SIZE_MAX, letter_spacing: 2 },
+    })
+  })
+
+  it.each([
+    '{',
+    JSON.stringify({ version: 2, overrides: {} }),
+    JSON.stringify([]),
+    JSON.stringify({ version: 1, overrides: null }),
+  ])('drops a malformed root/key: %s', (raw) => {
+    localStorage.setItem(KEY, raw)
+    reloadOverrides()
+    expect(getEffectiveText()).toMatchObject(settings.text)
+    expect(localStorage.getItem(KEY)).toBeNull()
+  })
+
+  it('rejects non-finite and wrong-type setter values', () => {
+    const unsafeSet = setOverride as (field: string, value: unknown) => void
+    for (const value of [NaN, Infinity, '18', [], {}, null, true]) {
+      unsafeSet('font_size', value)
+    }
+    for (const value of [1, [], {}, null, true]) unsafeSet('font_family', value)
+    expect(localStorage.getItem(KEY)).toBeNull()
+    expect(getEffectiveText()).toMatchObject(settings.text)
+  })
+
+  it('continues in memory when storage reads and writes throw', () => {
+    const getItem = vi.spyOn(localStorage, 'getItem').mockImplementation(() => {
+      throw new Error('disabled')
+    })
+    const setItem = vi.spyOn(localStorage, 'setItem').mockImplementation(() => {
+      throw new Error('disabled')
+    })
+    expect(() => reloadOverrides()).not.toThrow()
+    expect(() => setOverride('font_size', 22)).not.toThrow()
+    expect(getEffectiveText().font_size).toBe(22)
+    getItem.mockRestore()
+    setItem.mockRestore()
+  })
+})

--- a/frontend/src/test/useTerminalDeviceText.test.ts
+++ b/frontend/src/test/useTerminalDeviceText.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const xtermMocks = vi.hoisted(() => ({ instances: [] as any[] }))
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: class {
+    options: Record<string, any>
+    unicode = { activeVersion: '' }
+    parser = { registerOscHandler() {} }
+    buffer = { active: { getLine: () => null, cursorY: 0, cursorX: 0 } }
+    constructor(options: Record<string, any>) {
+      this.options = { ...options }
+      xtermMocks.instances.push(this)
+    }
+    loadAddon() {}
+    open(wrapper: HTMLElement) {
+      const el = document.createElement('div')
+      el.className = 'xterm'
+      wrapper.appendChild(el)
+    }
+    attachCustomKeyEventHandler() {}
+    registerLinkProvider() {}
+    onTitleChange() {}
+    onData() {}
+    hasSelection() { return false }
+    dispose() {}
+    focus() {}
+    blur() {}
+  },
+}))
+
+vi.mock('@xterm/addon-fit', () => ({ FitAddon: class { fit = vi.fn() } }))
+vi.mock('@xterm/addon-unicode11', () => ({ Unicode11Addon: class {} }))
+vi.mock('@xterm/addon-webgl', () => ({ WebglAddon: class { onContextLoss() {}; dispose() {} } }))
+vi.mock('@xterm/addon-search', () => ({ SearchAddon: class {} }))
+vi.mock('../composables/useTransport', () => ({
+  isTauri: () => true,
+  createTransport: () => ({
+    onConnect() {}, onMessage() {}, onDisconnect() {}, connect() {}, disconnect() {}, send() {},
+  }),
+}))
+
+import { TerminalInstance } from '../composables/useTerminal'
+import { settings, notifyTextChange } from '../composables/useSettings'
+import {
+  getEffectiveText,
+  resetAllOverrides,
+  setOverride,
+} from '../composables/useDeviceTextSettings'
+
+class MemoryStorage implements Storage {
+  private data = new Map<string, string>()
+  get length() { return this.data.size }
+  clear() { this.data.clear() }
+  getItem(key: string) { return this.data.get(key) ?? null }
+  key(index: number) { return [...this.data.keys()][index] ?? null }
+  removeItem(key: string) { this.data.delete(key) }
+  setItem(key: string, value: string) { this.data.set(key, String(value)) }
+}
+
+function attach(id: string) {
+  const term = new TerminalInstance(id)
+  vi.spyOn(term as any, '_setupAdaptiveWheel').mockImplementation(() => {})
+  vi.spyOn(term as any, '_scheduleSettleResize').mockImplementation(() => {})
+  vi.spyOn(term as any, '_refit').mockImplementation(() => {})
+  term.attach(document.createElement('div'))
+  return term
+}
+
+describe('useTerminal device text integration', () => {
+  beforeEach(() => {
+    xtermMocks.instances.length = 0
+    const storage = new MemoryStorage()
+    Object.defineProperty(window, 'localStorage', { value: storage, configurable: true })
+    vi.stubGlobal('localStorage', storage)
+    localStorage.clear()
+    resetAllOverrides()
+    settings.text.font_size = 16
+    settings.text.font_family = 'server-font'
+    settings.text.line_height = 1.2
+    settings.text.letter_spacing = 1
+    settings.text.cursor_blink = true
+    settings.text.scrollback = 10000
+    vi.stubGlobal('ResizeObserver', class { observe() {}; disconnect() {} })
+  })
+
+  it('initializes xterm from effective text', () => {
+    setOverride('font_size', 24)
+    setOverride('font_family', 'local-font')
+    const term = attach('p1')
+    expect(term.xterm?.options).toMatchObject({ fontSize: 24, fontFamily: 'local-font' })
+    term.destroy()
+  })
+
+  it('broadcasts local changes to two panes and refits each once', () => {
+    const one = attach('p1')
+    const two = attach('p2')
+    const refitOne = one['_refit'] as ReturnType<typeof vi.fn>
+    const refitTwo = two['_refit'] as ReturnType<typeof vi.fn>
+    setOverride('font_size', 26)
+    expect(one.xterm?.options.fontSize).toBe(26)
+    expect(two.xterm?.options.fontSize).toBe(26)
+    expect(refitOne).toHaveBeenCalledTimes(1)
+    expect(refitTwo).toHaveBeenCalledTimes(1)
+    one.destroy(); two.destroy()
+  })
+
+  it('zooms from the effective value, clamps, and reset returns the server default', () => {
+    setOverride('font_size', 20)
+    const term = attach('p1')
+    const refit = term['_refit'] as ReturnType<typeof vi.fn>
+    term.adjustFontSize(100)
+    expect(getEffectiveText().font_size).toBe(72)
+    expect(settings.text.font_size).toBe(16)
+    expect(refit).toHaveBeenCalledTimes(1)
+    term.resetFontSize()
+    expect(getEffectiveText().font_size).toBe(16)
+    expect(term.xterm?.options.fontSize).toBe(16)
+    expect(refit).toHaveBeenCalledTimes(2)
+    term.destroy()
+  })
+
+  it('propagates server cursor/scrollback changes but refits only layout changes', () => {
+    const term = attach('p1')
+    const refit = term['_refit'] as ReturnType<typeof vi.fn>
+    settings.text.cursor_blink = false
+    notifyTextChange()
+    expect(term.xterm?.options.cursorBlink).toBe(false)
+    expect(refit).not.toHaveBeenCalled()
+    settings.text.scrollback = 20000
+    notifyTextChange()
+    expect(term.xterm?.options.scrollback).toBe(20000)
+    expect(refit).toHaveBeenCalledTimes(1)
+    term.destroy()
+  })
+})


### PR DESCRIPTION
## What

Make the four text-appearance fields — font size, font family, line height and
letter spacing — **per-device**. The value stored on the server becomes a shared
default; each device (browser / installed app) keeps its own override in
`localStorage`. `custom_fonts` stays fully server-synced, unchanged.

This lets, e.g., a large desktop monitor and a laptop each keep their own
comfortable font size without one overwriting the other through the shared
settings, while everything else about the settings sync is untouched.

Frontend-only — no backend / API changes.

## How

- **new `useDeviceTextSettings` composable** — reactive overrides with
  `effective = localOverride ?? serverDefault` (nullish, so `letter-spacing: 0`
  and an empty font family are valid overrides), storage key
  `dinotty_device_text_overrides_v1`, per-field validation/clamp, a guarded
  storage adapter (bad/absent storage degrades to server defaults), and a
  module-level `effectiveText` watch used as the multi-pane broadcast channel.
- **`useTerminal`** — init and the reactive apply path read the effective value;
  `adjustFontSize` / `resetFontSize` write the device override instead of
  mutating `settings.text` and calling `saveSettings` (so a zoom on one device no
  longer PUTs a new shared default).
- **`AppearanceTab`** — the four controls bind to `WritableComputedRef`; a
  per-field reset (icon button) appears only when that field has an override and
  clears it back to the server default.
- **`SettingsPanel`** — terminal repaint is driven by the `effectiveText` watcher.

## Testing

- `pnpm build` green (includes `vue-tsc` typecheck).
- New unit tests (18) covering the nullish merge, storage validation/edge cases,
  the zoom-writes-override path, and the control rebinding all pass.
