### PR TITLE
feat(notify): inject per-surface DINOTTY_URL into spawned terminals

### DIFF
--- a/docs/notifications.en.md
+++ b/docs/notifications.en.md
@@ -7,7 +7,7 @@ Dinotty has a built-in notification system supporting terminal bell detection an
 Send notifications via `POST /api/notify`:
 
 ```bash
-curl -s -X POST http://127.0.0.1:8999/api/notify \
+curl -s -X POST ${DINOTTY_URL}/api/notify \
   -H "Content-Type: application/json" \
   -d '{"body": "Task completed", "title": "My Agent", "notification_type": "info"}'
 ```
@@ -38,13 +38,14 @@ Dinotty automatically injects the following environment variables when creating 
 |----------|-------------|
 | `DINOTTY_PANE_ID` | Unique ID of the current pane (leaf pane) |
 | `DINOTTY_TAB_ID` | Tab ID of the current pane |
+| `DINOTTY_URL` | the notify base URL of the dinotty surface that owns this pane (`http://127.0.0.1:<port>`) — use it instead of a hardcoded port. |
 
 Environment variables are **process-level isolated** — each pane is set independently and will not overwrite others.
 
 Send notifications with these IDs for precise jump targeting:
 
 ```bash
-curl -X POST http://127.0.0.1:8999/api/notify \
+curl -X POST ${DINOTTY_URL}/api/notify \
   -H "Content-Type: application/json" \
   -d "{
     \"pane_id\": \"$DINOTTY_PANE_ID\",
@@ -68,7 +69,7 @@ When running Claude Code in a dinotty terminal, you can use hooks to automatical
         "hooks": [
           {
             "type": "command",
-            "command": "curl -s -X POST http://127.0.0.1:8999/api/notify -H 'Content-Type: application/json' -d '{\"body\":\"Claude needs your input\",\"title\":\"Claude Code\",\"notification_type\":\"warning\",\"pane_id\":\"'\"$DINOTTY_PANE_ID\"'\"}'"
+            "command": "curl -s -X POST ${DINOTTY_URL}/api/notify -H 'Content-Type: application/json' -d '{\"body\":\"Claude needs your input\",\"title\":\"Claude Code\",\"notification_type\":\"warning\",\"pane_id\":\"'\"$DINOTTY_PANE_ID\"'\"}'"
           }
         ]
       }
@@ -79,7 +80,7 @@ When running Claude Code in a dinotty terminal, you can use hooks to automatical
         "hooks": [
           {
             "type": "command",
-            "command": "curl -s -X POST http://127.0.0.1:8999/api/notify -H 'Content-Type: application/json' -d '{\"body\":\"Task completed\",\"title\":\"Claude Code\",\"notification_type\":\"success\",\"pane_id\":\"'\"$DINOTTY_PANE_ID\"'\"}'"
+            "command": "curl -s -X POST ${DINOTTY_URL}/api/notify -H 'Content-Type: application/json' -d '{\"body\":\"Task completed\",\"title\":\"Claude Code\",\"notification_type\":\"success\",\"pane_id\":\"'\"$DINOTTY_PANE_ID\"'\"}'"
           }
         ]
       }

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -7,7 +7,7 @@ dinotty 内建通知系统，支持终端 bell 检测和自定义通知推送，
 通过 `POST /api/notify` 发送通知：
 
 ```bash
