### PR TITLE
feat(mobile): configurable single-row quick-key toolbar

### DIFF
--- a/frontend/src/components/keyboard/MobileKeyboard.vue
+++ b/frontend/src/components/keyboard/MobileKeyboard.vue
@@ -94,17 +94,6 @@
         <FileText :size="14" />
         <span class="mkb-path-label">{{ globalSelectedPath!.split('/').pop() }}</span>
       </button>
-      <div v-if="toolbarQuickKeyDefs.length" class="mkb-toolbar-quick-strip">
-        <MkbKey
-          v-for="(key, i) in toolbarQuickKeyDefs"
-          :key="`${key.l}-${key.s ?? key.sp ?? i}-${i}`"
-          class="mkb-toolbar-quick-key"
-          :k="key"
-          :state="modState"
-          @key-press="onKeyPress"
-          @special="onSpecial"
-        />
-      </div>
       <button
         type="button"
         class="mkb-tool-btn"
@@ -138,6 +127,20 @@
       >
         {{ t('mobileKb.targetHint') }}
       </span>
+    </div>
+
+    <div v-if="toolbarQuickKeyDefs.length" v-show="textInputFocused" class="mkb-toolbar mkb-toolbar-quick-row">
+      <div class="mkb-toolbar-quick-strip">
+        <MkbKey
+          v-for="(key, i) in toolbarQuickKeyDefs"
+          :key="`${key.l}-${key.s ?? key.sp ?? i}-${i}`"
+          class="mkb-toolbar-quick-key"
+          :k="key"
+          :state="modState"
+          @key-press="onKeyPress"
+          @special="onSpecial"
+        />
+      </div>
     </div>
 
     <div v-if="phoneUploading" class="mkb-upload-progress">

--- a/frontend/src/components/keyboard/MobileKeyboard.vue
+++ b/frontend/src/components/keyboard/MobileKeyboard.vue
@@ -94,6 +94,17 @@
         <FileText :size="14" />
         <span class="mkb-path-label">{{ globalSelectedPath!.split('/').pop() }}</span>
       </button>
+      <div v-if="toolbarQuickKeyDefs.length" class="mkb-toolbar-quick-strip">
+        <MkbKey
+          v-for="(key, i) in toolbarQuickKeyDefs"
+          :key="`${key.l}-${key.s ?? key.sp ?? i}-${i}`"
+          class="mkb-toolbar-quick-key"
+          :k="key"
+          :state="modState"
+          @key-press="onKeyPress"
+          @special="onSpecial"
+        />
+      </div>
       <button
         type="button"
         class="mkb-tool-btn"
@@ -310,7 +321,7 @@ import {
 } from '../../composables/useSettings'
 import { useI18n } from '../../composables/useI18n'
 import { useHistory } from '../../composables/useHistory'
