### PR TITLE
fix(tabbar): stop plugin/new-tab menus closing on mouseleave

### DIFF
--- a/frontend/src/components/terminal/TabBar.vue
+++ b/frontend/src/components/terminal/TabBar.vue
@@ -71,7 +71,7 @@
       >
         <Terminal :size="16" />
       </button>
-      <div v-if="newMenuOpen" class="new-menu-dropdown" :class="{ 'align-right': newMenuAlignRight }" @mouseleave="newMenuOpen = false">
+      <div v-if="newMenuOpen" class="new-menu-dropdown" :class="{ 'align-right': newMenuAlignRight }">
         <div
           class="new-menu-item"
           @click="emitAction('new-tab')"
@@ -135,7 +135,7 @@
       >
         <Puzzle :size="16" />
       </button>
-      <div v-if="pluginMenuOpen" class="plugin-dropdown" @mouseleave="pluginMenuOpen = false">
+      <div v-if="pluginMenuOpen" class="plugin-dropdown">
         <div
           v-for="p in plugins"
           :key="p.id"
@@ -285,11 +285,22 @@ function onDocTouchStart(e: TouchEvent) {
   }
 }
 
+function onDocMenuMouseDown(e: MouseEvent) {
+  if (pluginWrapRef.value && !pluginWrapRef.value.contains(e.target as Node)) {
+    pluginMenuOpen.value = false
+  }
+  if (newMenuWrapRef.value && !newMenuWrapRef.value.contains(e.target as Node)) {
+    newMenuOpen.value = false
+  }
+}
+
 watch([pluginMenuOpen, newMenuOpen], ([pluginOpen, newOpen]) => {
   if (pluginOpen || newOpen) {
     document.addEventListener('touchstart', onDocTouchStart, { passive: true })
+    document.addEventListener('mousedown', onDocMenuMouseDown)
   } else {
     document.removeEventListener('touchstart', onDocTouchStart)
+    document.removeEventListener('mousedown', onDocMenuMouseDown)
   }
   if (newOpen) {
     nextTick(() => {
@@ -426,6 +437,7 @@ function cleanup() {
 onBeforeUnmount(() => {
   cleanup()
   document.removeEventListener('mousedown', onDocMouseDown)
+  document.removeEventListener('mousedown', onDocMenuMouseDown)
   document.removeEventListener('touchstart', onDocTouchStart)
 })
 </script>


### PR DESCRIPTION
## Problem

The plugin-picker and new-tab dropdown menus in the TabBar close as soon as the
pointer leaves the menu box, without any click. Both menus had
`@mouseleave="...MenuOpen = false"` on their wrapper, so moving the mouse off the
menu (even to reach an item you just scrolled past, or briefly overshooting)
dismisses it. On desktop this makes the menus hard to use — you cannot move away
and come back.

## Fix

- Remove the `@mouseleave` auto-close handlers from both the new-tab and
  plugin-picker menu wrappers.
- Add a `mousedown` outside-click listener (`onDocMenuMouseDown`) alongside the
  existing `touchstart` one, registered/removed by the same `[pluginMenuOpen,
  newMenuOpen]` watch and torn down in `onBeforeUnmount`.

The menus now close on an explicit gesture — click the trigger again, select an
item, or click outside — instead of on incidental pointer movement. Touch
behavior is unchanged (the existing `touchstart` outside-close still applies).

## Scope

Single file, 14 insertions / 2 deletions in
`frontend/src/components/terminal/TabBar.vue`. No behavior change to tab logic,
keybindings, or the menus' open/select actions.