-curl -s -X POST http://127.0.0.1:8999/api/notify \
+curl -s -X POST ${DINOTTY_URL}/api/notify \
   -H "Content-Type: application/json" \
   -d '{"body": "任务完成", "title": "My Agent", "notification_type": "info"}'
 ```
@@ -38,13 +38,14 @@ dinotty 在每个终端创建时自动注入以下环境变量：
 |------|------|
 | `DINOTTY_PANE_ID` | 当前终端面板的唯一 ID（叶子 pane） |
 | `DINOTTY_TAB_ID` | 当前面板所属 tab 的唯一 ID |
+| `DINOTTY_URL` | 当前面板所属 dinotty 服务的通知地址（`http://127.0.0.1:<端口>`），发送通知时用它替代硬编码端口 |
 
 环境变量是**进程级别隔离**的，每个 pane 独立设置，多个 pane 之间不会互相覆盖。
 
 发送通知时带上这些 ID，即可实现精准跳转：
 
 ```bash
-curl -X POST http://127.0.0.1:8999/api/notify \
+curl -X POST ${DINOTTY_URL}/api/notify \
   -H "Content-Type: application/json" \
   -d "{
     \"pane_id\": \"$DINOTTY_PANE_ID\",
@@ -68,7 +69,7 @@ curl -X POST http://127.0.0.1:8999/api/notify \
         "hooks": [
           {
             "type": "command",
-            "command": "curl -s -X POST http://127.0.0.1:8999/api/notify -H 'Content-Type: application/json' -d '{\"body\":\"Claude 需要你的输入\",\"title\":\"Claude Code\",\"notification_type\":\"warning\",\"pane_id\":\"'\"$DINOTTY_PANE_ID\"'\"}'"
+            "command": "curl -s -X POST ${DINOTTY_URL}/api/notify -H 'Content-Type: application/json' -d '{\"body\":\"Claude 需要你的输入\",\"title\":\"Claude Code\",\"notification_type\":\"warning\",\"pane_id\":\"'\"$DINOTTY_PANE_ID\"'\"}'"
           }
         ]
       }
@@ -79,7 +80,7 @@ curl -X POST http://127.0.0.1:8999/api/notify \
         "hooks": [
           {
             "type": "command",
-            "command": "curl -s -X POST http://127.0.0.1:8999/api/notify -H 'Content-Type: application/json' -d '{\"body\":\"任务已完成\",\"title\":\"Claude Code\",\"notification_type\":\"success\",\"pane_id\":\"'\"$DINOTTY_PANE_ID\"'\"}'"
+            "command": "curl -s -X POST ${DINOTTY_URL}/api/notify -H 'Content-Type: application/json' -d '{\"body\":\"任务已完成\",\"title\":\"Claude Code\",\"notification_type\":\"success\",\"pane_id\":\"'\"$DINOTTY_PANE_ID\"'\"}'"
           }
         ]
       }

--- a/src-tauri/src/embedded_server.rs
+++ b/src-tauri/src/embedded_server.rs
@@ -438,233 +438,276 @@ async fn update_token(
     StatusCode::OK.into_response()
 }
 
-pub async fn run_server(port: u16, manager: Arc<SessionManager>) {
-    let monitor_state = MonitorState::new();
-    monitor_state.clone().start_collector();
-
-    let notifier = Arc::new(NotificationBroadcast::new());
-    let settings_state = settings::create_settings_state();
-    notifier.set_settings(settings_state.clone());
-    let history_state = HistoryState::new();
-    let plugins = Arc::new(PluginManager::new());
-    plugins.scan();
-
-    let initial_token =
-        settings::load_token().or_else(|| std::env::var("DINOTTY_TOKEN").ok()).unwrap_or_default();
-    let initial_token = if initial_token.is_empty() {
-        let token = generate_random_token();
-        if let Err(e) = settings::save_token(&token) {
-            tracing::error!("Failed to persist auto-generated token: {}", e);
-        }
-        tracing::info!("Desktop mode: auto-generated auth token");
-        token
-    } else {
-        tracing::info!("Auth token loaded (length={})", initial_token.len());
-        initial_token
-    };
-    let auth_token = Arc::new(tokio::sync::RwLock::new(initial_token));
-
-    let git_info = read_git_info();
-
-    let session_ttl_days = settings::load_settings().auth.session_ttl_days;
-    let sessions = Arc::new(SessionStore::new(session_ttl_days));
-    sessions.clone().start_cleanup_task();
-
-    let workspaces_state = workspace_mgmt::create_workspaces_state();
-
-    let state = AppState {
-        manager: manager.clone(),
-        settings: settings_state,
-        file_watcher: Arc::new(FileWatcherState::new()),
-        monitor: monitor_state,
-        notifier,
-        history: history_state,
-        auth_token,
-        plugins,
-        port,
-        git_info,
-        sessions,
-        workspaces: workspaces_state,
-    };
-
-    state.plugins.watch_changes(manager);
-
-    let app = Router::new()
-        .route("/ws", get(ws::ws_handler))
-        .route("/ws/sync", get(ws::sync_handler))
-        .route("/ws/watch", get(file_watcher::watch_handler))
-        .route("/ws/monitor", get(monitor::ws_monitor_handler))
-        .route("/ws/notify", get(ws::notification_ws_handler))
-        .route("/ws/history", get(history::ws_history_handler))
-        // Tab/Pane management
-        .route("/api/tabs", get(tabs::list_tabs).post(tabs::create_tab))
-        // SSH tab routes (must be before :tab_id routes)
-        .route("/api/tabs/ssh/quick", post(tabs::create_ssh_quick_tab))
-        .route("/api/tabs/ssh", post(tabs::create_ssh_tab))
-        .route("/api/tabs/:tab_id", delete(tabs::close_tab))
-        .route("/api/tabs/:tab_id/pane", post(tabs::split_pane))
-        .route("/api/tabs/:tab_id/pane/:pane_id", delete(tabs::close_pane))
-        .route("/api/tabs/:tab_id/pane/:pane_id/activate", put(tabs::activate_pane))
-        .route("/api/tabs/:tab_id/layout", put(tabs::update_layout))
-        .route("/api/input", post(ws::post_input))
-        .route("/api/settings", get(settings::get_settings).put(settings::put_settings))
-        .route(
-            "/api/settings/background",
-            post(settings::upload_background).get(settings::get_background),
-        )
-        .route("/api/log", get(settings::get_log))
-        .route("/api/workspace/resolve", get(workspace::workspace_resolve))
-        .route("/api/workspace/list", get(workspace::workspace_list))
-        .route("/api/workspace/meta", get(workspace::workspace_meta))
-        .route("/api/workspace/raw", get(workspace::workspace_raw))
-        .route("/api/workspace/upload", post(workspace::workspace_upload))
-        .merge(
-            Router::new()
-                .route(
-                    "/api/uploads",
-                    post(workspace::workspace_uploads).get(workspace::uploads_status),
-                )
-                .layer(axum::extract::DefaultBodyLimit::max(2 * 1024 * 1024 * 1024)),
-        )
-        .route("/api/uploads/clear", post(workspace::uploads_clear))
-        .route("/api/uploads/adopt", post(workspace::uploads_adopt))
-        .route("/api/uploads/default-dir", get(workspace::uploads_default_dir))
-        .route("/api/workspace/create", post(workspace::workspace_create_entry))
-        .route("/api/workspace/file", put(workspace::workspace_put_file))
-        .route("/api/workspace/delete", delete(workspace::workspace_delete))
-        .route("/api/workspace/rename", post(workspace::workspace_rename))
-        .route("/api/workspace/move", post(workspace::workspace_move))
-        .route("/api/workspace/git-status", get(workspace::workspace_git_status))
-        .route("/api/workspace/git-diff", get(workspace::workspace_git_diff))
-        .route("/api/workspace/git-stage-lines", post(workspace::workspace_git_stage_lines))
-        .route("/api/workspace/git-revert-lines", post(workspace::workspace_git_revert_lines))
-        .route("/api/workspace/syntax-check", post(workspace::workspace_syntax_check))
-        // Workspace management
-        .route(
-            "/api/workspaces",
-            get(workspace_mgmt::list_workspaces).post(workspace_mgmt::create_workspace),
-        )
-        .route("/api/workspaces/reorder", put(workspace_mgmt::reorder_workspaces))
-        .route(
-            "/api/workspaces/:id",
-            put(workspace_mgmt::update_workspace).delete(workspace_mgmt::delete_workspace),
-        )
-        .route("/api/workspaces/:id/activate", put(workspace_mgmt::activate_workspace))
-        .route("/api/workspaces/active", delete(workspace_mgmt::deactivate_workspace))
-        .route("/api/notify", post(notification::post_notify))
-        .route("/api/history", get(history::get_history).delete(history::delete_history))
-        .route("/api/info", get(server_info))
-        .route("/api/auth", post(check_auth))
-        .route("/api/auth/check", get(check_auth_session))
-        .route("/api/auth/logout", post(logout))
-        .route("/api/auth/sessions", get(list_sessions_handler).delete(revoke_other_sessions))
-        .route("/api/auth/sessions/:id", delete(revoke_session_handler))
-        .route("/api/token-configured", get(token_configured))
-        .route("/api/auto-token", get(auto_token))
-        .route("/api/token", get(get_token).put(update_token))
-        .route("/api/plugins", get(plugin::list_plugins))
-        .route("/api/plugins/market", get(plugin::get_market_registry))
-        .route("/api/plugins/market/:id/readme", get(plugin::get_market_readme))
-        .route("/api/plugins/dev-link", post(plugin::dev_link_plugin))
-        .merge(
-            Router::new()
-                .route("/api/plugins/install", post(plugin::install_plugin))
-                .route("/api/plugins/install-git", post(plugin::install_from_git))
-                .route("/api/plugins/:id/update", post(plugin::update_plugin))
-                .layer(axum::extract::DefaultBodyLimit::max(64 * 1024 * 1024)),
-        )
-        .route("/api/plugins/:id", get(plugin::plugin_detail).delete(plugin::delete_plugin))
-        .route("/api/plugins/:id/exec", post(plugin::plugin_exec))
-        .route("/api/plugins/:id/spawn", get(plugin::plugin_spawn_ws))
-        .route("/api/plugins/:id/process/start", post(plugin::plugin_process_start))
-        .route(
-            "/api/plugins/:id/process",
-            get(plugin::plugin_process_list).delete(plugin::plugin_process_stop_all),
-        )
-        .route("/api/plugins/:id/process/:pid", delete(plugin::plugin_process_stop))
-        .route("/api/plugins/:id/storage", get(plugin::plugin_storage_list))
-        .route(
-            "/api/plugins/:id/storage/:key",
-            get(plugin::plugin_storage_get)
-                .put(plugin::plugin_storage_set)
-                .delete(plugin::plugin_storage_delete),
-        )
-        .route("/api/plugins/:id/*path", get(plugin::plugin_asset))
-        .route("/api/proxy", any(proxy::external_proxy_handler))
-        .route("/preview/:port", any(proxy::proxy_handler_root))
-        .route("/preview/:port/", any(proxy::proxy_handler_root))
-        .route("/preview/:port/*path", any(proxy::proxy_handler_wildcard))
-        .route("/assets/*path", get(static_handler))
-        .route("/icons/*path", get(icon_handler))
-        .route("/manifest.json", get(manifest_handler))
-        .route(
-            "/logo.png",
-            get(|| async {
-                match StaticFiles::get("logo.png") {
-                    Some(content) => Response::builder()
-                        .header(header::CONTENT_TYPE, "image/png")
-                        .header(header::CACHE_CONTROL, "public, max-age=86400")
-                        .body(Body::from(content.data.into_owned()))
-                        .unwrap(),
-                    None => Response::builder()
-                        .status(StatusCode::NOT_FOUND)
-                        .body(Body::from("not found"))
-                        .unwrap(),
-                }
-            }),
-        )
-        .route("/", get(index))
-        .layer(middleware::from_fn_with_state(
-            state.clone(),
-            |AxumState(s): AxumState<AppState>,
-             req: axum::extract::Request,
-             next: middleware::Next| async move {
-                let token = s.auth_token.read().await.clone();
-                let client_ip = req
-                    .extensions()
-                    .get::<axum::extract::ConnectInfo<SocketAddr>>()
-                    .map(|ci| ci.ip())
-                    .unwrap_or_else(|| "127.0.0.1".parse().unwrap());
-                auth::auth_middleware(req, next, &token, &s.settings, &s.sessions, client_ip).await
-            },
-        ))
-        .layer(middleware::from_fn(
-            |req: axum::extract::Request, next: middleware::Next| async move {
-                let origin = req
-                    .headers()
-                    .get(header::ORIGIN)
-                    .and_then(|v| v.to_str().ok())
-                    .map(|s| s.to_string());
-                let is_preflight = req.method() == axum::http::Method::OPTIONS;
-                let mut response =
-                    if is_preflight { Response::new(Body::empty()) } else { next.run(req).await };
-                if let Some(origin) = origin {
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        header::ACCESS_CONTROL_ALLOW_ORIGIN,
-                        axum::http::HeaderValue::from_str(&origin).unwrap(),
-                    );
-                    headers.insert(
-                        header::ACCESS_CONTROL_ALLOW_CREDENTIALS,
-                        axum::http::HeaderValue::from_static("true"),
-                    );
-                    headers.insert(
-                        header::ACCESS_CONTROL_ALLOW_METHODS,
-                        axum::http::HeaderValue::from_static("GET, POST, PUT, DELETE, OPTIONS"),
-                    );
-                    headers.insert(
-                        header::ACCESS_CONTROL_ALLOW_HEADERS,
-                        axum::http::HeaderValue::from_static("Content-Type, Authorization"),
-                    );
-                }
-                response
-            },
-        ))
-        .with_state(state);
-
+pub fn bind_listener(port: u16) -> std::io::Result<std::net::TcpListener> {
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
-    tracing::info!("Embedded server listening on http://0.0.0.0:{}", port);
+    let listener = std::net::TcpListener::bind(addr)?;
+    listener.set_nonblocking(true)?;
+    Ok(listener)
+}
 
-    let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
-    axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>()).await.unwrap();
+struct NotifyPortGuard {
+    manager: Arc<SessionManager>,
+}
+
+impl Drop for NotifyPortGuard {
+    fn drop(&mut self) {
+        self.manager.set_notify_port(0);
+    }
+}
+
+pub fn run_server(
+    listener: std::net::TcpListener,
+    manager: Arc<SessionManager>,
+) -> impl std::future::Future<Output = ()> {
+    // Guard is created synchronously and moved into the returned future, so notify_port
+    // resets to 0 on ANY termination of the future — normal exit, panic, task abort, or a
+    // drop before the first poll.
+    let port_guard = NotifyPortGuard { manager: Arc::clone(&manager) };
+    async move {
+        let _port_guard = port_guard;
+        let listener = match tokio::net::TcpListener::from_std(listener) {
+            Ok(listener) => listener,
+            Err(e) => {
+                tracing::error!(
+                    "Failed to register embedded server listener: {}; notifications disabled",
+                    e
+                );
+                return;
+            }
+        };
+        let local_port = listener.local_addr().expect("bound listener").port();
+        manager.set_notify_port(local_port);
+        let monitor_state = MonitorState::new();
+        monitor_state.clone().start_collector();
+
+        let notifier = Arc::new(NotificationBroadcast::new());
+        let settings_state = settings::create_settings_state();
+        notifier.set_settings(settings_state.clone());
+        let history_state = HistoryState::new();
+        let plugins = Arc::new(PluginManager::new());
+        plugins.scan();
+
+        let initial_token = settings::load_token()
+            .or_else(|| std::env::var("DINOTTY_TOKEN").ok())
+            .unwrap_or_default();
+        let initial_token = if initial_token.is_empty() {
+            let token = generate_random_token();
+            if let Err(e) = settings::save_token(&token) {
+                tracing::error!("Failed to persist auto-generated token: {}", e);
+            }
+            tracing::info!("Desktop mode: auto-generated auth token");
+            token
+        } else {
+            tracing::info!("Auth token loaded (length={})", initial_token.len());
+            initial_token
+        };
+        let auth_token = Arc::new(tokio::sync::RwLock::new(initial_token));
+
+        let git_info = read_git_info();
+
+        let session_ttl_days = settings::load_settings().auth.session_ttl_days;
+        let sessions = Arc::new(SessionStore::new(session_ttl_days));
+        sessions.clone().start_cleanup_task();
+
+        let workspaces_state = workspace_mgmt::create_workspaces_state();
+
+        let state = AppState {
+            manager: manager.clone(),
+            settings: settings_state,
+            file_watcher: Arc::new(FileWatcherState::new()),
+            monitor: monitor_state,
+            notifier,
+            history: history_state,
+            auth_token,
+            plugins,
+            port: local_port,
+            git_info,
+            sessions,
+            workspaces: workspaces_state,
+        };
+
+        state.plugins.watch_changes(manager);
+
+        let app = Router::new()
+            .route("/ws", get(ws::ws_handler))
+            .route("/ws/sync", get(ws::sync_handler))
+            .route("/ws/watch", get(file_watcher::watch_handler))
+            .route("/ws/monitor", get(monitor::ws_monitor_handler))
+            .route("/ws/notify", get(ws::notification_ws_handler))
+            .route("/ws/history", get(history::ws_history_handler))
+            // Tab/Pane management
+            .route("/api/tabs", get(tabs::list_tabs).post(tabs::create_tab))
+            // SSH tab routes (must be before :tab_id routes)
+            .route("/api/tabs/ssh/quick", post(tabs::create_ssh_quick_tab))
+            .route("/api/tabs/ssh", post(tabs::create_ssh_tab))
+            .route("/api/tabs/:tab_id", delete(tabs::close_tab))
+            .route("/api/tabs/:tab_id/pane", post(tabs::split_pane))
+            .route("/api/tabs/:tab_id/pane/:pane_id", delete(tabs::close_pane))
+            .route("/api/tabs/:tab_id/pane/:pane_id/activate", put(tabs::activate_pane))
+            .route("/api/tabs/:tab_id/layout", put(tabs::update_layout))
+            .route("/api/input", post(ws::post_input))
+            .route("/api/settings", get(settings::get_settings).put(settings::put_settings))
+            .route(
+                "/api/settings/background",
+                post(settings::upload_background).get(settings::get_background),
+            )
+            .route("/api/log", get(settings::get_log))
+            .route("/api/workspace/resolve", get(workspace::workspace_resolve))
+            .route("/api/workspace/list", get(workspace::workspace_list))
+            .route("/api/workspace/meta", get(workspace::workspace_meta))
+            .route("/api/workspace/raw", get(workspace::workspace_raw))
+            .route("/api/workspace/upload", post(workspace::workspace_upload))
+            .merge(
+                Router::new()
+                    .route(
+                        "/api/uploads",
+                        post(workspace::workspace_uploads).get(workspace::uploads_status),
+                    )
+                    .layer(axum::extract::DefaultBodyLimit::max(2 * 1024 * 1024 * 1024)),
+            )
+            .route("/api/uploads/clear", post(workspace::uploads_clear))
+            .route("/api/uploads/adopt", post(workspace::uploads_adopt))
+            .route("/api/uploads/default-dir", get(workspace::uploads_default_dir))
+            .route("/api/workspace/create", post(workspace::workspace_create_entry))
+            .route("/api/workspace/file", put(workspace::workspace_put_file))
+            .route("/api/workspace/delete", delete(workspace::workspace_delete))
+            .route("/api/workspace/rename", post(workspace::workspace_rename))
+            .route("/api/workspace/move", post(workspace::workspace_move))
+            .route("/api/workspace/git-status", get(workspace::workspace_git_status))
+            .route("/api/workspace/git-diff", get(workspace::workspace_git_diff))
+            .route("/api/workspace/git-stage-lines", post(workspace::workspace_git_stage_lines))
+            .route("/api/workspace/git-revert-lines", post(workspace::workspace_git_revert_lines))
+            .route("/api/workspace/syntax-check", post(workspace::workspace_syntax_check))
+            // Workspace management
+            .route(
+                "/api/workspaces",
+                get(workspace_mgmt::list_workspaces).post(workspace_mgmt::create_workspace),
+            )
+            .route("/api/workspaces/reorder", put(workspace_mgmt::reorder_workspaces))
+            .route(
+                "/api/workspaces/:id",
+                put(workspace_mgmt::update_workspace).delete(workspace_mgmt::delete_workspace),
+            )
+            .route("/api/workspaces/:id/activate", put(workspace_mgmt::activate_workspace))
+            .route("/api/workspaces/active", delete(workspace_mgmt::deactivate_workspace))
+            .route("/api/notify", post(notification::post_notify))
+            .route("/api/history", get(history::get_history).delete(history::delete_history))
+            .route("/api/info", get(server_info))
+            .route("/api/auth", post(check_auth))
+            .route("/api/auth/check", get(check_auth_session))
+            .route("/api/auth/logout", post(logout))
+            .route("/api/auth/sessions", get(list_sessions_handler).delete(revoke_other_sessions))
+            .route("/api/auth/sessions/:id", delete(revoke_session_handler))
+            .route("/api/token-configured", get(token_configured))
+            .route("/api/auto-token", get(auto_token))
+            .route("/api/token", get(get_token).put(update_token))
+            .route("/api/plugins", get(plugin::list_plugins))
+            .route("/api/plugins/market", get(plugin::get_market_registry))
+            .route("/api/plugins/market/:id/readme", get(plugin::get_market_readme))
+            .route("/api/plugins/dev-link", post(plugin::dev_link_plugin))
+            .merge(
+                Router::new()
+                    .route("/api/plugins/install", post(plugin::install_plugin))
+                    .route("/api/plugins/install-git", post(plugin::install_from_git))
+                    .route("/api/plugins/:id/update", post(plugin::update_plugin))
+                    .layer(axum::extract::DefaultBodyLimit::max(64 * 1024 * 1024)),
+            )
+            .route("/api/plugins/:id", get(plugin::plugin_detail).delete(plugin::delete_plugin))
+            .route("/api/plugins/:id/exec", post(plugin::plugin_exec))
+            .route("/api/plugins/:id/spawn", get(plugin::plugin_spawn_ws))
+            .route("/api/plugins/:id/process/start", post(plugin::plugin_process_start))
+            .route(
+                "/api/plugins/:id/process",
+                get(plugin::plugin_process_list).delete(plugin::plugin_process_stop_all),
+            )
+            .route("/api/plugins/:id/process/:pid", delete(plugin::plugin_process_stop))
+            .route("/api/plugins/:id/storage", get(plugin::plugin_storage_list))
+            .route(
+                "/api/plugins/:id/storage/:key",
+                get(plugin::plugin_storage_get)
+                    .put(plugin::plugin_storage_set)
+                    .delete(plugin::plugin_storage_delete),
+            )
+            .route("/api/plugins/:id/*path", get(plugin::plugin_asset))
+            .route("/api/proxy", any(proxy::external_proxy_handler))
+            .route("/preview/:port", any(proxy::proxy_handler_root))
+            .route("/preview/:port/", any(proxy::proxy_handler_root))
+            .route("/preview/:port/*path", any(proxy::proxy_handler_wildcard))
+            .route("/assets/*path", get(static_handler))
+            .route("/icons/*path", get(icon_handler))
+            .route("/manifest.json", get(manifest_handler))
+            .route(
+                "/logo.png",
+                get(|| async {
+                    match StaticFiles::get("logo.png") {
+                        Some(content) => Response::builder()
+                            .header(header::CONTENT_TYPE, "image/png")
+                            .header(header::CACHE_CONTROL, "public, max-age=86400")
+                            .body(Body::from(content.data.into_owned()))
+                            .unwrap(),
+                        None => Response::builder()
+                            .status(StatusCode::NOT_FOUND)
+                            .body(Body::from("not found"))
+                            .unwrap(),
+                    }
+                }),
+            )
+            .route("/", get(index))
+            .layer(middleware::from_fn_with_state(
+                state.clone(),
+                |AxumState(s): AxumState<AppState>,
+                 req: axum::extract::Request,
+                 next: middleware::Next| async move {
+                    let token = s.auth_token.read().await.clone();
+                    let client_ip = req
+                        .extensions()
+                        .get::<axum::extract::ConnectInfo<SocketAddr>>()
+                        .map(|ci| ci.ip())
+                        .unwrap_or_else(|| "127.0.0.1".parse().unwrap());
+                    auth::auth_middleware(req, next, &token, &s.settings, &s.sessions, client_ip)
+                        .await
+                },
+            ))
+            .layer(middleware::from_fn(
+                |req: axum::extract::Request, next: middleware::Next| async move {
+                    let origin = req
+                        .headers()
+                        .get(header::ORIGIN)
+                        .and_then(|v| v.to_str().ok())
+                        .map(|s| s.to_string());
+                    let is_preflight = req.method() == axum::http::Method::OPTIONS;
+                    let mut response = if is_preflight {
+                        Response::new(Body::empty())
+                    } else {
+                        next.run(req).await
+                    };
+                    if let Some(origin) = origin {
+                        let headers = response.headers_mut();
+                        headers.insert(
+                            header::ACCESS_CONTROL_ALLOW_ORIGIN,
+                            axum::http::HeaderValue::from_str(&origin).unwrap(),
+                        );
+                        headers.insert(
+                            header::ACCESS_CONTROL_ALLOW_CREDENTIALS,
+                            axum::http::HeaderValue::from_static("true"),
+                        );
+                        headers.insert(
+                            header::ACCESS_CONTROL_ALLOW_METHODS,
+                            axum::http::HeaderValue::from_static("GET, POST, PUT, DELETE, OPTIONS"),
+                        );
+                        headers.insert(
+                            header::ACCESS_CONTROL_ALLOW_HEADERS,
+                            axum::http::HeaderValue::from_static("Content-Type, Authorization"),
+                        );
+                    }
+                    response
+                },
+            ))
+            .with_state(state);
+
+        tracing::info!("Embedded server listening on http://0.0.0.0:{}", local_port);
+        axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>())
+            .await
+            .unwrap();
+    }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -517,8 +517,10 @@ fn main() {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let mgr = Arc::clone(&manager);
         rt.block_on(async move {
+            let listener = embedded_server::bind_listener(port)
+                .unwrap_or_else(|e| panic!("failed to bind embedded server on port {port}: {e}"));
             mgr.start_cleanup_task();
-            embedded_server::run_server(port, mgr).await
+            embedded_server::run_server(listener, mgr).await
         });
         return;
     }
@@ -542,8 +544,25 @@ fn main() {
         .manage(manager.clone())
         .setup(move |app| {
             let mgr = Arc::clone(&manager);
-            tauri::async_runtime::spawn(embedded_server::run_server(port, mgr));
-            tracing::info!("Desktop mode: embedded server on port {}", port);
+            match embedded_server::bind_listener(port) {
+                Ok(listener) => {
+                    let actual = listener.local_addr().expect("bound listener").port();
+                    // Redundant-by-design: run_server() also sets notify_port from its own
+                    // local_addr once its future is first polled. We set it here too — synchronously,
+                    // before spawn — so a Tauri `pty_spawn` IPC that fires before the spawned task's
+                    // first poll still reads the real port (not 0). Do NOT remove either set.
+                    mgr.set_notify_port(actual);
+                    tauri::async_runtime::spawn(embedded_server::run_server(listener, mgr));
+                    tracing::info!("Desktop mode: embedded server on port {}", actual);
+                }
+                Err(e) => {
+                    tracing::error!(
+                        "Failed to bind embedded server on port {}: {}; notifications disabled",
+                        port,
+                        e
+                    );
+                }
+            }
 
             // Register global shortcut for Quake-mode toggle (Ctrl+Shift+`)
             let win = app.get_webview_window("main").expect("no main window");