-import { mapActionKeys } from '../../utils/actionKeyDef'
+import { actionKeyToKeyDef, mapActionKeys } from '../../utils/actionKeyDef'
 import {
   Keyboard,
   SquareTerminal,
@@ -649,6 +660,10 @@ const actionFollowingRows = computed(() => {
 
 const pasteSupported = computed(
   () => window.isSecureContext && typeof navigator.clipboard?.readText === 'function'
+)
+
+const toolbarQuickKeyDefs = computed(() =>
+  (settings.toolbar_quick_keys ?? []).slice(0, 5).map((key) => actionKeyToKeyDef(key))
 )
 
 const actionArrowUp: KeyDef = { l: '↑', s: '\x1b[A', cls: 'mkb-mod mkb-action-arrow', repeat: true }

--- a/frontend/src/components/settings/KeyboardTab.vue
+++ b/frontend/src/components/settings/KeyboardTab.vue
@@ -226,6 +226,40 @@
         </button>
       </div>
 
+      <h4>工具栏快捷键 / Toolbar Quick Keys</h4>
+      <p class="settings-hint">移动网页输入框聚焦时显示，最多 5 个。</p>
+      <div class="ak-wysiwyg">
+        <div class="ak-wyg-row-outer">
+          <div class="mkb-row-wrap">
+            <div class="mkb-row">
+              <div
+                v-for="(key, ki) in toolbarQuickKeys"
+                :key="akItemKey(key)"
+                class="ak-wyg-slot"
+                :style="toolbarPreviewSlotStyle"
+              >
+                <div class="mkb-btn ak-wyg-key" :class="[previewToolbarDef(key).cls]">
+                  <span class="ak-wyg-label" @click="editToolbarQuickKey(ki)">{{
+                    previewLabel(key)
+                  }}</span>
+                  <button type="button" class="ak-key-del" @click.stop="removeToolbarQuickKey(ki)">
+                    ✕
+                  </button>
+                </div>
+              </div>
+              <button
+                type="button"
+                class="mkb-btn mkb-mod ak-wyg-add-key"
+                :disabled="toolbarQuickKeys.length >= 5"
+                @click="addToolbarQuickKey"
+              >
+                +
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <!-- Edit modal -->
       <div v-if="akEdit" class="ak-modal-backdrop" @click.self="akEdit = null">
         <div class="ak-modal">
@@ -276,7 +310,9 @@
             <input type="checkbox" v-model="akEdit.repeat" /> {{ t('settings.repeatHold') }}
           </label>
           <div class="ak-modal-actions">
-            <button class="settings-save" @click="saveActionKey">{{ t('settings.save') }}</button>
+            <button class="settings-save" :disabled="!akCanSave" @click="saveActionKey">
+              {{ t('settings.save') }}
+            </button>
             <button class="shortcut-add" @click="akEdit = null">{{ t('settings.cancel') }}</button>
           </div>
         </div>
@@ -537,10 +573,17 @@ const actionRows = computed(() => {
   return (settings.action_keyboard ?? DEFAULT_ACTION_KEYBOARD).rows
 })
 
+const toolbarQuickKeys = computed(() => settings.toolbar_quick_keys ?? [])
+const toolbarPreviewSlotStyle = { flexGrow: 1, flexBasis: '0', minWidth: '0' }
+
 function previewDef(ri: number, ki: number) {
   const rows = actionRows.value
   const bottom = ri === rows.length - 1
   return actionKeyToKeyDef(rows[ri][ki], bottom ? { bottomIdx: ki } : undefined)
+}
+
+function previewToolbarDef(key: ActionKey) {
+  return actionKeyToKeyDef(key)
 }
 
 function akPreviewSlotStyle(ri: number, ki: number) {
@@ -582,6 +625,12 @@ function ensureActionKeyboard() {
   }
 }
 
+function ensureToolbarQuickKeys() {
+  if (!Array.isArray(settings.toolbar_quick_keys)) {
+    settings.toolbar_quick_keys = []
+  }
+}
+
 function addActionRow() {
   ensureActionKeyboard()
   settings.action_keyboard!.rows.push([])
@@ -612,6 +661,42 @@ function resolveAutoEnterForEdit(key: ActionKey): boolean {
 function removeActionKey(ri: number, ki: number) {
   ensureActionKeyboard()
   settings.action_keyboard!.rows[ri].splice(ki, 1)
+}
+
+function addToolbarQuickKey() {
+  ensureToolbarQuickKeys()
+  if (settings.toolbar_quick_keys.length >= 5) return
+  akEdit.value = {
+    scope: 'toolbar',
+    ri: -1,
+    ki: settings.toolbar_quick_keys.length,
+    label: '',
+    sendRaw: '',
+    style: '',
+    repeat: false,
+    auto_enter: true,
+  }
+}
+
+function editToolbarQuickKey(ki: number) {
+  ensureToolbarQuickKeys()
+  const key = settings.toolbar_quick_keys[ki]
+  if (!key) return
+  akEdit.value = {
+    scope: 'toolbar',
+    ri: -1,
+    ki,
+    label: key.label,
+    sendRaw: escapeForDisplay(key.send),
+    style: key.style || '',
+    repeat: key.repeat || false,
+    auto_enter: resolveAutoEnterForEdit(key),
+  }
+}
+
+function removeToolbarQuickKey(ki: number) {
+  ensureToolbarQuickKeys()
+  settings.toolbar_quick_keys.splice(ki, 1)
 }
 
 const akKeyIds = new WeakMap<ActionKey, string>()
@@ -661,7 +746,10 @@ function akResizePointerDown(ri: number, ki: number, e: PointerEvent) {
   window.addEventListener('pointercancel', end)
 }
 
+type AkEditScope = 'action' | 'toolbar'
+
 const akEdit = ref<{
+  scope: AkEditScope
   ri: number
   ki: number
   label: string
@@ -673,9 +761,16 @@ const akEdit = ref<{
 const akRecording = ref(false)
 const recordFocusSinkRef = ref<HTMLElement | null>(null)
 
+const akCanSave = computed(() => {
+  if (!akEdit.value) return false
+  if (akEdit.value.scope !== 'toolbar') return true
+  return akEdit.value.label.trim().length > 0 && unescapeFromDisplay(akEdit.value.sendRaw).length > 0
+})
+
 function editActionKey(ri: number, ki: number) {
   const key = actionRows.value[ri][ki]
   akEdit.value = {
+    scope: 'action',
     ri,
     ki,
     label: key.label,
@@ -687,15 +782,26 @@ function editActionKey(ri: number, ki: number) {
 }
 
 function saveActionKey() {
-  if (!akEdit.value) return
-  ensureActionKeyboard()
+  if (!akEdit.value || !akCanSave.value) return
   const { ri, ki, label, sendRaw, style, repeat, auto_enter } = akEdit.value
-  const key = settings.action_keyboard!.rows[ri][ki]
-  key.label = label
-  key.send = unescapeFromDisplay(sendRaw)
-  key.style = style || undefined
-  key.repeat = repeat || undefined
-  key.auto_enter = auto_enter
+  const next: ActionKey = {
+    label: akEdit.value.scope === 'toolbar' ? label.trim() : label,
+    send: unescapeFromDisplay(sendRaw),
+    style: style || undefined,
+    repeat: repeat || undefined,
+    auto_enter,
+  }
+  if (akEdit.value.scope === 'toolbar') {
+    ensureToolbarQuickKeys()
+    if (ki < settings.toolbar_quick_keys.length) {
+      settings.toolbar_quick_keys[ki] = next
+    } else if (settings.toolbar_quick_keys.length < 5) {
+      settings.toolbar_quick_keys.push(next)
+    }
+  } else {
+    ensureActionKeyboard()
+    Object.assign(settings.action_keyboard!.rows[ri][ki], next)
+  }
   akEdit.value = null
 }
 

--- a/frontend/src/composables/useSettings.ts
+++ b/frontend/src/composables/useSettings.ts
@@ -33,6 +33,7 @@ export interface SettingsData {
   recent_files: RecentEntry[]
   recent_urls: RecentEntry[]
   action_keyboard: ActionKeyboardConfig | null
+  toolbar_quick_keys: ActionKey[]
   upload_dir: string
   default_base_dir?: string | null
   default_workspace_root?: string | null
@@ -233,6 +234,7 @@ export const settings = reactive<SettingsData>({
   recent_files: [],
   recent_urls: [],
   action_keyboard: null,
+  toolbar_quick_keys: [],
   upload_dir: '',
   upload_cap_mb: 200,
   upload_file_cap_mb: 0,
@@ -312,6 +314,7 @@ export function useSettings() {
 }
 
 function restoreActionIcons() {
+  // Toolbar quick keys are plain user-defined labels/sends; do not attach default icons.
   const cfg = settings.action_keyboard
   if (!cfg?.rows) return
   // Build a lookup from send → icon using DEFAULT_ACTION_KEYBOARD

--- a/frontend/src/styles/mobile-keyboard.css
+++ b/frontend/src/styles/mobile-keyboard.css
@@ -531,11 +531,11 @@
 
 .mkb-toolbar-quick-strip {
   display: flex;
-  flex: 1 1 184px;
+  flex: 1 1 auto;
   flex-wrap: nowrap;
   gap: 4px;
   min-width: 0;
-  max-width: 184px;
+  max-width: none;
   overflow: hidden;
 }
 

--- a/frontend/src/styles/mobile-keyboard.css
+++ b/frontend/src/styles/mobile-keyboard.css
@@ -520,13 +520,30 @@
 }
 
 .mkb-path-chip {
-  flex: 0 1 120px;
+  flex: 0 1 112px;
   min-width: 0;
   width: auto;
   padding: 0 8px;
   gap: 4px;
   font-size: 12px;
   overflow: hidden;
+}
+
+.mkb-toolbar-quick-strip {
+  display: flex;
+  flex: 1 1 184px;
+  flex-wrap: nowrap;
+  gap: 4px;
+  min-width: 0;
+  max-width: 184px;
+  overflow: hidden;
+}
+
+.mkb-toolbar-quick-strip .mkb-btn {
+  flex: 1 1 0;
+  min-width: 0;
+  font-size: 12px;
+  text-overflow: ellipsis;
 }
 
 .mkb-path-label {

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -55,6 +55,8 @@ pub struct Settings {
     #[serde(default)]
     pub upload_file_cap_mb: u64,
     #[serde(default)]
+    pub toolbar_quick_keys: Vec<ActionKey>,
+    #[serde(default)]
     pub keyboard_sound: bool,
     #[serde(default)]
     pub show_virtual_keyboard: bool,
@@ -869,6 +871,7 @@ impl Default for Settings {
             recent_files: vec![],
             recent_urls: vec![],
             action_keyboard: None,
+            toolbar_quick_keys: vec![],
             upload_dir: default_upload_dir(),
             default_base_dir: None,
             default_workspace_root: None,


### PR DESCRIPTION
## What

A configurable single-row **quick-key toolbar** for the mobile keyboard. Users pick up to five action keys in **Settings → Keyboard**, and they appear as a dedicated strip right above the keyboard for one-tap access (arrows, Esc, Tab, Ctrl-C, or any custom label→send).

- **Backend** (`src/settings/mod.rs`): a new `toolbar_quick_keys: Vec<ActionKey>` field (serde-defaulted, so old settings files load unchanged); `ActionKey`'s `label`/`send` gain `#[serde(default)]` for forward-compat.
- **Frontend config** (`components/settings/KeyboardTab.vue`): add/remove/edit quick keys, persisted through the existing settings save path.
- **Frontend render** (`components/keyboard/MobileKeyboard.vue`, `styles/mobile-keyboard.css`): a `toolbarQuickKeyDefs` computed maps the configured keys through the existing `actionKeyToKeyDef` helper and renders them as `MkbKey` buttons in their **own dedicated toolbar row** (full width, keys share the row evenly) — separate from the existing action toolbar so it never competes with it for space on narrow screens.
- `useSettings.ts`: `toolbar_quick_keys` added to the settings type + default.

## Scope

Mostly frontend; one small backend settings field. The strip renders only when the user has configured at least one quick key (default is empty → zero visual change).

## CI note

Upstream `dev`'s `Backend (clippy + fmt + test)` job is currently red on pre-existing rustfmt drift + clippy pedantic under an unpinned stable toolchain, all in files this PR does not touch. This PR adds zero new fmt/clippy findings to `src/settings/mod.rs`, and `cargo test --lib` passes (242). Frontend `vue-tsc`, `build`, and vitest (421) pass locally.
