### PR TITLE
feat(plugin-api): createTerminalTab({cwd, argv, title}) — spawn a terminal tab running a given argv

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -696,17 +696,19 @@ window.addEventListener('beforeunload', (e) => {
 
 const DEFAULT_PREVIEW_URL = ''
 
-async function newTab(cwd?: string) {
+function newTab(cwd?: string): Promise<void>
+function newTab(cwd: string, argv: string[], title?: string): Promise<string>
+async function newTab(cwd?: string, argv?: string[], title?: string): Promise<string | void> {
   try {
     // Remote workspace: open an SSH terminal and cd into the workspace's remote path.
     const activeWs = workspaces.value.find((w) => w.id === activeWorkspaceId.value)
-    if (activeWs?.connection_id) {
+    if (!argv && activeWs?.connection_id) {
       const result = await apiCreateSshTab(activeWs.connection_id, activeWs.path)
       await onSshConnect(result)
-      return
+      return result.pane_id
     }
     const effectiveCwd = cwd ?? activeWorkspacePath.value
-    const result = await apiCreateTab(effectiveCwd)
+    const result = await apiCreateTab(effectiveCwd, argv, title)
     // Dedup: broadcast_sync echoes back to sender — tab_created handler may
     // have already added this tab if the sync message arrived before the
     // REST response.
@@ -716,10 +718,11 @@ async function newTab(cwd?: string) {
       if (result.cwd && existing.type === 'terminal' && !existing.cwd) {
         existing.cwd = result.cwd
       }
+      if (title && existing.type === 'terminal') existing.customTitle = title
       activePaneId.value = result.tab_id
       persist()
       nextTick(() => focusActive())
-      return
+      return result.pane_id
     }
     const layout = ensureSplitRoot(result.layout)
     tabs.value.push({
@@ -734,13 +737,17 @@ async function newTab(cwd?: string) {
       previewAddress: '',
       previewUrl: '',
       previewKind: 'web',
+      customTitle: title,
       cwd: result.cwd,
     })
     activePaneId.value = result.tab_id
     persist()
     nextTick(() => focusActive())
+    return result.pane_id
   } catch (e) {
     console.error('Failed to create tab:', e)
+    if (argv) throw e
+    return ''
   }
 }
 
@@ -1240,6 +1247,9 @@ window.__dinotty_terminal_api = {
     newTab()
     const tab = tabs.value.find((t) => t.paneId === activePaneId.value)
     return tab?.type === 'terminal' ? tab.activePaneId : ''
+  },
+  async createTerminalTab(opts: { cwd: string; argv: string[]; title?: string }) {
+    return newTab(opts.cwd, opts.argv, opts.title)
   },
 }
 // Test hooks for P3 verification (focusActive + isComposing guard).

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1249,6 +1249,9 @@ window.__dinotty_terminal_api = {
     return tab?.type === 'terminal' ? tab.activePaneId : ''
   },
   async createTerminalTab(opts: { cwd: string; argv: string[]; title?: string }) {
+    const ws = matchWorkspace(opts.cwd)
+    const targetId = ws?.id ?? null
+    if (targetId !== activeWorkspaceId.value) await activateWorkspace(targetId)
     return newTab(opts.cwd, opts.argv, opts.title)
   },
 }

--- a/frontend/src/composables/usePluginLoader.ts
+++ b/frontend/src/composables/usePluginLoader.ts
@@ -65,6 +65,8 @@ export interface PluginContext {
     listPanes(): Array<{ id: string; title: string; active: boolean }>
     onOutput(callback: (paneId: string, data: string) => void): Disposable
     createTab(command?: string): Promise<string>
+    /** Open a terminal tab in cwd and execute argv directly, without an intermediary shell. */
+    createTerminalTab(opts: { cwd: string; argv: string[]; title?: string }): Promise<string>
   }
 
   settings: {
@@ -312,6 +314,7 @@ function createPluginContext(pluginId: string): PluginContext {
       listPanes: () => [],
       onOutput: () => ({ dispose() {} }),
       createTab: async () => '',
+      createTerminalTab: async () => '',
     },
     settings: {
       get: () => (window as any).__dinotty_settings_data ?? {},

--- a/frontend/src/composables/useTabApi.ts
+++ b/frontend/src/composables/useTabApi.ts
@@ -31,11 +31,15 @@ export async function apiListTabs(): Promise<ListTabsResult> {
   return res.json()
 }
 
-export async function apiCreateTab(cwd?: string): Promise<CreateTabResult> {
+export async function apiCreateTab(
+  cwd?: string,
+  argv?: string[],
+  title?: string
+): Promise<CreateTabResult> {
   const res = await authFetch(apiUrl('/api/tabs'), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ cwd }),
+    body: JSON.stringify({ cwd, argv, title }),
   })
   if (!res.ok) throw new Error(`create tab failed: ${res.status}`)
   return res.json()

--- a/plugin-api/index.d.ts
+++ b/plugin-api/index.d.ts
@@ -20,6 +20,8 @@ export interface PluginContext {
     activePaneId(): string | null
     onOutput(callback: (paneId: string, data: string) => void): Disposable
     createTab(command?: string): Promise<string>
+    /** Open a terminal tab in cwd and execute argv directly, without an intermediary shell. */
+    createTerminalTab(opts: { cwd: string; argv: string[]; title?: string }): Promise<string>
   }
 
   settings: {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -595,10 +595,7 @@ fn import_login_shell_path() {
 
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
     let Ok(out) = std::process::Command::new(&shell)
-        .args([
-            "-lc",
-            "printf '__DINOTTY_PATH_START__%s__DINOTTY_PATH_END__' \"$PATH\"",
-        ])
+        .args(["-lc", "printf '__DINOTTY_PATH_START__%s__DINOTTY_PATH_END__' \"$PATH\""])
         .output()
     else {
         return;
@@ -607,17 +604,14 @@ fn import_login_shell_path() {
         return;
     }
 
-    let Some(start) = out
-        .stdout
-        .windows(START_MARKER.len())
-        .position(|window| window == START_MARKER)
+    let Some(start) =
+        out.stdout.windows(START_MARKER.len()).position(|window| window == START_MARKER)
     else {
         return;
     };
     let value_start = start + START_MARKER.len();
-    let Some(end) = out.stdout[value_start..]
-        .windows(END_MARKER.len())
-        .position(|window| window == END_MARKER)
+    let Some(end) =
+        out.stdout[value_start..].windows(END_MARKER.len()).position(|window| window == END_MARKER)
     else {
         return;
     };

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -585,7 +585,30 @@ fn close_window(app: AppHandle, state: State<'_, Arc<SessionManager>>) {
     quit_desktop_app(&app, state.inner().as_ref());
 }
 
+/// GUI-launched macOS apps inherit LaunchServices' minimal PATH, so argv tabs
+/// (e.g. `claude --resume`) fail to spawn. Import the user's login-shell PATH
+/// once at startup, before any PTY spawn or thread exists.
+fn import_login_shell_path() {
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+    let Ok(out) = std::process::Command::new(&shell)
+        .args(["-lc", "printf %s \"$PATH\""])
+        .output()
+    else {
+        return;
+    };
+    if !out.status.success() {
+        return;
+    }
+    if let Ok(path) = String::from_utf8(out.stdout) {
+        let path = path.trim();
+        if !path.is_empty() {
+            std::env::set_var("PATH", path);
+        }
+    }
+}
+
 fn main() {
+    import_login_shell_path();
     let _log_guard = dinotty_server::settings::init_logging();
 
     let args: Vec<String> = std::env::args().collect();

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -229,7 +229,7 @@ fn pty_spawn(
     }
 
     let (session, shell_type) =
-        pty::create_session(&manager, &pane_id, None, Some(Arc::clone(&exit_cb)), None)?;
+        pty::create_session(&manager, &pane_id, None, Some(Arc::clone(&exit_cb)), None, None)?;
 
     spawn_tauri_output_forwarder(app.clone(), pane_id.clone(), Arc::clone(&session));
     spawn_tauri_write_task(Arc::clone(&session), pane_id.clone());

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -585,13 +585,20 @@ fn close_window(app: AppHandle, state: State<'_, Arc<SessionManager>>) {
     quit_desktop_app(&app, state.inner().as_ref());
 }
 
-/// GUI-launched macOS apps inherit LaunchServices' minimal PATH, so argv tabs
-/// (e.g. `claude --resume`) fail to spawn. Import the user's login-shell PATH
-/// once at startup, before any PTY spawn or thread exists.
+/// macOS-specific: GUI-launched apps inherit LaunchServices' minimal PATH, so
+/// argv tabs (e.g. `claude --resume`) fail to spawn. Import the user's
+/// login-shell PATH once at startup, before any PTY spawn or thread exists.
+#[cfg(target_os = "macos")]
 fn import_login_shell_path() {
+    const START_MARKER: &[u8] = b"__DINOTTY_PATH_START__";
+    const END_MARKER: &[u8] = b"__DINOTTY_PATH_END__";
+
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
     let Ok(out) = std::process::Command::new(&shell)
-        .args(["-lc", "printf %s \"$PATH\""])
+        .args([
+            "-lc",
+            "printf '__DINOTTY_PATH_START__%s__DINOTTY_PATH_END__' \"$PATH\"",
+        ])
         .output()
     else {
         return;
@@ -599,7 +606,23 @@ fn import_login_shell_path() {
     if !out.status.success() {
         return;
     }
-    if let Ok(path) = String::from_utf8(out.stdout) {
+
+    let Some(start) = out
+        .stdout
+        .windows(START_MARKER.len())
+        .position(|window| window == START_MARKER)
+    else {
+        return;
+    };
+    let value_start = start + START_MARKER.len();
+    let Some(end) = out.stdout[value_start..]
+        .windows(END_MARKER.len())
+        .position(|window| window == END_MARKER)
+    else {
+        return;
+    };
+
+    if let Ok(path) = std::str::from_utf8(&out.stdout[value_start..value_start + end]) {
         let path = path.trim();
         if !path.is_empty() {
             std::env::set_var("PATH", path);
@@ -608,6 +631,7 @@ fn import_login_shell_path() {
 }
 
 fn main() {
+    #[cfg(target_os = "macos")]
     import_login_shell_path();
     let _log_guard = dinotty_server::settings::init_logging();
 

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -199,18 +199,19 @@ pub fn create_session(
         .openpty(PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 })
         .map_err(|e| e.to_string())?;
 
-    let shell_spec = argv.is_none().then(shell::default_shell);
-    let shell_type =
-        shell_spec.as_ref().map_or_else(|| "command".to_string(), |spec| spec.shell_type.clone());
-    let mut cmd = if let Some(argv) = argv.as_ref() {
-        let mut cmd = CommandBuilder::new(&argv[0]);
-        cmd.args(&argv[1..]);
-        cmd
-    } else {
-        let shell_spec = shell_spec.as_ref().expect("default shell is present without argv");
-        let mut cmd = CommandBuilder::new(&shell_spec.program);
-        cmd.args(&shell_spec.args);
-        cmd
+    #[allow(clippy::single_match_else)]
+    let (mut cmd, shell_type) = match argv {
+        Some(argv) => {
+            let mut cmd = CommandBuilder::new(&argv[0]);
+            cmd.args(&argv[1..]);
+            (cmd, "command".to_string())
+        }
+        None => {
+            let shell_spec = shell::default_shell();
+            let mut cmd = CommandBuilder::new(&shell_spec.program);
+            cmd.args(&shell_spec.args);
+            (cmd, shell_spec.shell_type.clone())
+        }
     };
     for key in claude_session_env_keys_to_strip() {
         cmd.env_remove(&key);
@@ -232,7 +233,7 @@ pub fn create_session(
     cmd.cwd(&effective_cwd);
 
     // Shell-specific hooks depend on HOME-style prompt expansion.
-    if argv.is_none() && matches!(shell_type.as_str(), "zsh" | "bash") {
+    if matches!(shell_type.as_str(), "zsh" | "bash") {
         let home =
             std::env::var("HOME").unwrap_or_else(|_| home_path.to_string_lossy().into_owned());
         if std::env::var_os("HOME").is_none() {

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -188,20 +188,32 @@ pub fn create_session(
     tab_id: Option<&str>,
     tauri_on_exit: Option<Arc<dyn Fn(String) + Send + Sync>>,
     cwd: Option<PathBuf>,
+    argv: Option<Vec<String>>,
 ) -> Result<(Arc<Session>, String), String> {
+    if argv.as_ref().is_some_and(Vec::is_empty) {
+        return Err("argv must be non-empty when provided".to_string());
+    }
+
     let pty_system = NativePtySystem::default();
     let pair = pty_system
         .openpty(PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 })
         .map_err(|e| e.to_string())?;
 
-    let shell_spec = shell::default_shell();
-    let shell_type = shell_spec.shell_type.clone();
-    let mut cmd = CommandBuilder::new(&shell_spec.program);
+    let shell_spec = argv.is_none().then(shell::default_shell);
+    let shell_type =
+        shell_spec.as_ref().map_or_else(|| "command".to_string(), |spec| spec.shell_type.clone());
+    let mut cmd = if let Some(argv) = argv.as_ref() {
+        let mut cmd = CommandBuilder::new(&argv[0]);
+        cmd.args(&argv[1..]);
+        cmd
+    } else {
+        let shell_spec = shell_spec.as_ref().expect("default shell is present without argv");
+        let mut cmd = CommandBuilder::new(&shell_spec.program);
+        cmd.args(&shell_spec.args);
+        cmd
+    };
     for key in claude_session_env_keys_to_strip() {
         cmd.env_remove(&key);
-    }
-    for arg in &shell_spec.args {
-        cmd.arg(arg);
     }
     cmd.env("TERM", "xterm-256color");
     cmd.env("DINOTTY_PANE_ID", pane_id);
@@ -220,7 +232,7 @@ pub fn create_session(
     cmd.cwd(&effective_cwd);
 
     // Shell-specific hooks depend on HOME-style prompt expansion.
-    if matches!(shell_type.as_str(), "zsh" | "bash") {
+    if argv.is_none() && matches!(shell_type.as_str(), "zsh" | "bash") {
         let home =
             std::env::var("HOME").unwrap_or_else(|_| home_path.to_string_lossy().into_owned());
         if std::env::var_os("HOME").is_none() {

--- a/src/tabs.rs
+++ b/src/tabs.rs
@@ -55,8 +55,8 @@ fn validate_create_tab_request(req: &CreateTabRequest) -> Result<Option<PathBuf>
         if argv.is_empty() {
             return Err("argv must be a non-empty array".to_string());
         }
-        if argv.iter().any(String::is_empty) {
-            return Err("argv entries must be non-empty strings".to_string());
+        if argv[0].is_empty() {
+            return Err("argv[0] must be a non-empty string".to_string());
         }
         if argv.iter().any(|arg| arg.contains('\0')) {
             return Err("argv entries must not contain NUL bytes".to_string());
@@ -105,9 +105,10 @@ pub async fn create_tab(
         Some(cwd) => Some(cwd),
         None => settings.read().await.resolved_default_workspace_root(),
     };
+    let is_argv_command = req.argv.is_some();
 
     // Create PTY session
-    let (_session, shell_type) =
+    let (session, shell_type) =
         match pty::create_session(&manager, &pane_id, Some(&tab_id), None, cwd, req.argv) {
             Ok(x) => x,
             Err(e) => {
@@ -131,27 +132,46 @@ pub async fn create_tab(
         "zoomed": false,
     });
 
-    // Store tab
-    manager.insert_tab(
-        tab_id.clone(),
-        serde_json::json!({
-            "layout": layout,
-            "active_pane_id": pane_id,
-        }),
-    );
+    let publish_tab = || {
+        manager.insert_tab(
+            tab_id.clone(),
+            serde_json::json!({
+                "layout": layout,
+                "active_pane_id": pane_id,
+            }),
+        );
 
-    // Set as active tab
-    *manager.active_pane_id.lock().unwrap_or_else(std::sync::PoisonError::into_inner) =
-        Some(pane_id.clone());
+        *manager.active_pane_id.lock().unwrap_or_else(std::sync::PoisonError::into_inner) =
+            Some(pane_id.clone());
 
-    // Broadcast to all sync clients
-    manager.broadcast_sync(&SyncMsg::TabCreated {
-        tab_id: tab_id.clone(),
-        pane_id: pane_id.clone(),
-        layout: Some(layout.clone()),
-        cwd: req.cwd.clone(),
-        connection_id: None,
-    });
+        manager.broadcast_sync(&SyncMsg::TabCreated {
+            tab_id: tab_id.clone(),
+            pane_id: pane_id.clone(),
+            layout: Some(layout.clone()),
+            cwd: req.cwd.clone(),
+            connection_id: None,
+        });
+    };
+
+    if is_argv_command {
+        // Fast commands can exit as soon as their PTY starts. Synchronize with
+        // exit cleanup so it either wins before we publish, or observes the
+        // registered tab and removes it after publication.
+        let exited = session.exited.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        if *exited {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(
+                    serde_json::json!({ "error": "command exited before tab creation completed" }),
+                ),
+            )
+                .into_response();
+        }
+        publish_tab();
+        drop(exited);
+    } else {
+        publish_tab();
+    }
 
     Json(serde_json::json!({
         "tab_id": tab_id,
@@ -175,15 +195,17 @@ mod tests {
     }
 
     #[test]
-    fn create_tab_argv_must_be_non_empty() {
+    fn create_tab_argv_requires_non_empty_program() {
         assert!(validate_create_tab_request(&request(vec![])).is_err());
-        assert!(validate_create_tab_request(&request(vec!["claude", ""])).is_err());
+        assert!(validate_create_tab_request(&request(vec![""])).is_err());
+        assert!(validate_create_tab_request(&request(vec!["claude", ""])).is_ok());
         assert!(validate_create_tab_request(&request(vec!["claude", "--resume"])).is_ok());
     }
 
     #[test]
     fn create_tab_argv_rejects_nul_bytes() {
         assert!(validate_create_tab_request(&request(vec!["claude\0", "--resume"])).is_err());
+        assert!(validate_create_tab_request(&request(vec!["claude", "--resume\0"])).is_err());
     }
 }
 

--- a/src/tabs.rs
+++ b/src/tabs.rs
@@ -4,7 +4,8 @@ use axum::{
     response::IntoResponse,
     Json,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::pty;
@@ -36,6 +37,39 @@ pub struct UpdateLayoutRequest {
 pub struct CreateTabRequest {
     #[serde(default)]
     pub cwd: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_optional_argv")]
+    pub argv: Option<Vec<String>>,
+    #[serde(default)]
+    pub title: Option<String>,
+}
+
+fn deserialize_optional_argv<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Vec::<String>::deserialize(deserializer).map(Some)
+}
+
+fn validate_create_tab_request(req: &CreateTabRequest) -> Result<Option<PathBuf>, String> {
+    if let Some(argv) = req.argv.as_ref() {
+        if argv.is_empty() {
+            return Err("argv must be a non-empty array".to_string());
+        }
+        if argv.iter().any(String::is_empty) {
+            return Err("argv entries must be non-empty strings".to_string());
+        }
+        if argv.iter().any(|arg| arg.contains('\0')) {
+            return Err("argv entries must not contain NUL bytes".to_string());
+        }
+    }
+
+    req.cwd.as_ref().map(PathBuf::from).map_or(Ok(None), |cwd| {
+        if cwd.is_dir() {
+            Ok(Some(cwd))
+        } else {
+            Err("cwd must exist and be a directory".to_string())
+        }
+    })
 }
 
 // ─── GET /api/tabs ─────────────────────────────────────────────────
@@ -56,18 +90,25 @@ pub async fn create_tab(
     State((manager, settings)): State<(Arc<SessionManager>, SettingsState)>,
     Json(req): Json<CreateTabRequest>,
 ) -> impl IntoResponse {
+    let requested_cwd = match validate_create_tab_request(&req) {
+        Ok(cwd) => cwd,
+        Err(e) => {
+            return (StatusCode::BAD_REQUEST, Json(serde_json::json!({ "error": e })))
+                .into_response();
+        }
+    };
     let tab_id = uuid::Uuid::new_v4().to_string();
     let pane_id = uuid::Uuid::new_v4().to_string();
 
     // Resolve CWD: explicit request > configured default workspace root > $HOME.
-    let cwd = match req.cwd.clone() {
-        Some(cwd) => Some(std::path::PathBuf::from(cwd)),
+    let cwd = match requested_cwd {
+        Some(cwd) => Some(cwd),
         None => settings.read().await.resolved_default_workspace_root(),
     };
 
     // Create PTY session
     let (_session, shell_type) =
-        match pty::create_session(&manager, &pane_id, Some(&tab_id), None, cwd) {
+        match pty::create_session(&manager, &pane_id, Some(&tab_id), None, cwd, req.argv) {
             Ok(x) => x,
             Err(e) => {
                 tracing::error!("Failed to create PTY: {}", e);
@@ -80,10 +121,11 @@ pub async fn create_tab(
         };
 
     // Create initial layout with single leaf
+    let title = req.title.as_deref().unwrap_or("Terminal");
     let layout = serde_json::json!({
         "type": "leaf",
         "paneId": pane_id,
-        "title": "Terminal",
+        "title": title,
         "shell_type": shell_type,
         "ratio": 1,
         "zoomed": false,
@@ -118,6 +160,31 @@ pub async fn create_tab(
         "cwd": req.cwd,
     }))
     .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{validate_create_tab_request, CreateTabRequest};
+
+    fn request(argv: Vec<&str>) -> CreateTabRequest {
+        CreateTabRequest {
+            cwd: None,
+            argv: Some(argv.into_iter().map(str::to_string).collect()),
+            title: None,
+        }
+    }
+
+    #[test]
+    fn create_tab_argv_must_be_non_empty() {
+        assert!(validate_create_tab_request(&request(vec![])).is_err());
+        assert!(validate_create_tab_request(&request(vec!["claude", ""])).is_err());
+        assert!(validate_create_tab_request(&request(vec!["claude", "--resume"])).is_ok());
+    }
+
+    #[test]
+    fn create_tab_argv_rejects_nul_bytes() {
+        assert!(validate_create_tab_request(&request(vec!["claude\0", "--resume"])).is_err());
+    }
 }
 
 // ─── DELETE /api/tabs/{tab_id} ─────────────────────────────────────
@@ -201,7 +268,7 @@ pub async fn split_pane(
     let (_session, _shell_type) = if req.force_local {
         // Force local PTY — use explicit cwd if provided, otherwise inherit from source
         let local_cwd = req.cwd.map(std::path::PathBuf::from).or(source_cwd);
-        match pty::create_session(&manager, &new_pane_id, Some(&tab_id), None, local_cwd) {
+        match pty::create_session(&manager, &new_pane_id, Some(&tab_id), None, local_cwd, None) {
             Ok(x) => x,
             Err(e) => {
                 tracing::error!("Failed to create PTY for force-local split: {}", e);
@@ -227,7 +294,7 @@ pub async fn split_pane(
         }
     } else {
         // Local PTY — inherit CWD from source pane
-        match pty::create_session(&manager, &new_pane_id, Some(&tab_id), None, source_cwd) {
+        match pty::create_session(&manager, &new_pane_id, Some(&tab_id), None, source_cwd, None) {
             Ok(x) => x,
             Err(e) => {
                 tracing::error!("Failed to create PTY for split: {}", e);

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -28,6 +28,7 @@ use crate::workspace_mgmt::WorkspacesState;
 pub struct WsQuery {
     #[serde(rename = "paneId")]
     pane_id: Option<String>,
+    argv: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -127,6 +128,11 @@ pub async fn ws_handler(
     ConnectInfo(_addr): ConnectInfo<SocketAddr>,
     _headers: axum::http::HeaderMap,
 ) -> impl IntoResponse {
+    // WebSocket connections only attach to panes already created through /api/tabs.
+    // Reject argv explicitly so a reconnect can never silently turn into a spawn request.
+    if q.argv.is_some() {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
     // paneId must reference a tab created via /api/tabs (or the sync WS
     // CreateTab message); otherwise an authenticated client could spawn
     // unbounded orphan PTYs by connecting with random/empty paneIds. Cookie
@@ -704,7 +710,7 @@ async fn handle_socket(
     info!("No existing session found for pane={}, creating new PTY session", pane_id);
     let cwd = settings.read().await.resolved_default_workspace_root();
     let (session, shell_type) =
-        match crate::pty::create_session(&manager, &pane_id, None, None, cwd) {
+        match crate::pty::create_session(&manager, &pane_id, None, None, cwd, None) {
             Ok(x) => x,
             Err(e) => {
                 error!("{}", e);


### PR DESCRIPTION
## What

Add a plugin API `createTerminalTab({ cwd, argv, title })` so a plugin can open a terminal tab that runs a specific program, instead of only an interactive shell.

- **Backend** (`src/tabs.rs`, `src/pty.rs`): `POST /api/tabs` accepts an optional `argv`; when present the PTY is spawned from `argv` via `CommandBuilder::new(argv[0])` + `args(argv[1..])` — a direct fork/exec, **no shell**, so nothing in `argv` is re-parsed (no shell-metacharacter injection). `validate_create_tab_request` rejects empty `argv`, empty `argv[0]`, and NUL bytes before spawn.
- **WS query hardening** (`src/ws/mod.rs`): the untrusted WebSocket reconnect query path explicitly rejects any `argv` (`400`) — argv only ever arrives through the tab-creation REST call, never the socket.
- **Fast-exit ordering** (`src/tabs.rs`): the tab is published while holding `session.exited`, so a program that exits immediately (e.g. `claude --resume` finishing) cannot broadcast `TabClosed` before the tab is registered; an already-exited spawn returns `500` instead of leaving a zombie tab.
- **Desktop PATH** (`src-tauri/src/main.rs`, macOS only): GUI-launched apps inherit LaunchServices' minimal `PATH`, so argv tabs like `claude --resume` couldn't find their binary. At startup (macOS only) the user's login-shell `PATH` is imported once, via a sentinel-delimited `printf` — every failure mode (spawn error, non-zero exit, missing marker, invalid UTF-8) leaves the inherited `PATH` untouched.
- **Frontend** (`App.vue`, `useTabApi.ts`, `usePluginLoader.ts`, `plugin-api/index.d.ts`): plugin bridge + type surface, returning the new tab id.

## Design notes for review

Two intentional behaviors worth an explicit maintainer decision — flagging rather than hiding them:

1. **`argv` trust tier.** `POST /api/tabs` sits behind the same global auth middleware as the rest of the terminal REST/WS surface. There is no separate *plugin-identity* check, so "argv is plugin-only" is a UI-layer convention, not a backend-enforced boundary — any authenticated client can `POST /api/tabs` with `argv`. This is **not a privilege escalation**: an authenticated session already has full arbitrary-command execution via any ordinary shell tab. If you ever introduce a lower-trust caller (a scoped agent/plugin token distinct from the human user), argv would want its own capability gate; today it is deliberately full-user-trust. Take or adjust as you prefer.

2. **Workspace auto-activate.** `createTerminalTab` switches the active workspace to the one matching `cwd` (so a resumed session lands visibly). If `cwd` matches no configured workspace it deactivates the workspace filter. Bounded to the user's own workspaces, no security impact — but if you'd rather a plugin never move the active workspace, that call is a one-line opt-out.

## Scope

Backend (`src/`, `src-tauri/`) + frontend. Independent PR (no dependency on the notification PRs).

## CI note

Upstream `dev`'s `Backend (clippy + fmt + test)` job is currently red on pre-existing rustfmt drift + clippy pedantic (`doc_markdown`, one `pass-by-value`) under an unpinned stable toolchain, all in files this PR does not touch. This PR adds **zero** new fmt drift and **zero** new clippy findings in the files it changes, and `cargo test --lib` passes (244, +2 new tests). Frontend `vue-tsc`, `build`, and vitest (421) pass locally.