--- a/src/main.rs
+++ b/src/main.rs
@@ -731,6 +731,7 @@ async fn main() {
     };
 
     state.plugins.watch_changes(state.manager.clone());
+    let notify_manager = state.manager.clone();
 
     let app =
         Router::new()
@@ -914,5 +915,6 @@ async fn main() {
     tracing::info!("Listening on http://0.0.0.0:{}", port);
 
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+    notify_manager.set_notify_port(listener.local_addr().expect("bound listener").port());
     axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>()).await.unwrap();
 }

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -127,6 +127,10 @@ fn cleanup_exited_pty_session(
     }
 }
 
+fn notify_url_for(port: u16) -> Option<String> {
+    (port != 0).then(|| format!("http://127.0.0.1:{port}"))
+}
+
 /// Create a new PTY session and register it with the session manager.
 ///
 /// # Errors
@@ -158,6 +162,10 @@ pub fn create_session(
     }
     cmd.env("TERM", "xterm-256color");
     cmd.env("DINOTTY_PANE_ID", pane_id);
+    cmd.env_remove("DINOTTY_URL");
+    if let Some(url) = notify_url_for(manager.notify_port()) {
+        cmd.env("DINOTTY_URL", url);
+    }
     if let Some(tid) = tab_id {
         cmd.env("DINOTTY_TAB_ID", tid);
     }
