### PR TITLE
fix(notification): honor bell.debounce_ms from settings in send_bell

### DIFF
--- a/src/notification.rs
+++ b/src/notification.rs
@@ -20,7 +20,6 @@ pub enum NotificationEvent {
 pub struct NotificationBroadcast {
     tx: broadcast::Sender<NotificationEvent>,
     bell_debounce: Mutex<HashMap<String, Instant>>,
-    debounce_ms: Mutex<u32>,
     settings: Mutex<Option<SettingsState>>,
 }
 
@@ -34,20 +33,11 @@ impl NotificationBroadcast {
     #[must_use]
     pub fn new() -> Self {
         let (tx, _) = broadcast::channel(256);
-        Self {
-            tx,
-            bell_debounce: Mutex::new(HashMap::new()),
-            debounce_ms: Mutex::new(300),
-            settings: Mutex::new(None),
-        }
+        Self { tx, bell_debounce: Mutex::new(HashMap::new()), settings: Mutex::new(None) }
     }
 
     pub fn set_settings(&self, state: SettingsState) {
         *self.settings.lock().unwrap_or_else(std::sync::PoisonError::into_inner) = Some(state);
-    }
-
-    pub fn set_debounce_ms(&self, ms: u32) {
-        *self.debounce_ms.lock().unwrap_or_else(std::sync::PoisonError::into_inner) = ms;
     }
 
     pub fn subscribe(&self) -> broadcast::Receiver<NotificationEvent> {
@@ -55,8 +45,15 @@ impl NotificationBroadcast {
     }
 
     pub fn send_bell(&self, pane_id: &str) {
-        let debounce_ms =
-            *self.debounce_ms.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let debounce_ms = {
+            let guard = self.settings.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            match guard.as_ref() {
+                Some(state) => {
+                    state.try_read().map_or(300, |settings| settings.notification.bell.debounce_ms)
+                }
+                None => 300,
+            }
+        };
         let mut map = self.bell_debounce.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         let now = Instant::now();
         if let Some(last) = map.get(pane_id) {


### PR DESCRIPTION
## Problem

`NotificationBroadcast::send_bell` read its debounce interval from a private `debounce_ms: Mutex<u32>` field. Nothing ever updated that field — `set_debounce_ms` had **zero callers** — so the settings value `notification.bell.debounce_ms` was dead: every install debounced at the hardcoded 300 ms default regardless of what the user configured.

## Fix

`send_bell` now reads the live settings state, the same pattern `run_hooks` already uses in this file:

```rust
let debounce_ms = {
    let guard = self.settings.lock()...;
    match guard.as_ref() {
        Some(state) => state.try_read().map_or(300, |s| s.notification.bell.debounce_ms),
        None => 300,
    }
};
```

The 300 ms default now applies only as a fallback when settings are absent or a concurrent write holds the read lock (`try_read` is non-blocking) — a bounded, single-bell degradation identical to the existing `run_hooks` fail-safe. The dead `debounce_ms` field and `set_debounce_ms` setter are removed.

## Scope

- Single file: `src/notification.rs`, +10 / −13.
- No new dependency; `SettingsState` (`Arc<RwLock<Settings>>`), `try_read`, and `settings.notification.bell.debounce_ms` all pre-exist unmodified on `dev`.
- Lock discipline unchanged: the `settings` lock is taken inside a block and dropped before `bell_debounce` is locked — no nested hold, no new lock-ordering risk.

## Testing

- `cargo test --lib` — 242 passed, 0 failed.
- `cargo clippy -- -D warnings` — zero hits in `notification.rs` (no new lint).
- `cargo fmt --check` — zero drift in `notification.rs`.

## Note on CI

The `dev` base's `Backend (clippy + fmt + test)` job is currently red on pre-existing rustfmt drift + clippy pedantic lints (unpinned `stable` toolchain), in regions this PR does not touch. This change adds **zero** new fmt drift and **zero** new clippy findings. Happy to rebase onto a repo-wide `cargo fmt` / clippy cleanup if maintainers land one.
