### PR TITLE
fix(macos): declare Bluetooth usage for terminal tools

### DIFF
--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>Dinotty needs local network access to connect to SSH hosts and other services on your network.</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Dinotty allows terminal applications to query Bluetooth device information.</string>
 	<key>NSBonjourServices</key>
 	<array>
 		<string>_ssh._tcp</string>


### PR DESCRIPTION
## Summary

Fixes #150.

macOS TCC aborts terminal child processes that query paired Bluetooth devices when the responsible Dinotty app lacks a Bluetooth usage description. This lets macOS use its normal privacy flow instead of terminating those processes with `SIGABRT`.

## Changes

- Add `NSBluetoothAlwaysUsageDescription` to `src-tauri/Info.plist` with a user-facing explanation covering terminal applications.

## Test Plan

- [x] Tested locally
- [ ] Frontend type-check passes (`npx vue-tsc --noEmit`) — not applicable; no frontend changes
- [ ] No regressions on desktop browser — not applicable; macOS bundle metadata only
- [ ] No regressions on mobile browser (if applicable) — not applicable

Additional verification:

- `plutil -lint src-tauri/Info.plist`
- `pnpm dlx @tauri-apps/cli@2.11.4 build --bundles app --debug --ci`
- Verified `NSBluetoothAlwaysUsageDescription` in the generated `Dinotty.app/Contents/Info.plist`
- `codesign --verify --deep --strict --verbose=2 target/debug/bundle/macos/Dinotty.app`