@@ -604,7 +612,13 @@ pub fn get_shell_args(shell: &str) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_claude_session_env_key, locale_adjustment, LocaleAdjustment};
+    use super::{is_claude_session_env_key, locale_adjustment, notify_url_for, LocaleAdjustment};
+
+    #[test]
+    fn builds_notify_url_for_bound_port() {
+        assert_eq!(notify_url_for(8999), Some("http://127.0.0.1:8999".to_string()));
+        assert_eq!(notify_url_for(0), None);
+    }
 
     #[test]
     fn strips_claude_session_keys_case_insensitive() {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -9,7 +9,7 @@ use std::{
     io::Write,
     path::{Path, PathBuf},
     sync::{
-        atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicU16, AtomicU64, AtomicUsize, Ordering},
         Arc, Mutex,
     },
     time::Instant,
@@ -847,6 +847,7 @@ pub struct SessionManager {
     pub pending_ssh_auth: DashMap<String, PendingSshAuth>,
     pub tab_order: Mutex<Vec<String>>,
     pub event_bus: EventBus,
+    notify_port: AtomicU16,
 }
 
 #[derive(Serialize)]
@@ -945,7 +946,17 @@ impl SessionManager {
             tab_order: Mutex::new(Vec::new()),
             pending_ssh_auth: DashMap::new(),
             event_bus: EventBus::new(),
+            notify_port: AtomicU16::new(0),
         }
+    }
+
+    #[must_use]
+    pub fn notify_port(&self) -> u16 {
+        self.notify_port.load(Ordering::Relaxed)
+    }
+
+    pub fn set_notify_port(&self, port: u16) {
+        self.notify_port.store(port, Ordering::Relaxed);
     }
 
     /// Insert a tab layout and record its order position.


