### PR TITLE
fix(ws): close notification socket on broadcast lag instead of silent forwarder exit

### DIFF
--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::too_many_lines)]
 use axum::{
     extract::{
-        ws::{Message, WebSocket},
+        ws::{close_code, CloseFrame, Message, WebSocket},
         ConnectInfo, Query, State, WebSocketUpgrade,
     },
     http::StatusCode,
@@ -899,24 +899,64 @@ async fn handle_notification_socket(socket: WebSocket, notifier: Arc<Notificatio
         }
     });
 
+    let (lag_close_tx, mut lag_close_rx) = tokio::sync::oneshot::channel::<()>();
     let fwd_ws_out_tx = ws_out_tx.clone();
     let fwd = tokio::spawn(async move {
-        while let Ok(event) = rx.recv().await {
-            let json = serde_json::to_string(&event).expect("serialization is infallible");
-            if fwd_ws_out_tx.send(Message::Text(json)).is_err() {
-                break;
+        loop {
+            match rx.recv().await {
+                Ok(event) => {
+                    let json = serde_json::to_string(&event).expect("serialization is infallible");
+                    if fwd_ws_out_tx.send(Message::Text(json)).is_err() {
+                        break;
+                    }
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                    warn!(
+                        "Notification stream lagged by {} events; closing notification WebSocket",
+                        skipped
+                    );
+                    let _ = fwd_ws_out_tx.send(Message::Close(Some(CloseFrame {
+                        code: close_code::RESTART,
+                        reason: "notification stream lagged; reconnect".into(),
+                    })));
+                    let _ = lag_close_tx.send(());
+                    break;
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
             }
         }
     });
 
-    // Keep connection alive until client disconnects
-    while let Some(Ok(msg)) = ws_rx.next().await {
-        match msg {
-            Message::Ping(data) => {
-                let _ = ws_out_tx.send(Message::Pong(data));
+    // Keep connection alive until client disconnects or a lagged stream starts closing.
+    let lag_closing = loop {
+        tokio::select! {
+            msg = ws_rx.next() => {
+                match msg {
+                    Some(Ok(Message::Ping(data))) => {
+                        let _ = ws_out_tx.send(Message::Pong(data));
+                    }
+                    Some(Ok(Message::Close(_)) | Err(_)) | None => break false,
+                    Some(Ok(_)) => {}
+                }
             }
-            Message::Close(_) => break,
-            _ => {}
+            res = &mut lag_close_rx => break res.is_ok(),
+        }
+    };
+
+    if lag_closing {
+        let close_handshake = async {
+            loop {
+                match ws_rx.next().await {
+                    Some(Ok(Message::Ping(data))) => {
+                        let _ = ws_out_tx.send(Message::Pong(data));
+                    }
+                    Some(Ok(Message::Close(_)) | Err(_)) | None => break,
+                    Some(Ok(_)) => {}
+                }
+            }
+        };
+        if tokio::time::timeout(std::time::Duration::from_secs(5), close_handshake).await.is_err() {
+            warn!("client did not complete close handshake after lag; dropping connection");
         }
     }
     fwd.abort();


### PR DESCRIPTION
## Problem

`handle_notification_socket` forwards broadcast events to the client via a `tokio::sync::broadcast` receiver. When the client (or the forwarder task) falls behind and the channel overflows, `rx.recv()` returns `RecvError::Lagged(n)`. The current `while let Ok(event) = rx.recv().await` loop treats `Lagged` as a loop-terminating error: the forwarder task exits **silently**, leaving the WebSocket open. The client stays connected but never receives another notification event — a silent stale connection with no signal to reconnect.

## Fix

Handle `RecvError::Lagged` explicitly:

- Log the number of skipped events (`warn!`).
- Send a `Close` frame to the client (`close_code::RESTART`, reason `"notification stream lagged; reconnect"`) so the client knows to re-establish the socket rather than sitting on a dead stream.
- Signal the read loop (via a `oneshot`) to run a bounded close handshake, then tear down all tasks.

The close handshake is bounded by a 5-second `tokio::time::timeout`; on timeout it logs and proceeds to `abort()` the forwarder/writer/ping tasks either way — no unbounded wait, no task leak. `RecvError::Closed` (broadcast sender dropped, essentially process shutdown) continues to break cleanly.

## Scope

- Single file: `src/ws/mod.rs`, +52 / −12.
- No `Cargo.toml` / `Cargo.lock` change; `axum` stays 0.7.9. The two new symbols (`close_code`, `CloseFrame`) are from `axum::extract::ws`, stable since axum 0.6.

## Testing

- `cargo test --lib` — 242 passed.
- `cargo clippy -- -D warnings` — no new findings introduced (the two new match arms this PR adds use nested or-patterns to stay at the pre-existing base count).

## Note on CI

The `dev` base's `Backend (clippy + fmt + test)` job is currently red on pre-existing rustfmt drift + clippy pedantic lints under the unpinned `stable` toolchain, in regions this PR does not touch (the drift includes `src/ws/mod.rs` enum-variant / snapshot formatting that this change is unrelated to). This PR adds **zero** new fmt drift and **zero** new clippy findings — a red `Backend` job reflects the inherited base state, not this change. Happy to rebase onto a repo-wide `cargo fmt` / clippy cleanup if maintainers land one.
