### PR TITLE
Strip inherited Claude Code session env from spawned terminals; make detached-reap timeout configurable

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -120,6 +120,7 @@ Windows 上可通过 Docker Desktop 使用 Linux 容器部署；`.env` 中的工
 | Token | `DINOTTY_TOKEN` 环境变量或配置文件 | 未配置 / 首次设置 | 访问认证令牌，为空时进入首次设置流程 |
 | 日志级别 | `RUST_LOG` 环境变量 | info | trace / debug / info / warn / error |
 | Shell | Unix: `SHELL`；Windows: `DINOTTY_SHELL` | 自动检测 | Windows 优先 `DINOTTY_SHELL`，再尝试 `pwsh.exe`、`powershell.exe`、`%ComSpec%` / `cmd.exe` |
+| 分离会话回收时间 | `DINOTTY_DETACH_REAP_SECS` 环境变量 | 5400（90 分钟） | seconds a detached (disconnected) session is kept before the cleanup task reaps it; default 5400 (90 minutes) |
 
 ### 配置与数据目录
 

--- a/src/plugin/handlers.rs
+++ b/src/plugin/handlers.rs
@@ -156,6 +156,9 @@ pub async fn plugin_exec(
     if let Some(ref cwd) = body.cwd {
         cmd.current_dir(cwd);
     }
+    for key in crate::pty::claude_session_env_keys_to_strip() {
+        cmd.env_remove(key);
+    }
     if let Some(ref env) = body.env {
         cmd.envs(env);
     }
@@ -219,6 +222,9 @@ pub async fn plugin_spawn_ws(
 
         let bin_path = plugin_dir.join(&bin.entry);
         let mut cmd = Command::new(&bin_path);
+        for key in crate::pty::claude_session_env_keys_to_strip() {
+            cmd.env_remove(key);
+        }
         cmd.no_window().args(&args).stdout(Stdio::piped()).stderr(Stdio::piped());
         let mut child = match cmd.spawn() {
             Ok(c) => c,
@@ -748,6 +754,9 @@ pub async fn plugin_process_start(
 
     let bin_path = pm.plugin_dir.join(&id).join(&bin.entry);
     let mut cmd = Command::new(&bin_path);
+    for key in crate::pty::claude_session_env_keys_to_strip() {
+        cmd.env_remove(key);
+    }
     cmd.no_window();
     cmd.args(&body.args);
     cmd.stdout(Stdio::piped());

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -150,6 +150,9 @@ pub fn create_session(
     let shell_spec = shell::default_shell();
     let shell_type = shell_spec.shell_type.clone();
     let mut cmd = CommandBuilder::new(&shell_spec.program);
+    for key in claude_session_env_keys_to_strip() {
+        cmd.env_remove(&key);
+    }
     for arg in &shell_spec.args {
         cmd.arg(arg);
     }
@@ -551,6 +554,24 @@ fn locale_adjustment(
     }
 }
 
+/// Env keys inherited from a parent Claude Code session that must NOT leak into
+/// the spawned terminal — otherwise an interactive `claude` inside the terminal
+/// treats itself as a child session and never persists its transcript.
+pub(crate) fn claude_session_env_keys_to_strip() -> Vec<String> {
+    std::env::vars_os()
+        .filter_map(|(k, _)| k.into_string().ok())
+        .filter(|k| is_claude_session_env_key(k))
+        .collect()
+}
+
+/// True if `key` is a Claude Code SESSION-scoped env var that must be stripped
+/// from spawned child processes (case-insensitive; generic CLAUDE_* like
+/// `CLAUDE_CONFIG_DIR` is preserved).
+fn is_claude_session_env_key(key: &str) -> bool {
+    let ku = key.to_ascii_uppercase();
+    ku.starts_with("CLAUDE_CODE_") || ku == "CLAUDECODE" || ku == "CLAUDE_SESSION_ID"
+}
+
 fn configure_utf8_locale(cmd: &mut CommandBuilder) {
     let lc_all = std::env::var("LC_ALL").ok();
     let lc_ctype = std::env::var("LC_CTYPE").ok();
@@ -583,7 +604,37 @@ pub fn get_shell_args(shell: &str) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{locale_adjustment, LocaleAdjustment};
+    use super::{is_claude_session_env_key, locale_adjustment, LocaleAdjustment};
+
+    #[test]
+    fn strips_claude_session_keys_case_insensitive() {
+        for k in [
+            "CLAUDE_CODE_CHILD_SESSION",
+            "claude_code_child_session",
+            "CLAUDECODE",
+            "claudecode",
+            "CLAUDE_SESSION_ID",
+            "Claude_Session_Id",
+            "CLAUDE_CODE_ENTRYPOINT",
+        ] {
+            assert!(is_claude_session_env_key(k), "should strip {k}");
+        }
+    }
+
+    #[test]
+    fn preserves_generic_and_dinotty_keys() {
+        for k in [
+            "CLAUDE_CONFIG_DIR",
+            "DINOTTY_PANE_ID",
+            "DINOTTY_TAB_ID",
+            "PATH",
+            "HOME",
+            "TERM",
+            "CLAUDECODEX",
+        ] {
+            assert!(!is_claude_session_env_key(k), "should preserve {k}");
+        }
+    }
 
     #[test]
     fn locale_defaults_to_utf8_ctype_when_environment_is_missing() {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -62,6 +62,10 @@ const SYNC_BUFFER_LIMIT: usize = 256 * 1024;
 /// Maximum size of a single chunk sent to clients during flush.
 const FLUSH_CHUNK_SIZE: usize = 64 * 1024;
 
+fn parse_reap_secs(raw: Option<String>) -> u64 {
+    raw.and_then(|v| v.parse::<u64>().ok()).unwrap_or(5_400)
+}
+
 pub enum SessionStatus {
     Connected,
     Detached { since: Instant },
@@ -1205,9 +1209,10 @@ impl SessionManager {
         let manager = Arc::clone(self);
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
+            let reap_secs = parse_reap_secs(std::env::var("DINOTTY_DETACH_REAP_SECS").ok());
+            let timeout = std::time::Duration::from_secs(reap_secs);
             loop {
                 interval.tick().await;
-                let timeout = std::time::Duration::from_mins(5);
                 // Two-pass: collect stale IDs first, then kill_and_remove.
                 // Can't use retain() because we need to kill child processes.
                 let stale: Vec<String> = manager

--- a/src/session/tests.rs
+++ b/src/session/tests.rs
@@ -23,6 +23,28 @@ fn split(direction: &str, children: Vec<serde_json::Value>) -> serde_json::Value
     })
 }
 
+// ── parse_reap_secs ─────────────────────────────────────────────
+
+#[test]
+fn parse_reap_secs_defaults_when_missing() {
+    assert_eq!(parse_reap_secs(None), 5_400);
+}
+
+#[test]
+fn parse_reap_secs_parses_valid_value() {
+    assert_eq!(parse_reap_secs(Some("3600".to_string())), 3_600);
+}
+
+#[test]
+fn parse_reap_secs_defaults_for_invalid_value() {
+    assert_eq!(parse_reap_secs(Some("notanumber".to_string())), 5_400);
+}
+
+#[test]
+fn parse_reap_secs_accepts_zero() {
+    assert_eq!(parse_reap_secs(Some("0".to_string())), 0);
+}
+
 // ── find_subslice ────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Two related fixes for running dinotty from within a Claude Code session.

### 1. Session-env leak breaks transcript persistence (bug fix)

A terminal or plugin process spawned by dinotty inherits the parent process
environment. When dinotty itself is launched from inside a Claude Code session,
the session-scoped vars `CLAUDE_CODE_CHILD_SESSION` / `CLAUDECODE` /
`CLAUDE_SESSION_ID` leak into every PTY and plugin child. An interactive
`claude` running inside a dinotty terminal then sees
`CLAUDE_CODE_CHILD_SESSION=1`, treats itself as a sub-session, and never writes
its top-level transcript — so the session is absent from `--resume` even though
its work (git commits, tool results) lands normally.

Fix: strip these session-scoped vars at every child-spawn site — the shared PTY
`create_session` plus all three plugin exec paths (`exec`, `spawn_ws`,
`process_start`). Generic `CLAUDE_*` vars (e.g. `CLAUDE_CONFIG_DIR`) are
preserved; the prefix match is limited to `CLAUDE_CODE_*`. Matching is
ASCII-case-insensitive for Windows env semantics, and removing an absent var is
a no-op, so sessions launched without these vars are unaffected.

### 2. Detached-session reap timeout is hard-coded to 5 min (enhancement)

The detached-session reaper force-kills any session that has been detached for
5 minutes. A browser tab that loses its WebSocket (laptop sleep, network drop,
backgrounded tab) is therefore killed after 5 min even while the tab is still
open. This makes the timeout configurable via `DINOTTY_DETACH_REAP_SECS`,
defaulting to 5400s (90 min). The parse/fallback logic is extracted into a pure
helper with unit tests (default, valid override, unparseable-fallback, zero).

## Testing

- `cargo fmt --check` clean
- `cargo test` passes (including the new `parse_reap_secs` unit tests)
- Manual: an interactive `claude` inside a dinotty terminal spawned by the
  patched server now persists its transcript and reappears in `--resume`;
  before the patch it did not.