### PR DESCRIPTION
## Problem
Each dinotty surface (web server, desktop app) serves POST /api/notify on its own
port. A spawned terminal only gets DINOTTY_PANE_ID / DINOTTY_TAB_ID injected — not
the surface's URL — so a notification hook has to hardcode a port. A terminal spawned
by the desktop app (8999) then sends notifications to whatever port is hardcoded
(e.g. a web instance on 8998) instead of its own surface.

## What this does
Inject `DINOTTY_URL=http://127.0.0.1:<the surface's bound port>` into every terminal a
surface spawns, so a hook can POST to `${DINOTTY_URL}/api/notify` and always reach the
surface that owns the pane.

- `SessionManager` carries an `AtomicU16 notify_port` (getter/setter).
- `pty::create_session` injects `DINOTTY_URL`, unconditionally `env_remove`-ing it first
  so a stale inherited value (dinotty launched from inside a dinotty pane) can never
  cross-route.
- The port is published only after a successful bind — fail-safe: port 0 => no injection
  => no notification, never a wrong one.
- Desktop embedded server: synchronous std bind + a RAII guard that resets the port to 0
  when the server future ends, so `notify_port != 0` iff the server is alive.
- docs/notifications updated to document `DINOTTY_URL`.

## Notes
- Reuses the existing `DINOTTY_URL` convention already used by `scripts/notify-done.sh`;
  no new env var name.
- Hooks opt in via `[ -n "$DINOTTY_PANE_ID" ] && [ -n "$DINOTTY_URL" ]`.
- rustfmt clean; `cargo test -p dinotty-server --lib` 242 passed.
