### PR TITLE
feat(notification): attention core — bidirectional /ws/notify revision protocol + AttentionLedger

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -270,6 +270,7 @@ import {
   fetchAutoToken,
   validateToken,
   apiUrl,
+  authFetch,
   markCookieAuthenticated,
 } from './composables/apiBase'
 import { isTauri, tauriInvoke } from './composables/useTransport'
@@ -283,7 +284,17 @@ import { isWindowsClient } from './utils/clientPlatform'
 import { initMonitorHistory } from './composables/useMonitor'
 import NotificationPanel from './components/notification/NotificationPanel.vue'
 import { useToast } from 'vue-toastification'
-import { useNotification, pushNotification, setToastInstance, aggregateSeverity } from './composables/useNotification'
+import {
+  useNotification,
+  pushNotification,
+  setToastInstance,
+  setActiveReadContext,
+  evaluateActiveRead,
+  aggregateSeverity,
+  getNotificationClientId,
+  mintNotificationRequestId,
+} from './composables/useNotification'
+import { getIsAppForeground, onAppForegroundGain } from './composables/useAppForeground'
 import { usePluginLoader } from './composables/usePluginLoader'
 import PluginView from './components/plugin/PluginView.vue'
 import {
@@ -344,6 +355,12 @@ const { t } = useI18n()
 const { getBinding, formatBinding } = useKeybindings()
 const notif = useNotification()
 setToastInstance(useToast())
+setActiveReadContext({
+  getActiveFocusedPaneId: () =>
+    activeTab.value?.type === 'terminal' ? activeTab.value.activePaneId : null,
+  isAppForeground: getIsAppForeground,
+})
+const stopForegroundGainSubscription = onAppForegroundGain(evaluateActiveRead)
 const { loadedPlugins, loadAll, getPluginContext, pluginList, allCommands } = usePluginLoader()
 const { isMobile } = useIsMobile()
 
@@ -1366,18 +1383,180 @@ window.__dinotty_terminal_api = {
 // Test hooks for P3 verification (focusActive + isComposing guard).
 window.__dinotty_test_focus_active = focusActive
 window.__dinotty_test_is_composing = (paneId: string) => termRefs[paneId]?.isComposing() ?? false
+const PLUGIN_NOTIFY_RETRY_DELAYS_MS = [1000, 2000, 4000] as const
+const BRIDGE_MAX_CONCURRENT = 3
+const BRIDGE_QUEUE_CAP = 64
+
+interface PluginNotifyBridgeJob {
+  readonly requestId: string
+  readonly body: string
+}
+
+const pluginNotifyBridgeQueue: PluginNotifyBridgeJob[] = []
+const pluginNotifyBridgeRetryTimers = new Map<
+  ReturnType<typeof setTimeout>,
+  (shouldContinue: boolean) => void
+>()
+const pluginNotifyBridgeAbortControllers = new Set<AbortController>()
+let pluginNotifyBridgeActiveJobs = 0
+let pluginNotifyBridgeDisposed = false
+let pluginNotifyBridgeOverflowDropped = 0
+let pluginNotifyBridgeOverflowWarnScheduled = false
+
+function waitForPluginNotifyRetry(delayMs: number) {
+  if (pluginNotifyBridgeDisposed) return Promise.resolve(false)
+  return new Promise<boolean>((resolve) => {
+    const timer = setTimeout(() => {
+      pluginNotifyBridgeRetryTimers.delete(timer)
+      resolve(!pluginNotifyBridgeDisposed)
+    }, delayMs)
+    pluginNotifyBridgeRetryTimers.set(timer, resolve)
+  })
+}
+
+async function runPluginNotifyBridgeJob(job: PluginNotifyBridgeJob) {
+  for (let attempt = 0; attempt < 4; attempt++) {
+    try {
+      await getApiBase()
+      if (pluginNotifyBridgeDisposed) return
+
+      const controller = new AbortController()
+      pluginNotifyBridgeAbortControllers.add(controller)
+      let response: Awaited<ReturnType<typeof authFetch>>
+      try {
+        response = await authFetch(apiUrl('/api/notify'), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: job.body,
+          signal: controller.signal,
+        })
+      } finally {
+        pluginNotifyBridgeAbortControllers.delete(controller)
+      }
+      if (pluginNotifyBridgeDisposed) return
+
+      const responseBody = await response.json().catch(() => null)
+      if (pluginNotifyBridgeDisposed) return
+
+      if (response.status === 200) {
+        const accepted =
+          responseBody?.status === 'accepted' ||
+          (typeof responseBody?.eventSeq === 'string' &&
+            (typeof responseBody?.notifId === 'string' || typeof responseBody?.paneId === 'string'))
+        if (accepted || responseBody?.status === 'suppressed') return
+        console.error('[notification] plugin notify returned an unexpected 200 response')
+        return
+      }
+
+      if (response.status === 503) {
+        if (attempt < PLUGIN_NOTIFY_RETRY_DELAYS_MS.length) {
+          if (!(await waitForPluginNotifyRetry(PLUGIN_NOTIFY_RETRY_DELAYS_MS[attempt]))) return
+          continue
+        }
+        break
+      }
+
+      console.error(`[notification] plugin notify failed with HTTP ${response.status}`)
+      return
+    } catch (error) {
+      if (pluginNotifyBridgeDisposed) return
+      if (attempt < PLUGIN_NOTIFY_RETRY_DELAYS_MS.length) {
+        if (!(await waitForPluginNotifyRetry(PLUGIN_NOTIFY_RETRY_DELAYS_MS[attempt]))) return
+        continue
+      }
+      console.error('[notification] plugin notify retry exhausted', error)
+      break
+    }
+  }
+
+  if (pluginNotifyBridgeDisposed) return
+  const request = JSON.parse(job.body) as {
+    type: 'info' | 'warning' | 'error'
+    title: string
+    body: string
+  }
+  console.error('[notification] plugin notify retry exhausted; inserting locally')
+  pushNotification({
+    type: request.type,
+    title: request.title,
+    body: request.body,
+    source: 'plugin',
+  })
+}
+
+function pumpPluginNotifyBridgeQueue() {
+  while (
+    !pluginNotifyBridgeDisposed &&
+    pluginNotifyBridgeActiveJobs < BRIDGE_MAX_CONCURRENT &&
+    pluginNotifyBridgeQueue.length > 0
+  ) {
+    const job = pluginNotifyBridgeQueue.shift()!
+    pluginNotifyBridgeActiveJobs++
+    void runPluginNotifyBridgeJob(job).finally(() => {
+      pluginNotifyBridgeActiveJobs--
+      pumpPluginNotifyBridgeQueue()
+    })
+  }
+}
+
+function enqueuePluginNotifyBridgeJob(job: PluginNotifyBridgeJob) {
+  if (pluginNotifyBridgeDisposed) return
+  if (pluginNotifyBridgeQueue.length >= BRIDGE_QUEUE_CAP) {
+    pluginNotifyBridgeQueue.shift()
+    pluginNotifyBridgeOverflowDropped++
+    if (!pluginNotifyBridgeOverflowWarnScheduled) {
+      pluginNotifyBridgeOverflowWarnScheduled = true
+      queueMicrotask(() => {
+        pluginNotifyBridgeOverflowWarnScheduled = false
+        if (pluginNotifyBridgeDisposed) {
+          pluginNotifyBridgeOverflowDropped = 0
+          return
+        }
+        const dropped = pluginNotifyBridgeOverflowDropped
+        pluginNotifyBridgeOverflowDropped = 0
+        console.warn(
+          `[notification] plugin notify bridge queue full; evicted ${dropped} oldest pending ${dropped === 1 ? 'job' : 'jobs'}`
+        )
+      })
+    }
+  }
+  pluginNotifyBridgeQueue.push(job)
+  pumpPluginNotifyBridgeQueue()
+}
+
+function disposePluginNotifyBridge() {
+  pluginNotifyBridgeDisposed = true
+  pluginNotifyBridgeQueue.length = 0
+  pluginNotifyBridgeOverflowDropped = 0
+  for (const [timer, resolve] of pluginNotifyBridgeRetryTimers) {
+    clearTimeout(timer)
+    resolve(false)
+  }
+  pluginNotifyBridgeRetryTimers.clear()
+  for (const controller of pluginNotifyBridgeAbortControllers) controller.abort()
+  pluginNotifyBridgeAbortControllers.clear()
+}
+
 window.__dinotty_ui_notify = (
   message: string,
   level?: 'info' | 'warn' | 'error',
   title?: string
 ) => {
   const type = level === 'error' ? 'error' : level === 'warn' ? 'warning' : 'info'
-  pushNotification({
-    type,
-    title: title ?? 'Plugin',
-    body: message,
-    source: 'plugin',
+  const requestId = mintNotificationRequestId()
+  const job = Object.freeze({
+    requestId,
+    body: JSON.stringify({
+      clientId: getNotificationClientId(),
+      requestId,
+      source: 'plugin',
+      type,
+      title: title ?? 'Plugin',
+      body: message,
+    }),
   })
+
+  enqueuePluginNotifyBridgeJob(job)
 }
 window.__dinotty_ui_confirm = (message: string) => uiConfirm(message)
 window.__dinotty_open_plugin = openPlugin
@@ -1736,6 +1915,8 @@ onMounted(async () => {
 })
 
 onBeforeUnmount(() => {
+  stopForegroundGainSubscription()
+  disposePluginNotifyBridge()
   unlistenWindowClose?.()
   document.removeEventListener('keydown', onGlobalKeydown)
   document.removeEventListener('terminal-scroll', onTerminalScroll)

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -674,6 +674,7 @@ function onDividerDragEnd(tab: Tab) {
 
 let persistTimer: ReturnType<typeof setTimeout> | null = null
 function persistNow() {
+  if (typeof localStorage === "undefined") return
   const state = tabs.value.map((t) => {
     if (t.type === 'terminal') {
       return {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -66,7 +66,7 @@
           <Settings :size="16" />
         </button>
         <button
-          v-if="notif.notifications.value.length > 0"
+          v-if="notif.notifications.value.length > 0 || notif.unreadAttentionCount.value > 0"
           type="button"
           class="tab-bar-icon-btn notif-btn"
           :title="t('notification.title')"
@@ -74,8 +74,8 @@
           @touchend.prevent="notif.togglePanel()"
         >
           <Bell :size="16" />
-          <span v-if="notif.unreadCount.value > 0" class="notif-badge">{{
-            notif.unreadCount.value > 9 ? '9+' : notif.unreadCount.value
+          <span v-if="notif.unreadAttentionCount.value > 0" class="notif-badge">{{
+            notif.unreadAttentionCount.value > 9 ? '9+' : notif.unreadAttentionCount.value
           }}</span>
         </button>
       </template>
@@ -786,12 +786,12 @@ function resolveTabWorkspace(tab: Tab) {
     : tab.workspaceId ? workspaces.value.find((w) => w.id === tab.workspaceId) ?? null : null
 }
 
-function clearResolvedTabNotifications(tab: Tab) {
+function clearResolvedTabNotifications(tab: Tab, reason: 'tab_activate' | 'goto' = 'tab_activate') {
   // Clear notifications for this tab on activation (terminal: tab-level + all leaves; plugin: tab-level)
   const activatedPaneIds = tab.type === 'terminal'
     ? [tab.paneId, ...getAllLeaves(tab.layout).map((l) => l.paneId)]
     : [tab.paneId]
-  notif.clearForPaneIds(activatedPaneIds)
+  notif.clearForPaneIds(activatedPaneIds, reason)
 }
 
 let revealNavGen = 0
@@ -904,7 +904,7 @@ async function revealPane(paneId: string): Promise<boolean> {
   if (!tab) return false
 
   activePaneId.value = tab.paneId
-  clearResolvedTabNotifications(tab)
+  clearResolvedTabNotifications(tab, 'goto')
   persist()
   nextTick(() => focusActive())
 
@@ -989,8 +989,6 @@ async function closeTab(tabId: string) {
   const closedPaneIds = tab.type === 'terminal'
     ? [tab.paneId, ...getAllLeaves(tab.layout).map((l) => l.paneId)]
     : [tab.paneId]
-  notif.clearForPaneIds(closedPaneIds)
-
   // Invalidate plugin preview cache when closing a plugin tab
   if (tab.type === 'plugin') {
     invalidatePluginPreview(tab.paneId)
@@ -1009,6 +1007,8 @@ async function closeTab(tabId: string) {
       return
     }
   }
+
+  notif.clearForPaneIds(closedPaneIds, 'tab_close')
 
   // Remove tab from local array
   const idx = tabs.value.findIndex((t) => t.paneId === tabId)

--- a/frontend/src/composables/__tests__/attentionReconcile.spec.ts
+++ b/frontend/src/composables/__tests__/attentionReconcile.spec.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from 'vitest'
+import { createAttentionStore, type AttentionStateEnvelope } from '../attentionReconcile'
+
+function state(
+  revision: string,
+  panes: AttentionStateEnvelope['panes'] = [],
+  notifs: AttentionStateEnvelope['notifs'] = [],
+  epoch = 'epoch-a'
+): AttentionStateEnvelope {
+  return { epoch, revision, panes, notifs }
+}
+
+function pane(
+  paneId: string,
+  latestEventSeq: string,
+  readThroughSeq: string,
+  severity = 'warning'
+) {
+  return {
+    paneId,
+    latestEventSeq,
+    readThroughSeq,
+    firstUnreadAt: latestEventSeq === readThroughSeq ? null : 100,
+    severity: latestEventSeq === readThroughSeq ? null : severity,
+  }
+}
+
+describe('attentionReconcile', () => {
+  it('uses BigInt revision gates and accepts equal-revision snapshots', () => {
+    const store = createAttentionStore()
+    store.applySnapshot(state('9007199254740993', [pane('p', '9', '0')]))
+
+    expect(store.applyDelta(state('9007199254740992', [pane('p', '10', '0')]))).toBe(false)
+    expect(store.applyDelta(state('9007199254740993', [pane('p', '10', '0')]))).toBe(false)
+    expect(store.panes.get('p')?.latestEventSeq).toBe(9n)
+
+    expect(store.applySnapshot(state('9007199254740993', [pane('p', '11', '0')]))).toBe(true)
+    expect(store.panes.get('p')?.latestEventSeq).toBe(11n)
+  })
+
+  it('discards interim deltas while awaiting a recovery snapshot', () => {
+    const store = createAttentionStore()
+    store.applySnapshot(state('1', [pane('p', '1', '0')]))
+    store.noteResyncRequired()
+
+    expect(store.awaitingSnapshot).toBe(true)
+    expect(store.applyDelta(state('2', [pane('p', '2', '0')]))).toBe(false)
+    expect(store.cacheRevision).toBe(1n)
+
+    store.applySnapshot(state('2', [pane('p', '2', '2')]))
+    expect(store.awaitingSnapshot).toBe(false)
+    expect(store.cacheRevision).toBe(2n)
+    expect(store.unreadAttentionCount()).toBe(0)
+  })
+
+  it('treats a foreign-epoch delta defensively and adopts the next snapshot', () => {
+    const store = createAttentionStore()
+    store.applySnapshot(state('4', [pane('old', '4', '0')]))
+
+    store.applyDelta(state('5', [pane('foreign', '5', '0')], [], 'epoch-b'))
+    expect(store.awaitingSnapshot).toBe(true)
+    expect(store.epoch).toBe('epoch-a')
+
+    store.applySnapshot(state('0', [pane('new', '1', '0')], [], 'epoch-b'))
+    expect(store.epoch).toBe('epoch-b')
+    expect(store.cacheRevision).toBe(0n)
+    expect([...store.panes.keys()]).toEqual(['new'])
+  })
+
+  it('changes epoch by replacing the baseline and cancelling old overlays', () => {
+    const store = createAttentionStore()
+    store.applySnapshot(state('8', [pane('old', '8', '0')]))
+    store.addOverlay('request-old', [{ paneId: 'old', throughEventSeq: 8n }])
+    expect(store.unreadAttentionCount()).toBe(0)
+
+    store.applySnapshot(state('1', [pane('new', '1', '0')], [], 'epoch-b'))
+    expect(store.overlays.size).toBe(0)
+    expect(store.panes.has('old')).toBe(false)
+    expect(store.unreadPaneSeverities()).toEqual({ new: 'warning' })
+  })
+
+  it('masks only through the pane overlay watermark', () => {
+    const store = createAttentionStore()
+    store.applySnapshot(state('1', [pane('p', '5', '0')]))
+    store.addOverlay('read-5', [{ paneId: 'p', throughEventSeq: 5n }])
+    expect(store.unreadPaneSeverities()).toEqual({})
+
+    store.applyDelta(state('2', [pane('p', '6', '0', 'urgent')]))
+    expect(store.unreadPaneSeverities()).toEqual({ p: 'urgent' })
+  })
+
+  it('applies every pane in a single revision transaction', () => {
+    const store = createAttentionStore()
+    store.applySnapshot(state('1'))
+    store.applyDelta(state('2', [pane('a', '2', '0', 'info'), pane('b', '3', '0', 'error')]))
+
+    expect(store.cacheRevision).toBe(2n)
+    expect(store.unreadPaneSeverities()).toEqual({ a: 'info', b: 'error' })
+  })
+
+  it('clears pane aggregate fields when a full delta row contains nulls', () => {
+    const store = createAttentionStore()
+    store.applySnapshot(state('1', [pane('p', '5', '0', 'urgent')]))
+
+    store.applyDelta(
+      state('2', [
+        {
+          paneId: 'p',
+          latestEventSeq: '5',
+          readThroughSeq: '5',
+          firstUnreadAt: null,
+          severity: null,
+        },
+      ])
+    )
+
+    expect(store.panes.get('p')).toMatchObject({ firstUnreadAt: null, severity: null })
+    expect(store.firstUnreadAtByPane()).toEqual({ p: null })
+    expect(store.unreadPaneSeverities()).toEqual({})
+  })
+
+  it('does not advance cache revision from an ack and avoids ack-before-delta flash', () => {
+    const store = createAttentionStore()
+    store.applySnapshot(state('10', [pane('p', '5', '0')]))
+    store.addOverlay('read-p', [{ paneId: 'p', throughEventSeq: 5n }])
+
+    store.applyMarkReadResult({
+      requestId: 'read-p',
+      epoch: 'epoch-a',
+      appliedAtRevision: '12',
+      results: [{ target: { paneId: 'p' }, status: 'applied' }],
+    })
+    expect(store.cacheRevision).toBe(10n)
+    expect(store.overlays.get('read-p')?.ackedAtRevision).toBe(12n)
+    expect(store.unreadAttentionCount()).toBe(0)
+
+    store.applyDelta(state('11', []))
+    expect(store.overlays.has('read-p')).toBe(true)
+    expect(store.unreadAttentionCount()).toBe(0)
+
+    store.applyDelta(state('12', [pane('p', '5', '5')]))
+    expect(store.overlays.has('read-p')).toBe(false)
+    expect(store.unreadAttentionCount()).toBe(0)
+  })
+
+  it.each(['invalid', 'not_found', 'conflict'] as const)(
+    'rolls back a %s target individually',
+    (rejectedStatus) => {
+      const store = createAttentionStore()
+      store.applySnapshot(state('1', [pane('a', '1', '0'), pane('b', '2', '0')]))
+      store.addOverlay('mixed', [
+        { paneId: 'a', throughEventSeq: 1n },
+        { paneId: 'b', throughEventSeq: 2n },
+      ])
+
+      store.applyMarkReadResult({
+        requestId: 'mixed',
+        epoch: 'epoch-a',
+        appliedAtRevision: '3',
+        results: [
+          { target: { paneId: 'a' }, status: 'applied' },
+          { target: { paneId: 'b' }, status: rejectedStatus },
+        ],
+      })
+
+      expect(store.unreadPaneSeverities()).toEqual({ b: 'warning' })
+      expect(store.overlays.get('mixed')?.targets).toHaveLength(1)
+    }
+  )
+
+  it('cancels all overlays on stale_epoch', () => {
+    const store = createAttentionStore()
+    store.applySnapshot(state('1', [pane('a', '1', '0'), pane('b', '2', '0')]))
+    store.addOverlay('one', [{ paneId: 'a', throughEventSeq: 1n }])
+    store.addOverlay('two', [{ paneId: 'b', throughEventSeq: 2n }])
+
+    store.applyMarkReadResult({
+      requestId: 'one',
+      epoch: 'epoch-b',
+      appliedAtRevision: null,
+      results: [{ target: { paneId: 'a' }, status: 'stale_epoch' }],
+    })
+
+    expect(store.overlays.size).toBe(0)
+    expect(store.unreadAttentionCount()).toBe(2)
+  })
+
+  it('keeps pending masks across unread snapshots and retires them only when proved', () => {
+    const store = createAttentionStore()
+    store.applySnapshot(state('1', [pane('p', '5', '0')], [{ notifId: 'n', read: false }]))
+    store.addOverlay('pending', [{ paneId: 'p', throughEventSeq: 5n }, { notifId: 'n' }])
+
+    store.applySnapshot(state('1', [pane('p', '5', '0')], [{ notifId: 'n', read: false }]))
+    expect(store.overlays.get('pending')?.targets).toHaveLength(2)
+    expect(store.unreadAttentionCount()).toBe(0)
+
+    store.applySnapshot(state('2', [pane('p', '5', '5')], [{ notifId: 'n', read: true }]))
+    expect(store.overlays.has('pending')).toBe(false)
+    expect(store.unreadAttentionCount()).toBe(0)
+  })
+
+  it('counts unread panes and pane-less notification identities', () => {
+    const store = createAttentionStore()
+    store.applySnapshot(
+      state(
+        '1',
+        [pane('a', '1', '0'), pane('read', '2', '2')],
+        [
+          { notifId: 'n1', read: false },
+          { notifId: 'n2', read: true },
+        ]
+      )
+    )
+    expect(store.unreadAttentionCount()).toBe(2)
+  })
+})

--- a/frontend/src/composables/__tests__/useAppForeground.spec.ts
+++ b/frontend/src/composables/__tests__/useAppForeground.spec.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.doUnmock('../useTransport')
+  vi.doUnmock('@tauri-apps/api/window')
+  vi.resetModules()
+})
+
+describe('useAppForeground', () => {
+  it('requires web visibility and focus for each foreground event source', async () => {
+    vi.resetModules()
+    vi.doMock('../useTransport', () => ({ isTauri: () => false }))
+    let visibility: DocumentVisibilityState = 'hidden'
+    let focused = false
+    vi.spyOn(document, 'visibilityState', 'get').mockImplementation(() => visibility)
+    vi.spyOn(document, 'hasFocus').mockImplementation(() => focused)
+
+    const foreground = await import('../useAppForeground')
+    const gained = vi.fn()
+    foreground.onAppForegroundGain(gained)
+    expect(foreground.getIsAppForeground()).toBe(false)
+
+    visibility = 'visible'
+    document.dispatchEvent(new Event('visibilitychange'))
+    expect(foreground.getIsAppForeground()).toBe(false)
+
+    focused = true
+    window.dispatchEvent(new Event('focus'))
+    expect(foreground.getIsAppForeground()).toBe(true)
+    expect(gained).toHaveBeenCalledTimes(1)
+
+    focused = false
+    window.dispatchEvent(new Event('blur'))
+    expect(foreground.getIsAppForeground()).toBe(false)
+
+    visibility = 'hidden'
+    focused = true
+    window.dispatchEvent(new Event('focus'))
+    expect(foreground.getIsAppForeground()).toBe(false)
+
+    visibility = 'visible'
+    document.dispatchEvent(new Event('visibilitychange'))
+    expect(foreground.getIsAppForeground()).toBe(true)
+    expect(gained).toHaveBeenCalledTimes(2)
+  })
+
+  it('registers the Tauri listener before querying and lets an early event win', async () => {
+    vi.resetModules()
+    vi.doMock('../useTransport', () => ({ isTauri: () => true }))
+    let resolveInitialFocus!: (value: boolean) => void
+    const initialFocus = new Promise<boolean>((resolve) => {
+      resolveInitialFocus = resolve
+    })
+    let focusListener: ((event: { payload: boolean }) => void) | undefined
+    const callOrder: string[] = []
+    const appWindow = {
+      onFocusChanged: vi.fn(async (listener: (event: { payload: boolean }) => void) => {
+        callOrder.push('listener')
+        focusListener = listener
+        return () => {}
+      }),
+      isFocused: vi.fn(() => {
+        callOrder.push('query')
+        return initialFocus
+      }),
+    }
+    vi.doMock('@tauri-apps/api/window', () => ({ getCurrentWindow: () => appWindow }))
+
+    const foreground = await import('../useAppForeground')
+    await vi.waitFor(() => expect(appWindow.isFocused).toHaveBeenCalledTimes(1))
+    expect(callOrder).toEqual(['listener', 'query'])
+
+    const gained = vi.fn()
+    foreground.onAppForegroundGain(gained)
+    focusListener?.({ payload: true })
+    expect(foreground.getIsAppForeground()).toBe(true)
+    expect(gained).toHaveBeenCalledTimes(1)
+
+    resolveInitialFocus(false)
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(foreground.getIsAppForeground()).toBe(true)
+    expect(gained).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/composables/__tests__/useNotificationProtocol.spec.ts
+++ b/frontend/src/composables/__tests__/useNotificationProtocol.spec.ts
@@ -1,0 +1,637 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+class FakeWebSocket {
+  static OPEN = 1
+  static instances: FakeWebSocket[] = []
+
+  url: string
+  readyState = FakeWebSocket.OPEN
+  sent: string[] = []
+  onopen: ((event: Event) => void) | null = null
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onclose: ((event: CloseEvent) => void) | null = null
+  onerror: ((event: Event) => void) | null = null
+
+  constructor(url: string) {
+    this.url = url
+    FakeWebSocket.instances.push(this)
+  }
+
+  send(data: string) {
+    this.sent.push(data)
+  }
+
+  close() {
+    this.readyState = 3
+  }
+}
+
+vi.stubGlobal('WebSocket', FakeWebSocket)
+
+function memoryStorage(): Storage {
+  const values = new Map<string, string>()
+  return {
+    get length() {
+      return values.size
+    },
+    clear: () => values.clear(),
+    getItem: (key: string) => values.get(key) ?? null,
+    key: (index: number) => [...values.keys()][index] ?? null,
+    removeItem: (key: string) => values.delete(key),
+    setItem: (key: string, value: string) => values.set(key, String(value)),
+  }
+}
+
+vi.stubGlobal('localStorage', memoryStorage())
+vi.stubGlobal('sessionStorage', memoryStorage())
+
+const transportMock = vi.hoisted(() => ({ tauri: false }))
+const reloadMock = vi.hoisted(() => vi.fn())
+vi.stubGlobal('location', {
+  protocol: 'http:',
+  host: 'localhost',
+  reload: reloadMock,
+})
+
+vi.mock('vue-toastification', () => ({
+  TYPE: { INFO: 'info', SUCCESS: 'success', WARNING: 'warning', ERROR: 'error' },
+}))
+
+vi.mock('../useI18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('../useTransport', () => ({ isTauri: () => transportMock.tauri }))
+
+vi.mock('../apiBase', () => ({
+  getApiBase: async () => 'http://127.0.0.1:28999',
+  wsUrlWithToken: (url: string) => url,
+}))
+
+import { settings } from '../useSettings'
+import {
+  __dispatchServerMessageForTest,
+  __pendingRequestCountForTest,
+  __resetForTest,
+  useNotification,
+  type NotificationItem,
+} from '../useNotification'
+
+function snapshot(
+  revision: string,
+  panes: Array<{
+    paneId: string
+    latestEventSeq: string
+    readThroughSeq: string
+    severity: string | null
+  }> = [],
+  notifs: Array<{ notifId: string; read: boolean }> = [],
+  epoch = 'epoch-a'
+) {
+  return {
+    type: 'snapshot',
+    epoch,
+    revision,
+    panes: panes.map((pane) => ({ ...pane, firstUnreadAt: 100 })),
+    notifs,
+  }
+}
+
+function delta(
+  revision: string,
+  panes: Array<{
+    paneId: string
+    latestEventSeq: string
+    readThroughSeq: string
+    severity: string | null
+  }> = [],
+  notifs: Array<{ notifId: string; read: boolean }> = []
+) {
+  return {
+    type: 'state_delta',
+    epoch: 'epoch-a',
+    revision,
+    panes: panes.map((pane) => ({ ...pane, firstUnreadAt: 100 })),
+    notifs,
+  }
+}
+
+function legacyEvent(overrides: Record<string, unknown> = {}) {
+  return {
+    type: 'notify',
+    v: 1,
+    pane_id: 'pane-a',
+    title: null,
+    body: 'done',
+    notification_type: 'info',
+    eventSeq: '1',
+    occurredAt: 100,
+    severity: 'info',
+    ...overrides,
+  }
+}
+
+function current() {
+  return useNotification()
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  __resetForTest()
+  FakeWebSocket.instances = []
+  localStorage.clear()
+  sessionStorage.clear()
+  transportMock.tauri = false
+  reloadMock.mockReset()
+  ;(settings as any).notification = {
+    enabled: true,
+    osc_notify: true,
+    bell: { enabled: true },
+    channels: { sound: false, vibration: false, panel: false },
+    sounds: {},
+  }
+})
+
+afterEach(() => {
+  __resetForTest()
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+describe('useNotification protocol dispatcher', () => {
+  it('connects to protocol v1 and dispatches state, resync, snapshot, ack, and legacy envelopes', () => {
+    const notif = current()
+    expect(FakeWebSocket.instances[0].url).toContain('/ws/notify?v=1')
+
+    __dispatchServerMessageForTest(
+      snapshot('1', [
+        { paneId: 'pane-a', latestEventSeq: '2', readThroughSeq: '0', severity: 'error' },
+      ])
+    )
+    expect(notif.unreadByPane['pane-a']).toBe('error')
+
+    notif.markPanesRead([{ paneId: 'pane-a' }], 'focus')
+    expect(notif.unreadAttentionCount.value).toBe(0)
+
+    const payload = JSON.parse(FakeWebSocket.instances[0].sent[0])
+    expect(payload).toMatchObject({
+      type: 'notification.mark_read',
+      v: 1,
+      epoch: 'epoch-a',
+      reason: 'focus',
+      panes: [{ paneId: 'pane-a', throughEventSeq: '2' }],
+      notifs: [],
+    })
+    expect(payload.clientId).toEqual(expect.any(String))
+    expect(payload.requestId).toEqual(expect.any(String))
+    __dispatchServerMessageForTest({
+      type: 'mark_read_result',
+      requestId: payload.requestId,
+      epoch: 'epoch-a',
+      appliedAtRevision: null,
+      results: [{ target: { paneId: 'pane-a' }, status: 'conflict' }],
+    })
+    expect(notif.unreadAttentionCount.value).toBe(1)
+
+    __dispatchServerMessageForTest({ type: 'resync_required', v: 1 })
+    __dispatchServerMessageForTest(
+      delta('2', [{ paneId: 'pane-a', latestEventSeq: '2', readThroughSeq: '2', severity: null }])
+    )
+    expect(notif.unreadAttentionCount.value).toBe(1)
+
+    __dispatchServerMessageForTest(
+      snapshot('2', [
+        { paneId: 'pane-a', latestEventSeq: '2', readThroughSeq: '2', severity: null },
+      ])
+    )
+    expect(notif.unreadAttentionCount.value).toBe(0)
+
+    __dispatchServerMessageForTest(legacyEvent())
+    expect(notif.historyCount.value).toBe(1)
+  })
+
+  it('bounds ack-timeout resends and rolls back the overlay after exhaustion', async () => {
+    const notif = current()
+    const socket = FakeWebSocket.instances[0]
+    __dispatchServerMessageForTest(
+      snapshot('1', [
+        { paneId: 'pane-a', latestEventSeq: '7', readThroughSeq: '0', severity: 'warning' },
+      ])
+    )
+
+    notif.markPanesRead([{ paneId: 'pane-a' }], 'terminal_input')
+    expect(socket.sent).toHaveLength(1)
+    expect(notif.unreadAttentionCount.value).toBe(0)
+
+    await vi.advanceTimersByTimeAsync(15_000)
+    expect(socket.sent).toHaveLength(4)
+    expect(new Set(socket.sent).size).toBe(1)
+    expect(notif.unreadAttentionCount.value).toBe(0)
+
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(socket.sent).toHaveLength(4)
+    expect(notif.unreadAttentionCount.value).toBe(1)
+  })
+
+  it('deduplicates history by epoch plus pane sequence or pane-less notif identity', () => {
+    const notif = current()
+    __dispatchServerMessageForTest(snapshot('1'))
+
+    __dispatchServerMessageForTest(legacyEvent())
+    __dispatchServerMessageForTest(legacyEvent())
+    __dispatchServerMessageForTest(
+      legacyEvent({ pane_id: '', notifId: 'notif-1', eventSeq: '9', body: 'plugin' })
+    )
+    __dispatchServerMessageForTest(
+      legacyEvent({ pane_id: '', notifId: 'notif-1', eventSeq: '10', body: 'plugin duplicate' })
+    )
+    expect(notif.historyCount.value).toBe(2)
+
+    __dispatchServerMessageForTest(snapshot('0', [], [], 'epoch-b'))
+    __dispatchServerMessageForTest(legacyEvent())
+    __dispatchServerMessageForTest(
+      legacyEvent({ pane_id: '', notifId: 'notif-1', eventSeq: '11', body: 'new epoch' })
+    )
+    expect(notif.historyCount.value).toBe(4)
+  })
+
+  it('keeps authoritative attention count independent from history count', () => {
+    const notif = current()
+    __dispatchServerMessageForTest(
+      snapshot(
+        '1',
+        [{ paneId: 'pane-a', latestEventSeq: '1', readThroughSeq: '0', severity: 'urgent' }],
+        [{ notifId: 'notif-a', read: false }]
+      )
+    )
+    expect(notif.unreadAttentionCount.value).toBe(2)
+    expect(notif.historyCount.value).toBe(0)
+
+    __dispatchServerMessageForTest(legacyEvent())
+    expect(notif.unreadAttentionCount.value).toBe(2)
+    expect(notif.historyCount.value).toBe(1)
+  })
+
+  it('projects firstUnreadAt values alongside unread severity', () => {
+    const notif = current()
+    __dispatchServerMessageForTest(
+      snapshot('1', [
+        { paneId: 'pane-a', latestEventSeq: '1', readThroughSeq: '0', severity: 'urgent' },
+      ])
+    )
+    expect(notif.firstUnreadAtByPane['pane-a']).toBe(100)
+
+    __dispatchServerMessageForTest(
+      delta('2', [
+        { paneId: 'pane-a', latestEventSeq: '1', readThroughSeq: '1', severity: null },
+      ])
+    )
+    expect(notif.firstUnreadAtByPane['pane-a']).toBe(100)
+
+    __dispatchServerMessageForTest({
+      type: 'state_delta',
+      epoch: 'epoch-a',
+      revision: '3',
+      panes: [
+        {
+          paneId: 'pane-a',
+          latestEventSeq: '1',
+          readThroughSeq: '1',
+          firstUnreadAt: null,
+          severity: null,
+        },
+      ],
+      notifs: [],
+    })
+    expect(notif.firstUnreadAtByPane['pane-a']).toBeNull()
+  })
+
+  it('clearAll sends one combined request with authoritative pane and notif targets', () => {
+    const notif = current()
+    const socket = FakeWebSocket.instances[0]
+    __dispatchServerMessageForTest(
+      snapshot(
+        '1',
+        [{ paneId: 'pane-a', latestEventSeq: '8', readThroughSeq: '2', severity: 'warning' }],
+        [{ notifId: 'notif-a', read: false }]
+      )
+    )
+
+    notif.clearAll()
+
+    expect(socket.sent).toHaveLength(1)
+    expect(JSON.parse(socket.sent[0])).toMatchObject({
+      reason: 'clear_all',
+      panes: [{ paneId: 'pane-a', throughEventSeq: '8' }],
+      notifs: [{ notifId: 'notif-a' }],
+    })
+    expect(notif.unreadAttentionCount.value).toBe(0)
+  })
+
+  it('stale_epoch cancels every pending overlay', () => {
+    const notif = current()
+    const socket = FakeWebSocket.instances[0]
+    __dispatchServerMessageForTest(
+      snapshot('1', [
+        { paneId: 'a', latestEventSeq: '1', readThroughSeq: '0', severity: 'info' },
+        { paneId: 'b', latestEventSeq: '2', readThroughSeq: '0', severity: 'error' },
+      ])
+    )
+    notif.markPanesRead([{ paneId: 'a' }], 'focus')
+    notif.markPanesRead([{ paneId: 'b' }], 'focus')
+    expect(notif.unreadAttentionCount.value).toBe(0)
+
+    const firstPayload = JSON.parse(socket.sent[0])
+    __dispatchServerMessageForTest({
+      type: 'mark_read_result',
+      requestId: firstPayload.requestId,
+      epoch: 'epoch-b',
+      appliedAtRevision: null,
+      results: [{ target: { paneId: 'a' }, status: 'stale_epoch' }],
+    })
+    expect(notif.unreadAttentionCount.value).toBe(2)
+  })
+
+  it('close 4001 cancels pending timers, restores authoritative state, and reloads the web app once', async () => {
+    const notif = current()
+    const socket = FakeWebSocket.instances[0]
+    __dispatchServerMessageForTest(
+      snapshot('1', [
+        { paneId: 'pane-a', latestEventSeq: '1', readThroughSeq: '0', severity: 'error' },
+      ])
+    )
+    notif.markPanesRead([{ paneId: 'pane-a' }], 'focus')
+    expect(notif.unreadAttentionCount.value).toBe(0)
+    expect(__pendingRequestCountForTest()).toBe(1)
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout')
+
+    socket.onclose?.({ code: 4001, reason: 'protocol_upgrade_required' } as CloseEvent)
+    expect(clearTimeoutSpy).toHaveBeenCalledOnce()
+    expect(__pendingRequestCountForTest()).toBe(0)
+    expect(notif.unreadAttentionCount.value).toBe(1)
+    await vi.advanceTimersByTimeAsync(120_000)
+
+    expect(socket.sent).toHaveLength(1)
+    expect(FakeWebSocket.instances).toHaveLength(1)
+    expect(reloadMock).toHaveBeenCalledOnce()
+  })
+
+  it('close 4001 in Tauri cancels pending timers without reload or reconnect', async () => {
+    transportMock.tauri = true
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const notif = current()
+    await Promise.resolve()
+    const socket = FakeWebSocket.instances[0]
+    __dispatchServerMessageForTest(
+      snapshot('1', [
+        { paneId: 'pane-a', latestEventSeq: '1', readThroughSeq: '0', severity: 'error' },
+      ])
+    )
+    notif.markPanesRead([{ paneId: 'pane-a' }], 'focus')
+
+    socket.onclose?.({ code: 4001, reason: 'protocol_upgrade_required' } as CloseEvent)
+    await vi.advanceTimersByTimeAsync(120_000)
+
+    expect(socket.sent).toHaveLength(1)
+    expect(__pendingRequestCountForTest()).toBe(0)
+    expect(FakeWebSocket.instances).toHaveLength(1)
+    expect(reloadMock).not.toHaveBeenCalled()
+    expect(errorSpy).toHaveBeenCalled()
+  })
+
+  it('bounds disconnected requests, evicts the oldest at 64, and expires all overlays', async () => {
+    const notif = current()
+    const socket = FakeWebSocket.instances[0]
+    const panes = Array.from({ length: 65 }, (_, index) => ({
+      paneId: `pane-${index}`,
+      latestEventSeq: String(index + 1),
+      readThroughSeq: '0',
+      severity: 'warning',
+    }))
+    __dispatchServerMessageForTest(snapshot('1', panes))
+    socket.readyState = 3
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout')
+
+    for (const pane of panes) notif.markPanesRead([{ paneId: pane.paneId }], 'focus')
+
+    expect(socket.sent).toHaveLength(0)
+    expect(__pendingRequestCountForTest()).toBe(64)
+    expect(notif.unreadAttentionCount.value).toBe(1)
+    expect(clearTimeoutSpy).toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(20_000)
+    expect(__pendingRequestCountForTest()).toBe(0)
+    expect(notif.unreadAttentionCount.value).toBe(65)
+  })
+
+  it('dismisses a stale-epoch history card locally without sending mark_read', () => {
+    const notif = current()
+    const socket = FakeWebSocket.instances[0]
+    __dispatchServerMessageForTest(
+      snapshot('1', [
+        { paneId: 'pane-a', latestEventSeq: '1', readThroughSeq: '0', severity: 'info' },
+      ])
+    )
+    __dispatchServerMessageForTest(legacyEvent())
+    const item = notif.notifications.value[0]
+
+    __dispatchServerMessageForTest(
+      snapshot(
+        '1',
+        [{ paneId: 'pane-a', latestEventSeq: '9', readThroughSeq: '0', severity: 'urgent' }],
+        [],
+        'epoch-b'
+      )
+    )
+    notif.dismissOne(item.id)
+
+    expect(notif.notifications.value).toHaveLength(0)
+    expect(socket.sent).toHaveLength(0)
+    expect(notif.unreadAttentionCount.value).toBe(1)
+  })
+
+  it('reconnect resend uses the current snapshot epoch', async () => {
+    const notif = current()
+    const firstSocket = FakeWebSocket.instances[0]
+    __dispatchServerMessageForTest(
+      snapshot('1', [
+        { paneId: 'pane-a', latestEventSeq: '3', readThroughSeq: '0', severity: 'info' },
+      ])
+    )
+    notif.markPanesRead([{ paneId: 'pane-a' }], 'focus')
+
+    firstSocket.onclose?.({ code: 1006 } as CloseEvent)
+    await vi.advanceTimersByTimeAsync(3000)
+    const reconnected = FakeWebSocket.instances[1]
+    __dispatchServerMessageForTest(
+      snapshot('2', [
+        { paneId: 'pane-a', latestEventSeq: '3', readThroughSeq: '0', severity: 'info' },
+      ])
+    )
+
+    expect(reconnected.sent).toHaveLength(1)
+    expect(JSON.parse(reconnected.sent[0]).epoch).toBe('epoch-a')
+  })
+
+  it('drops old-epoch pending entries after reconnect instead of resending them', async () => {
+    const notif = current()
+    const firstSocket = FakeWebSocket.instances[0]
+    __dispatchServerMessageForTest(
+      snapshot('1', [
+        { paneId: 'pane-a', latestEventSeq: '3', readThroughSeq: '0', severity: 'info' },
+      ])
+    )
+    notif.markPanesRead([{ paneId: 'pane-a' }], 'focus')
+
+    firstSocket.onclose?.({ code: 1006 } as CloseEvent)
+    await vi.advanceTimersByTimeAsync(3000)
+    const reconnected = FakeWebSocket.instances[1]
+    __dispatchServerMessageForTest(
+      snapshot(
+        '1',
+        [{ paneId: 'pane-a', latestEventSeq: '8', readThroughSeq: '0', severity: 'error' }],
+        [],
+        'epoch-b'
+      )
+    )
+
+    expect(reconnected.sent).toHaveLength(0)
+    expect(__pendingRequestCountForTest()).toBe(0)
+    expect(notif.unreadAttentionCount.value).toBe(1)
+  })
+
+  it('keeps retrying through the real disconnected close path until the overlay expires', async () => {
+    const notif = current()
+    const firstSocket = FakeWebSocket.instances[0]
+    __dispatchServerMessageForTest(
+      snapshot('1', [
+        { paneId: 'pane-a', latestEventSeq: '3', readThroughSeq: '0', severity: 'info' },
+      ])
+    )
+
+    notif.markPanesRead([{ paneId: 'pane-a' }], 'focus')
+    expect(__pendingRequestCountForTest()).toBe(1)
+    expect(notif.unreadAttentionCount.value).toBe(0)
+    firstSocket.onclose?.({ code: 1006 } as CloseEvent)
+
+    await vi.advanceTimersByTimeAsync(20_000)
+
+    expect(__pendingRequestCountForTest()).toBe(0)
+    expect(notif.unreadAttentionCount.value).toBe(1)
+    expect(firstSocket.sent).toHaveLength(1)
+    expect(FakeWebSocket.instances[1].sent).toHaveLength(0)
+  })
+
+  it('counts a retry in the reconnect pre-snapshot window but waits for snapshot to send', async () => {
+    const notif = current()
+    const firstSocket = FakeWebSocket.instances[0]
+    __dispatchServerMessageForTest(
+      snapshot(
+        '1',
+        [{ paneId: 'pane-a', latestEventSeq: '3', readThroughSeq: '0', severity: 'info' }],
+        [],
+        'epoch-current'
+      )
+    )
+    notif.markPanesRead([{ paneId: 'pane-a' }], 'focus')
+    expect(firstSocket.sent).toHaveLength(1)
+
+    firstSocket.onclose?.({ code: 1006 } as CloseEvent)
+    await vi.advanceTimersByTimeAsync(5000)
+    const reconnected = FakeWebSocket.instances[1]
+    expect(reconnected.sent).toHaveLength(0)
+
+    __dispatchServerMessageForTest(
+      snapshot(
+        '2',
+        [{ paneId: 'pane-a', latestEventSeq: '3', readThroughSeq: '0', severity: 'info' }],
+        [],
+        'epoch-current'
+      )
+    )
+
+    expect(reconnected.sent).toHaveLength(1)
+    expect(JSON.parse(reconnected.sent[0])).toMatchObject({ epoch: 'epoch-current' })
+
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(reconnected.sent).toHaveLength(2)
+    expect(__pendingRequestCountForTest()).toBe(0)
+  })
+
+  it('cancels the resend timer when mark_read_result arrives', async () => {
+    const notif = current()
+    const socket = FakeWebSocket.instances[0]
+    __dispatchServerMessageForTest(
+      snapshot('1', [
+        { paneId: 'pane-a', latestEventSeq: '3', readThroughSeq: '0', severity: 'info' },
+      ])
+    )
+    notif.markPanesRead([{ paneId: 'pane-a' }], 'focus')
+    const payload = JSON.parse(socket.sent[0])
+
+    __dispatchServerMessageForTest({
+      type: 'mark_read_result',
+      requestId: payload.requestId,
+      epoch: 'epoch-a',
+      appliedAtRevision: '2',
+      results: [{ target: { paneId: 'pane-a' }, status: 'applied' }],
+    })
+    await vi.advanceTimersByTimeAsync(20_000)
+
+    expect(socket.sent).toHaveLength(1)
+    expect(__pendingRequestCountForTest()).toBe(0)
+  })
+
+  it('retires a proved overlay through snapshot message dispatch', async () => {
+    const notif = current()
+    const socket = FakeWebSocket.instances[0]
+    __dispatchServerMessageForTest(
+      snapshot('1', [
+        { paneId: 'pane-a', latestEventSeq: '3', readThroughSeq: '0', severity: 'info' },
+      ])
+    )
+    notif.markPanesRead([{ paneId: 'pane-a' }], 'focus')
+
+    __dispatchServerMessageForTest(
+      snapshot('2', [
+        { paneId: 'pane-a', latestEventSeq: '3', readThroughSeq: '3', severity: null },
+      ])
+    )
+    await vi.advanceTimersByTimeAsync(20_000)
+
+    expect(__pendingRequestCountForTest()).toBe(0)
+    expect(socket.sent).toHaveLength(1)
+    expect(notif.unreadAttentionCount.value).toBe(0)
+  })
+
+  it('retires and cancels a proved overlay through delta message dispatch', async () => {
+    const notif = current()
+    const socket = FakeWebSocket.instances[0]
+    __dispatchServerMessageForTest(
+      snapshot('1', [
+        { paneId: 'pane-a', latestEventSeq: '3', readThroughSeq: '0', severity: 'info' },
+      ])
+    )
+    notif.markPanesRead([{ paneId: 'pane-a' }], 'focus')
+
+    __dispatchServerMessageForTest(
+      delta('2', [
+        { paneId: 'pane-a', latestEventSeq: '3', readThroughSeq: '3', severity: null },
+      ])
+    )
+    await vi.advanceTimersByTimeAsync(20_000)
+
+    expect(__pendingRequestCountForTest()).toBe(0)
+    expect(socket.sent).toHaveLength(1)
+    expect(notif.unreadAttentionCount.value).toBe(0)
+  })
+
+  it('keeps the history item identity fields from legacy envelopes', () => {
+    const notif = current()
+    __dispatchServerMessageForTest(snapshot('1'))
+    __dispatchServerMessageForTest(legacyEvent({ eventSeq: '55', notifId: undefined }))
+    const item = notif.notifications.value[0] as NotificationItem
+    expect(item.eventSeq).toBe('55')
+    expect(item.notifId).toBeUndefined()
+  })
+})

--- a/frontend/src/composables/__tests__/useNotificationTriggers.spec.ts
+++ b/frontend/src/composables/__tests__/useNotificationTriggers.spec.ts
@@ -1,0 +1,296 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+class FakeWebSocket {
+  static OPEN = 1
+  static instances: FakeWebSocket[] = []
+
+  readyState = FakeWebSocket.OPEN
+  sent: string[] = []
+  onopen: ((event: Event) => void) | null = null
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onclose: ((event: CloseEvent) => void) | null = null
+  onerror: ((event: Event) => void) | null = null
+
+  constructor(public url: string) {
+    FakeWebSocket.instances.push(this)
+  }
+
+  send(data: string) {
+    this.sent.push(data)
+  }
+
+  close() {
+    this.readyState = 3
+  }
+}
+
+function memoryStorage(): Storage {
+  const values = new Map<string, string>()
+  return {
+    get length() {
+      return values.size
+    },
+    clear: () => values.clear(),
+    getItem: (key: string) => values.get(key) ?? null,
+    key: (index: number) => [...values.keys()][index] ?? null,
+    removeItem: (key: string) => values.delete(key),
+    setItem: (key: string, value: string) => values.set(key, String(value)),
+  }
+}
+
+vi.stubGlobal('WebSocket', FakeWebSocket)
+vi.stubGlobal('localStorage', memoryStorage())
+vi.stubGlobal('sessionStorage', memoryStorage())
+vi.stubGlobal('location', { protocol: 'http:', host: 'localhost', reload: vi.fn() })
+
+vi.mock('vue-toastification', () => ({
+  TYPE: { INFO: 'info', SUCCESS: 'success', WARNING: 'warning', ERROR: 'error' },
+}))
+vi.mock('../useI18n', () => ({ useI18n: () => ({ t: (key: string) => key }) }))
+vi.mock('../useTransport', () => ({ isTauri: () => false }))
+vi.mock('../apiBase', () => ({
+  getApiBase: async () => '',
+  wsUrlWithToken: (url: string) => url,
+}))
+
+import { settings } from '../useSettings'
+import {
+  __dispatchServerMessageForTest,
+  __pendingRequestCountForTest,
+  __resetForTest,
+  evaluateActiveRead,
+  markPaneReadIfUnread,
+  setActiveReadContext,
+  useNotification,
+} from '../useNotification'
+
+function pane(paneId: string, latestEventSeq: string, readThroughSeq = '0') {
+  return {
+    paneId,
+    latestEventSeq,
+    readThroughSeq,
+    firstUnreadAt: 100,
+    severity: latestEventSeq === readThroughSeq ? null : 'warning',
+  }
+}
+
+function snapshot(revision: string, panes = [] as ReturnType<typeof pane>[]) {
+  return { type: 'snapshot', epoch: 'epoch-a', revision, panes, notifs: [] }
+}
+
+function delta(revision: string, panes = [] as ReturnType<typeof pane>[]) {
+  return { type: 'state_delta', epoch: 'epoch-a', revision, panes, notifs: [] }
+}
+
+function raised(overrides: Record<string, unknown> = {}) {
+  return {
+    type: 'notify',
+    v: 1,
+    pane_id: 'pane-a',
+    title: null,
+    body: 'done',
+    notification_type: 'info',
+    eventSeq: '1',
+    occurredAt: 100,
+    severity: 'info',
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  __resetForTest()
+  FakeWebSocket.instances = []
+  localStorage.clear()
+  ;(settings as any).notification = {
+    enabled: true,
+    osc_notify: true,
+    bell: { enabled: true },
+    channels: { sound: false, vibration: false, panel: false },
+    sounds: {},
+  }
+})
+
+afterEach(() => {
+  __resetForTest()
+  vi.useRealTimers()
+})
+
+describe('active-read state triggers', () => {
+  it.each([
+    ['snapshot', () => snapshot('1', [pane('pane-a', '7')])],
+    [
+      'delta',
+      () => {
+        __dispatchServerMessageForTest(snapshot('1'))
+        return delta('2', [pane('pane-a', '7')])
+      },
+    ],
+  ])('marks an active foreground pane read from a %s without a raised envelope', (_, message) => {
+    const notif = useNotification()
+    setActiveReadContext({
+      getActiveFocusedPaneId: () => 'pane-a',
+      isAppForeground: () => true,
+    })
+
+    __dispatchServerMessageForTest(message())
+
+    expect(notif.unreadByPane['pane-a']).toBeUndefined()
+    expect(notif.unreadAttentionCount.value).toBe(0)
+    expect(__pendingRequestCountForTest()).toBe(1)
+    const sent = FakeWebSocket.instances[0].sent
+    expect(JSON.parse(sent[sent.length - 1])).toMatchObject({
+      reason: 'active_observed',
+      panes: [{ paneId: 'pane-a', throughEventSeq: '7' }],
+    })
+  })
+
+  it.each([
+    ['backgrounded', 'pane-a', false, true],
+    ['different focused pane', 'pane-b', true, true],
+    ['unregistered context', 'pane-a', true, false],
+  ])('does not active-read when %s', (_, focusedPaneId, foreground, registered) => {
+    const notif = useNotification()
+    if (registered) {
+      setActiveReadContext({
+        getActiveFocusedPaneId: () => focusedPaneId,
+        isAppForeground: () => foreground,
+      })
+    }
+
+    __dispatchServerMessageForTest(snapshot('1', [pane('pane-a', '4')]))
+
+    expect(notif.unreadByPane['pane-a']).toBe('warning')
+    expect(__pendingRequestCountForTest()).toBe(0)
+  })
+
+  it('does not emit a duplicate while the optimistic overlay masks the pane', () => {
+    useNotification()
+    setActiveReadContext({
+      getActiveFocusedPaneId: () => 'pane-a',
+      isAppForeground: () => true,
+    })
+    __dispatchServerMessageForTest(snapshot('1', [pane('pane-a', '5')]))
+    __dispatchServerMessageForTest(delta('2', [pane('pane-a', '5')]))
+
+    expect(__pendingRequestCountForTest()).toBe(1)
+    expect(FakeWebSocket.instances[0].sent).toHaveLength(1)
+  })
+
+  it('does not active-read an interim delta discarded while awaiting a snapshot', () => {
+    useNotification()
+    setActiveReadContext({
+      getActiveFocusedPaneId: () => 'pane-a',
+      isAppForeground: () => true,
+    })
+    __dispatchServerMessageForTest(snapshot('1'))
+    __dispatchServerMessageForTest({ type: 'resync_required' })
+
+    __dispatchServerMessageForTest(delta('2', [pane('pane-a', '5')]))
+
+    expect(__pendingRequestCountForTest()).toBe(0)
+    expect(FakeWebSocket.instances[0].sent).toHaveLength(0)
+  })
+
+  it('active-reads a genuinely newer event above an existing overlay watermark', () => {
+    useNotification()
+    setActiveReadContext({
+      getActiveFocusedPaneId: () => 'pane-a',
+      isAppForeground: () => true,
+    })
+    __dispatchServerMessageForTest(snapshot('1', [pane('pane-a', '5')]))
+
+    __dispatchServerMessageForTest(delta('2', [pane('pane-a', '6')]))
+
+    expect(__pendingRequestCountForTest()).toBe(2)
+    const sent = FakeWebSocket.instances[0].sent.map((payload) => JSON.parse(payload))
+    expect(sent).toHaveLength(2)
+    expect(sent[0]).toMatchObject({
+      reason: 'active_observed',
+      panes: [{ paneId: 'pane-a', throughEventSeq: '5' }],
+    })
+    expect(sent[1]).toMatchObject({
+      reason: 'active_observed',
+      panes: [{ paneId: 'pane-a', throughEventSeq: '6' }],
+    })
+  })
+
+  it('does not re-emit active_observed when a proving read delta retires its overlay', () => {
+    useNotification()
+    setActiveReadContext({
+      getActiveFocusedPaneId: () => 'pane-a',
+      isAppForeground: () => true,
+    })
+    __dispatchServerMessageForTest(snapshot('1', [pane('pane-a', '5')]))
+
+    __dispatchServerMessageForTest(delta('2', [pane('pane-a', '5', '5')]))
+
+    expect(__pendingRequestCountForTest()).toBe(0)
+    expect(FakeWebSocket.instances[0].sent).toHaveLength(1)
+  })
+
+  it('can re-evaluate authoritative unread state independently on foreground gain', () => {
+    useNotification()
+    let foreground = false
+    setActiveReadContext({
+      getActiveFocusedPaneId: () => 'pane-a',
+      isAppForeground: () => foreground,
+    })
+    __dispatchServerMessageForTest(snapshot('1', [pane('pane-a', '8')]))
+    expect(__pendingRequestCountForTest()).toBe(0)
+
+    foreground = true
+    evaluateActiveRead()
+
+    expect(__pendingRequestCountForTest()).toBe(1)
+    expect(JSON.parse(FakeWebSocket.instances[0].sent[0])).toMatchObject({
+      reason: 'active_observed',
+      panes: [{ paneId: 'pane-a', throughEventSeq: '8' }],
+    })
+  })
+
+  it('makes explicit trigger calls a no-op unless the masked projection is visibly unread', () => {
+    useNotification()
+    __dispatchServerMessageForTest(snapshot('1', [pane('pane-a', '3', '3')]))
+    markPaneReadIfUnread('pane-a', 'focus')
+    expect(__pendingRequestCountForTest()).toBe(0)
+
+    __dispatchServerMessageForTest(delta('2', [pane('pane-a', '4', '3')]))
+    markPaneReadIfUnread('pane-a', 'terminal_input')
+    markPaneReadIfUnread('pane-a', 'terminal_input')
+    expect(__pendingRequestCountForTest()).toBe(1)
+    expect(JSON.parse(FakeWebSocket.instances[0].sent[0])).toMatchObject({
+      reason: 'terminal_input',
+      panes: [{ paneId: 'pane-a', throughEventSeq: '4' }],
+    })
+  })
+})
+
+describe('raised envelope compatibility', () => {
+  it('accepts pane-less plugin notify regardless of osc_notify and never creates an empty pane key', () => {
+    const notif = useNotification()
+    ;(settings as any).notification.osc_notify = false
+    __dispatchServerMessageForTest(snapshot('1'))
+
+    __dispatchServerMessageForTest(
+      raised({ pane_id: '', notifId: 'notif-1', eventSeq: '9', body: 'plugin message' })
+    )
+
+    expect(notif.historyCount.value).toBe(1)
+    expect(notif.notifications.value[0]).toMatchObject({
+      paneId: undefined,
+      notifId: 'notif-1',
+      source: 'plugin',
+      body: 'plugin message',
+    })
+    expect(Object.prototype.hasOwnProperty.call(notif.unreadByPane, '')).toBe(false)
+  })
+
+  it('keeps osc_notify gating for legacy notify envelopes without notifId', () => {
+    const notif = useNotification()
+    ;(settings as any).notification.osc_notify = false
+    __dispatchServerMessageForTest(snapshot('1'))
+    __dispatchServerMessageForTest(raised())
+    expect(notif.historyCount.value).toBe(0)
+  })
+})

--- a/frontend/src/composables/attentionReconcile.ts
+++ b/frontend/src/composables/attentionReconcile.ts
@@ -1,0 +1,271 @@
+export interface PaneDeltaWire {
+  paneId: string
+  latestEventSeq: string | null
+  readThroughSeq: string | null
+  firstUnreadAt: number | null
+  severity: string | null
+  removed?: true
+}
+
+export interface NotifDeltaWire {
+  notifId: string
+  read: boolean | null
+  removed?: true
+}
+
+export interface AttentionStateEnvelope {
+  epoch: string
+  revision: string
+  panes: PaneDeltaWire[]
+  notifs: NotifDeltaWire[]
+}
+
+export type OverlayTarget = { paneId: string; throughEventSeq: bigint } | { notifId: string }
+
+export interface MarkReadResultWire {
+  requestId: string
+  epoch: string
+  appliedAtRevision: string | null
+  results: Array<{
+    target: { paneId: string } | { notifId: string }
+    status: 'applied' | 'stale_epoch' | 'invalid' | 'not_found' | 'conflict'
+  }>
+}
+
+export interface PaneAttentionState {
+  latestEventSeq: bigint
+  readThroughSeq: bigint
+  firstUnreadAt: number | null
+  severity: string | null
+}
+
+export interface NotifAttentionState {
+  read: boolean
+}
+
+export interface AttentionOverlay {
+  targets: OverlayTarget[]
+  ackedAtRevision: bigint | null
+}
+
+function isPaneTarget(target: OverlayTarget): target is Extract<OverlayTarget, { paneId: string }> {
+  return 'paneId' in target
+}
+
+function sameTarget(left: OverlayTarget, right: { paneId: string } | { notifId: string }): boolean {
+  return isPaneTarget(left)
+    ? 'paneId' in right && left.paneId === right.paneId
+    : 'notifId' in right && left.notifId === right.notifId
+}
+
+export function createAttentionStore() {
+  const store = {
+    epoch: null as string | null,
+    cacheRevision: 0n,
+    awaitingSnapshot: false,
+    panes: new Map<string, PaneAttentionState>(),
+    notifs: new Map<string, NotifAttentionState>(),
+    overlays: new Map<string, AttentionOverlay>(),
+
+    applyDelta(delta: AttentionStateEnvelope): boolean {
+      if (store.awaitingSnapshot) return false
+      if (store.epoch !== null && delta.epoch !== store.epoch) {
+        store.awaitingSnapshot = true
+        return false
+      }
+
+      const revision = BigInt(delta.revision)
+      if (revision <= store.cacheRevision) return false
+      if (store.epoch === null) store.epoch = delta.epoch
+
+      for (const paneDelta of delta.panes) {
+        if (paneDelta.removed) {
+          store.panes.delete(paneDelta.paneId)
+          continue
+        }
+        const previous = store.panes.get(paneDelta.paneId) ?? {
+          latestEventSeq: 0n,
+          readThroughSeq: 0n,
+          firstUnreadAt: null,
+          severity: null,
+        }
+        store.panes.set(paneDelta.paneId, {
+          latestEventSeq:
+            paneDelta.latestEventSeq === null
+              ? previous.latestEventSeq
+              : BigInt(paneDelta.latestEventSeq),
+          readThroughSeq:
+            paneDelta.readThroughSeq === null
+              ? previous.readThroughSeq
+              : BigInt(paneDelta.readThroughSeq),
+          firstUnreadAt: paneDelta.firstUnreadAt,
+          severity: paneDelta.severity,
+        })
+      }
+
+      for (const notifDelta of delta.notifs) {
+        if (notifDelta.removed) {
+          store.notifs.delete(notifDelta.notifId)
+          continue
+        }
+        const previous = store.notifs.get(notifDelta.notifId) ?? { read: false }
+        store.notifs.set(notifDelta.notifId, {
+          read: notifDelta.read === null ? previous.read : notifDelta.read,
+        })
+      }
+
+      store.cacheRevision = revision
+      store.revalidateOverlays()
+      return true
+    },
+
+    applySnapshot(snapshot: AttentionStateEnvelope): boolean {
+      const revision = BigInt(snapshot.revision)
+      const epochChanged = store.epoch !== snapshot.epoch
+      if (!epochChanged && revision < store.cacheRevision) return false
+
+      if (epochChanged) store.overlays.clear()
+      store.epoch = snapshot.epoch
+      store.cacheRevision = revision
+      store.awaitingSnapshot = false
+      store.panes.clear()
+      store.notifs.clear()
+
+      for (const pane of snapshot.panes) {
+        if (pane.removed) continue
+        store.panes.set(pane.paneId, {
+          latestEventSeq: BigInt(pane.latestEventSeq ?? '0'),
+          readThroughSeq: BigInt(pane.readThroughSeq ?? '0'),
+          firstUnreadAt: pane.firstUnreadAt,
+          severity: pane.severity,
+        })
+      }
+      for (const notif of snapshot.notifs) {
+        if (notif.removed) continue
+        store.notifs.set(notif.notifId, { read: notif.read ?? false })
+      }
+
+      store.revalidateOverlays()
+      return true
+    },
+
+    noteResyncRequired(): boolean {
+      if (store.awaitingSnapshot) return false
+      store.awaitingSnapshot = true
+      return false
+    },
+
+    addOverlay(requestId: string, targets: OverlayTarget[]): boolean {
+      if (targets.length === 0) return false
+      store.overlays.set(requestId, { targets: [...targets], ackedAtRevision: null })
+      return true
+    },
+
+    dropOverlay(requestId: string): boolean {
+      return store.overlays.delete(requestId)
+    },
+
+    dropOverlayTarget(
+      requestId: string,
+      target: { paneId: string } | { notifId: string }
+    ): boolean {
+      const overlay = store.overlays.get(requestId)
+      if (!overlay) return false
+      const nextTargets = overlay.targets.filter((candidate) => !sameTarget(candidate, target))
+      if (nextTargets.length === overlay.targets.length) return false
+      if (nextTargets.length === 0) store.overlays.delete(requestId)
+      else overlay.targets = nextTargets
+      return true
+    },
+
+    applyMarkReadResult(result: MarkReadResultWire): boolean {
+      if (result.results.some(({ status }) => status === 'stale_epoch')) {
+        const changed = store.overlays.size > 0
+        store.overlays.clear()
+        return changed
+      }
+
+      const overlay = store.overlays.get(result.requestId)
+      if (!overlay) return false
+      let changed = false
+      const appliedRevision =
+        result.appliedAtRevision === null ? null : BigInt(result.appliedAtRevision)
+
+      for (const targetResult of result.results) {
+        if (targetResult.status === 'applied') {
+          if (appliedRevision === null || appliedRevision <= store.cacheRevision) {
+            changed = store.dropOverlayTarget(result.requestId, targetResult.target) || changed
+          } else {
+            const current = store.overlays.get(result.requestId)
+            if (current) current.ackedAtRevision = appliedRevision
+          }
+        } else {
+          changed = store.dropOverlayTarget(result.requestId, targetResult.target) || changed
+        }
+      }
+
+      return changed
+    },
+
+    unreadPaneSeverities(): Record<string, string> {
+      const result: Record<string, string> = {}
+      for (const [paneId, pane] of store.panes) {
+        if (pane.latestEventSeq <= pane.readThroughSeq) continue
+        const masked = [...store.overlays.values()].some((overlay) =>
+          overlay.targets.some(
+            (target) =>
+              isPaneTarget(target) &&
+              target.paneId === paneId &&
+              target.throughEventSeq >= pane.latestEventSeq
+          )
+        )
+        if (!masked && pane.severity !== null) result[paneId] = pane.severity
+      }
+      return result
+    },
+
+    unreadNotifIds(): string[] {
+      const result: string[] = []
+      for (const [notifId, notif] of store.notifs) {
+        if (notif.read) continue
+        const masked = [...store.overlays.values()].some((overlay) =>
+          overlay.targets.some((target) => !isPaneTarget(target) && target.notifId === notifId)
+        )
+        if (!masked) result.push(notifId)
+      }
+      return result
+    },
+
+    unreadAttentionCount(): number {
+      return Object.keys(store.unreadPaneSeverities()).length + store.unreadNotifIds().length
+    },
+
+    firstUnreadAtByPane(): Record<string, number | null> {
+      const result: Record<string, number | null> = {}
+      for (const [paneId, pane] of store.panes) result[paneId] = pane.firstUnreadAt
+      return result
+    },
+
+    revalidateOverlays(): void {
+      for (const [requestId, overlay] of store.overlays) {
+        if (overlay.ackedAtRevision !== null && overlay.ackedAtRevision <= store.cacheRevision) {
+          store.overlays.delete(requestId)
+          continue
+        }
+
+        overlay.targets = overlay.targets.filter((target) => {
+          if (isPaneTarget(target)) {
+            const pane = store.panes.get(target.paneId)
+            return !pane || pane.readThroughSeq < target.throughEventSeq
+          }
+          return store.notifs.get(target.notifId)?.read !== true
+        })
+        if (overlay.targets.length === 0) store.overlays.delete(requestId)
+      }
+    },
+  }
+
+  return store
+}
+
+export type AttentionStore = ReturnType<typeof createAttentionStore>

--- a/frontend/src/composables/useAppForeground.ts
+++ b/frontend/src/composables/useAppForeground.ts
@@ -1,0 +1,67 @@
+import { ref, type Ref } from 'vue'
+import { isTauri } from './useTransport'
+
+export const isAppForeground: Ref<boolean> = ref(false)
+
+let forcedValue: boolean | null = null
+const foregroundGainSubscribers = new Set<() => void>()
+
+function setForeground(value: boolean) {
+  const nextValue = forcedValue ?? value
+  const gainedForeground = !isAppForeground.value && nextValue
+  isAppForeground.value = nextValue
+  if (gainedForeground) {
+    for (const subscriber of foregroundGainSubscribers) subscriber()
+  }
+}
+
+function readWebForeground(): boolean {
+  return document.visibilityState === 'visible' && document.hasFocus()
+}
+
+function refreshWebForeground() {
+  setForeground(readWebForeground())
+}
+
+async function initializeTauriForeground() {
+  try {
+    const { getCurrentWindow } = await import('@tauri-apps/api/window')
+    const appWindow = getCurrentWindow()
+    let focusEventApplied = false
+    await appWindow.onFocusChanged(({ payload }) => {
+      focusEventApplied = true
+      setForeground(payload)
+    })
+    const initiallyFocused = await appWindow.isFocused()
+    if (!focusEventApplied) setForeground(initiallyFocused)
+  } catch {
+    setForeground(false)
+  }
+}
+
+if (isTauri()) {
+  void initializeTauriForeground()
+} else {
+  refreshWebForeground()
+  document.addEventListener('visibilitychange', refreshWebForeground)
+  window.addEventListener('focus', refreshWebForeground)
+  window.addEventListener('blur', refreshWebForeground)
+}
+
+export function getIsAppForeground(): boolean {
+  return isAppForeground.value
+}
+
+export function onAppForegroundGain(callback: () => void): () => void {
+  foregroundGainSubscribers.add(callback)
+  return () => foregroundGainSubscribers.delete(callback)
+}
+
+export function __setAppForegroundForTest(value: boolean | null) {
+  forcedValue = value
+  if (value !== null) {
+    setForeground(value)
+  } else if (!isTauri()) {
+    refreshWebForeground()
+  }
+}

--- a/frontend/src/composables/useNotification.ts
+++ b/frontend/src/composables/useNotification.ts
@@ -98,7 +98,7 @@ export interface NotificationItem {
   epoch?: string
 }
 
-type MarkReadReason =
+export type MarkReadReason =
   | 'focus'
   | 'terminal_input'
   | 'tab_activate'
@@ -173,6 +173,13 @@ let cachedClientId: string | null = null
 const pendingRequests = new Map<string, PendingRequest>()
 const historyDedup = new Set<string>()
 
+interface ActiveReadContext {
+  getActiveFocusedPaneId: () => string | null
+  isAppForeground: () => boolean
+}
+
+let activeReadContext: ActiveReadContext | null = null
+
 function randomToken(): string {
   try {
     if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
@@ -189,7 +196,7 @@ function randomToken(): string {
 
 const tabNonce = randomToken()
 
-function getClientId(): string {
+export function getNotificationClientId(): string {
   if (cachedClientId) return cachedClientId
   try {
     const stored = localStorage.getItem(CLIENT_ID_KEY)
@@ -204,6 +211,10 @@ function getClientId(): string {
     cachedClientId = randomToken()
     return cachedClientId
   }
+}
+
+export function mintNotificationRequestId(): string {
+  return `${tabNonce}-${++requestCounter}`
 }
 
 function genId(): string {
@@ -240,6 +251,7 @@ export function aggregateSeverity(paneIds: string[]): NotificationType | null {
 
 function refreshProjection() {
   const next = attentionStore.unreadPaneSeverities()
+  delete next['']
   for (const paneId of Object.keys(unreadByPane)) {
     if (!(paneId in next)) delete unreadByPane[paneId]
   }
@@ -287,7 +299,7 @@ function handleEvent(event: LegacyEvent) {
     if (!cfg.bell?.enabled) return
     body = 'Bell'
   } else if (event.type === 'notify') {
-    if (!cfg.osc_notify) return
+    if (!event.notifId && !cfg.osc_notify) return
     title = event.title ?? null
     body = event.body ?? ''
     notifType = (event.notification_type as NotificationType) || 'info'
@@ -307,7 +319,7 @@ function handleEvent(event: LegacyEvent) {
     title,
     body,
     timestamp: Date.now(),
-    source: 'terminal',
+    source: event.notifId && !event.pane_id ? 'plugin' : 'terminal',
     eventSeq: event.eventSeq,
     notifId: event.notifId,
     epoch: attentionStore.epoch ?? undefined,
@@ -390,6 +402,17 @@ let goToHandler: ((paneId: string) => void) | null = null
 
 export function setGoToPaneHandler(handler: (paneId: string) => void) {
   goToHandler = handler
+}
+
+export function setActiveReadContext(context: ActiveReadContext | null) {
+  activeReadContext = context
+}
+
+export function evaluateActiveRead() {
+  if (!activeReadContext?.isAppForeground()) return
+  const paneId = activeReadContext.getActiveFocusedPaneId()
+  if (!paneId) return
+  markPaneReadIfUnread(paneId, 'active_observed')
 }
 
 function showToast(item: NotificationItem) {
@@ -503,12 +526,12 @@ function createPending(
   notifs: MarkReadPayload['notifs']
 ) {
   if (targets.length === 0) return
-  const requestId = `${tabNonce}-${++requestCounter}`
+  const requestId = mintNotificationRequestId()
   const payload: MarkReadPayload = {
     type: 'notification.mark_read',
     v: 1,
     epoch: attentionStore.epoch ?? '',
-    clientId: getClientId(),
+    clientId: getNotificationClientId(),
     requestId,
     reason,
     panes,
@@ -539,6 +562,13 @@ export function markPanesRead(
     targets.push({ paneId: requested.paneId, throughEventSeq: BigInt(throughEventSeq) })
   }
   createPending(targets, reason, wirePanes, [])
+}
+
+export function markPaneReadIfUnread(paneId: string, reason: MarkReadReason) {
+  if (!paneId || !unreadByPane[paneId]) return
+  const pane = attentionStore.panes.get(paneId)
+  if (!pane) return
+  markPanesRead([{ paneId, throughEventSeq: pane.latestEventSeq.toString() }], reason)
 }
 
 export function markNotifsRead(notifIds: string[], reason: MarkReadReason) {
@@ -616,15 +646,19 @@ export function __dispatchServerMessageForTest(msg: unknown) {
   const envelope = msg as { type: string }
   switch (envelope.type) {
     case 'state_delta':
-      attentionStore.applyDelta(msg as unknown as AttentionStateEnvelope)
-      prunePendingWithoutOverlay()
-      refreshProjection()
+      {
+        const applied = attentionStore.applyDelta(msg as unknown as AttentionStateEnvelope)
+        prunePendingWithoutOverlay()
+        refreshProjection()
+        if (applied) evaluateActiveRead()
+      }
       break
     case 'snapshot': {
       const snapshot = msg as unknown as AttentionStateEnvelope
-      attentionStore.applySnapshot(snapshot)
+      const applied = attentionStore.applySnapshot(snapshot)
       prunePendingWithoutOverlay()
       refreshProjection()
+      if (applied) evaluateActiveRead()
       if (connectionNeedsSnapshot) {
         connectionNeedsSnapshot = false
         resendPendingAfterSnapshot()
@@ -713,6 +747,7 @@ export function __resetForTest() {
   protocolUpgradeStopped = false
   toastInstance = null
   goToHandler = null
+  activeReadContext = null
 }
 
 export function useNotification() {
@@ -729,6 +764,7 @@ export function useNotification() {
     historyCount,
     setGoToPaneHandler,
     markPanesRead,
+    markPaneReadIfUnread,
     markNotifsRead,
     dismissOne(id: string) {
       const item = notifications.value.find((notification) => notification.id === id)

--- a/frontend/src/composables/useNotification.ts
+++ b/frontend/src/composables/useNotification.ts
@@ -1,9 +1,15 @@
-import { ref, shallowReactive, computed, h, watch } from 'vue'
+import { ref, shallowReactive, computed, h } from 'vue'
 import { TYPE } from 'vue-toastification'
 import { getApiBase, wsUrlWithToken } from './apiBase'
 import { isTauri } from './useTransport'
 import { settings } from './useSettings'
 import { useI18n } from './useI18n'
+import {
+  createAttentionStore,
+  type AttentionStateEnvelope,
+  type MarkReadResultWire,
+  type OverlayTarget,
+} from './attentionReconcile'
 
 // ── Sound ──────────────────────────────────────────────
 
@@ -87,17 +93,118 @@ export interface NotificationItem {
   body: string
   timestamp: number
   source?: 'terminal' | 'plugin'
+  eventSeq?: string
+  notifId?: string
+  epoch?: string
 }
+
+type MarkReadReason =
+  | 'focus'
+  | 'terminal_input'
+  | 'tab_activate'
+  | 'tab_close'
+  | 'pane_close'
+  | 'goto'
+  | 'active_observed'
+  | 'dismiss'
+  | 'clear_all'
+
+interface LegacyEvent {
+  type: 'bell' | 'notify'
+  v: number
+  pane_id: string
+  title: string | null
+  body: string
+  notification_type: string
+  eventSeq: string
+  occurredAt: number
+  severity: NotificationType
+  notifId?: string
+}
+
+interface MarkReadPayload {
+  type: 'notification.mark_read'
+  v: 1
+  epoch: string
+  clientId: string
+  requestId: string
+  reason: MarkReadReason
+  panes: Array<{ paneId: string; throughEventSeq: string }>
+  notifs: Array<{ notifId: string }>
+}
+
+interface PendingRequest {
+  requestId: string
+  payload: MarkReadPayload
+  attempts: number
+  timer: ReturnType<typeof setTimeout> | null
+}
+
+const ACK_TIMEOUT_MS = 5000
+const MAX_SEND_ATTEMPTS = 4
+const PENDING_CAP = 64
+const HISTORY_DEDUP_CAP = 512
+const CLIENT_ID_KEY = 'dinotty.notifClientId'
+const PROTO_RELOAD_KEY = 'dinotty.protoReloadAt'
 
 const notifications = ref<NotificationItem[]>([])
 const panelVisible = ref(false)
 const unreadByPane = shallowReactive<Record<string, NotificationType>>({})
-const unreadCount = computed(() => notifications.value.length)
+const firstUnreadAtByPane = shallowReactive<Record<string, number | null>>({})
+const projectionVersion = ref(0)
+const historyCount = computed(() => notifications.value.length)
+const unreadAttentionCount = computed(() => {
+  projectionVersion.value
+  return attentionStore.unreadAttentionCount()
+})
 
+let attentionStore = createAttentionStore()
 let ws: WebSocket | null = null
 let idCounter = 0
 let initialized = false
 let reconnectDelay = 3000
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+let connectionNeedsSnapshot = false
+let protocolUpgradeStopped = false
+let suppressClose = false
+let connectGeneration = 0
+let requestCounter = 0
+let cachedClientId: string | null = null
+const pendingRequests = new Map<string, PendingRequest>()
+const historyDedup = new Set<string>()
+
+function randomToken(): string {
+  try {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID()
+    }
+    if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+      const bytes = new Uint32Array(4)
+      crypto.getRandomValues(bytes)
+      return [...bytes].map((value) => value.toString(36)).join('-')
+    }
+  } catch {}
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+}
+
+const tabNonce = randomToken()
+
+function getClientId(): string {
+  if (cachedClientId) return cachedClientId
+  try {
+    const stored = localStorage.getItem(CLIENT_ID_KEY)
+    if (stored) {
+      cachedClientId = stored
+      return stored
+    }
+    cachedClientId = randomToken()
+    localStorage.setItem(CLIENT_ID_KEY, cachedClientId)
+    return cachedClientId
+  } catch {
+    cachedClientId = randomToken()
+    return cachedClientId
+  }
+}
 
 function genId(): string {
   return `notif-${++idCounter}-${Date.now()}`
@@ -121,27 +228,54 @@ export function aggregateSeverity(paneIds: string[]): NotificationType | null {
   for (const pid of paneIds) {
     const sev = unreadByPane[pid]
     if (sev) {
-      const r = severityRank(sev)
-      if (r > highestRank) {
+      const rank = severityRank(sev)
+      if (rank > highestRank) {
         highest = sev
-        highestRank = r
+        highestRank = rank
       }
     }
   }
   return highest
 }
 
+function refreshProjection() {
+  const next = attentionStore.unreadPaneSeverities()
+  for (const paneId of Object.keys(unreadByPane)) {
+    if (!(paneId in next)) delete unreadByPane[paneId]
+  }
+  for (const [paneId, severity] of Object.entries(next)) {
+    unreadByPane[paneId] = severity as NotificationType
+  }
+  const nextFirstUnreadAt = attentionStore.firstUnreadAtByPane()
+  for (const paneId of Object.keys(firstUnreadAtByPane)) {
+    if (!(paneId in nextFirstUnreadAt)) delete firstUnreadAtByPane[paneId]
+  }
+  for (const [paneId, firstUnreadAt] of Object.entries(nextFirstUnreadAt)) {
+    firstUnreadAtByPane[paneId] = firstUnreadAt
+  }
+  projectionVersion.value++
+}
+
 function getNotifConfig() {
   return settings.notification
 }
 
-function handleEvent(event: {
-  type: string
-  pane_id: string
-  title?: string | null
-  body?: string
-  notification_type?: string
-}) {
+function rememberHistoryKey(key: string): boolean {
+  if (historyDedup.has(key)) return false
+  historyDedup.add(key)
+  if (historyDedup.size > HISTORY_DEDUP_CAP) {
+    const oldest = historyDedup.values().next().value
+    if (oldest !== undefined) historyDedup.delete(oldest)
+  }
+  return true
+}
+
+function insertHistory(item: NotificationItem) {
+  notifications.value.unshift(item)
+  if (notifications.value.length > 100) notifications.value.length = 100
+}
+
+function handleEvent(event: LegacyEvent) {
   const cfg = getNotifConfig()
   if (!cfg || !cfg.enabled) return
 
@@ -161,25 +295,24 @@ function handleEvent(event: {
     return
   }
 
+  const dedupKey = event.pane_id
+    ? `${attentionStore.epoch ?? ''}|${event.pane_id}|${event.eventSeq}`
+    : `${attentionStore.epoch ?? ''}|notif|${event.notifId ?? ''}`
+  if (!rememberHistoryKey(dedupKey)) return
+
   const item: NotificationItem = {
     id: genId(),
     type: notifType,
-    paneId: event.pane_id,
+    paneId: event.pane_id || undefined,
     title,
     body,
     timestamp: Date.now(),
     source: 'terminal',
+    eventSeq: event.eventSeq,
+    notifId: event.notifId,
+    epoch: attentionStore.epoch ?? undefined,
   }
-  notifications.value.unshift(item)
-  if (notifications.value.length > 100) {
-    notifications.value.length = 100
-  }
-
-  // Track unread per pane (highest severity)
-  const current = unreadByPane[event.pane_id]
-  if (!current || severityRank(notifType) > severityRank(current)) {
-    unreadByPane[event.pane_id] = notifType
-  }
+  insertHistory(item)
 
   // Sound
   if (cfg.channels?.sound) {
@@ -220,18 +353,9 @@ export function pushNotification(opts: {
     body: opts.body,
     timestamp: Date.now(),
     source: opts.source ?? 'terminal',
+    epoch: attentionStore.epoch ?? undefined,
   }
-  notifications.value.unshift(item)
-  if (notifications.value.length > 100) {
-    notifications.value.length = 100
-  }
-
-  if (item.paneId) {
-    const current = unreadByPane[item.paneId]
-    if (!current || severityRank(item.type) > severityRank(current)) {
-      unreadByPane[item.paneId] = item.type
-    }
-  }
+  insertHistory(item)
 
   if (cfg.channels?.sound) {
     const soundCfg: SoundConfig | undefined = cfg.sounds?.[item.type]
@@ -270,7 +394,9 @@ export function setGoToPaneHandler(handler: (paneId: string) => void) {
 
 function showToast(item: NotificationItem) {
   if (!toastInstance) {
-    console.warn('[notification] toast instance not set; call setToastInstance() from App.vue setup')
+    console.warn(
+      '[notification] toast instance not set; call setToastInstance() from App.vue setup'
+    )
     return
   }
   const { t } = useI18n()
@@ -312,34 +438,281 @@ function showToast(item: NotificationItem) {
   })
 }
 
+function isSocketOpen(): boolean {
+  return ws !== null && ws.readyState === WebSocket.OPEN
+}
+
+function cancelPending(requestId: string) {
+  const pending = pendingRequests.get(requestId)
+  if (!pending) return
+  if (pending.timer !== null) clearTimeout(pending.timer)
+  pendingRequests.delete(requestId)
+}
+
+function dropPending(requestId: string) {
+  cancelPending(requestId)
+  attentionStore.dropOverlay(requestId)
+}
+
+function cancelAllPending() {
+  for (const pending of pendingRequests.values()) {
+    if (pending.timer !== null) clearTimeout(pending.timer)
+  }
+  pendingRequests.clear()
+}
+
+function prunePendingWithoutOverlay() {
+  for (const requestId of pendingRequests.keys()) {
+    if (!attentionStore.overlays.has(requestId)) cancelPending(requestId)
+  }
+}
+
+function scheduleAckTimeout(pending: PendingRequest) {
+  if (pending.timer !== null) clearTimeout(pending.timer)
+  pending.timer = setTimeout(() => {
+    pending.timer = null
+    if (!pendingRequests.has(pending.requestId)) return
+    if (pending.attempts >= MAX_SEND_ATTEMPTS) {
+      pendingRequests.delete(pending.requestId)
+      attentionStore.dropOverlay(pending.requestId)
+      refreshProjection()
+      return
+    }
+    sendPending(pending)
+  }, ACK_TIMEOUT_MS)
+}
+
+function sendPending(pending: PendingRequest) {
+  if (pending.attempts >= MAX_SEND_ATTEMPTS) {
+    pendingRequests.delete(pending.requestId)
+    attentionStore.dropOverlay(pending.requestId)
+    refreshProjection()
+    return
+  }
+  pending.attempts++
+  if (isSocketOpen() && !connectionNeedsSnapshot && pending.payload.epoch) {
+    ws!.send(JSON.stringify(pending.payload))
+  }
+  scheduleAckTimeout(pending)
+}
+
+function createPending(
+  targets: OverlayTarget[],
+  reason: MarkReadReason,
+  panes: MarkReadPayload['panes'],
+  notifs: MarkReadPayload['notifs']
+) {
+  if (targets.length === 0) return
+  const requestId = `${tabNonce}-${++requestCounter}`
+  const payload: MarkReadPayload = {
+    type: 'notification.mark_read',
+    v: 1,
+    epoch: attentionStore.epoch ?? '',
+    clientId: getClientId(),
+    requestId,
+    reason,
+    panes,
+    notifs,
+  }
+  const pending: PendingRequest = { requestId, payload, attempts: 0, timer: null }
+  if (pendingRequests.size >= PENDING_CAP) {
+    const oldestRequestId = pendingRequests.keys().next().value
+    if (oldestRequestId !== undefined) dropPending(oldestRequestId)
+  }
+  attentionStore.addOverlay(requestId, targets)
+  pendingRequests.set(requestId, pending)
+  refreshProjection()
+  sendPending(pending)
+}
+
+export function markPanesRead(
+  panes: Array<{ paneId: string; throughEventSeq?: string }>,
+  reason: MarkReadReason
+) {
+  const wirePanes: MarkReadPayload['panes'] = []
+  const targets: OverlayTarget[] = []
+  for (const requested of panes) {
+    const pane = attentionStore.panes.get(requested.paneId)
+    if (!pane) continue
+    const throughEventSeq = requested.throughEventSeq ?? pane.latestEventSeq.toString()
+    wirePanes.push({ paneId: requested.paneId, throughEventSeq })
+    targets.push({ paneId: requested.paneId, throughEventSeq: BigInt(throughEventSeq) })
+  }
+  createPending(targets, reason, wirePanes, [])
+}
+
+export function markNotifsRead(notifIds: string[], reason: MarkReadReason) {
+  const ids = [...new Set(notifIds)].filter((notifId) => attentionStore.notifs.has(notifId))
+  createPending(
+    ids.map((notifId) => ({ notifId })),
+    reason,
+    [],
+    ids.map((notifId) => ({ notifId }))
+  )
+}
+
+function resendPendingAfterSnapshot() {
+  for (const pending of [...pendingRequests.values()]) {
+    if (!attentionStore.overlays.has(pending.requestId)) {
+      cancelPending(pending.requestId)
+      continue
+    }
+    if (pending.timer !== null) clearTimeout(pending.timer)
+    pending.timer = null
+    pending.payload.epoch = attentionStore.epoch ?? ''
+    sendPending(pending)
+  }
+}
+
+function handleProtocolUpgradeRequired() {
+  protocolUpgradeStopped = true
+  if (reconnectTimer !== null) {
+    clearTimeout(reconnectTimer)
+    reconnectTimer = null
+  }
+  if (isTauri()) {
+    console.error('[notification] protocol update required; update the desktop application')
+    if (toastInstance)
+      toastInstance('Notification update required', { type: TYPE.ERROR, timeout: false })
+    return
+  }
+
+  let lastReload = 0
+  try {
+    lastReload = Number(sessionStorage.getItem(PROTO_RELOAD_KEY) ?? '0')
+  } catch {}
+  const now = Date.now()
+  if (!Number.isFinite(lastReload) || now - lastReload > 60_000) {
+    try {
+      sessionStorage.setItem(PROTO_RELOAD_KEY, String(now))
+    } catch {}
+    location.reload()
+  } else {
+    console.error('[notification] protocol update required; automatic reload already attempted')
+  }
+}
+
+function handleClose(event: CloseEvent) {
+  ws = null
+  connectionNeedsSnapshot = false
+  if (suppressClose) return
+  if (event.code === 4001) {
+    cancelAllPending()
+    attentionStore.overlays.clear()
+    refreshProjection()
+    handleProtocolUpgradeRequired()
+    return
+  }
+  if (protocolUpgradeStopped) return
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null
+    connectWs()
+  }, reconnectDelay)
+  reconnectDelay = Math.min(reconnectDelay * 2, 30000)
+}
+
+export function __dispatchServerMessageForTest(msg: unknown) {
+  if (!msg || typeof msg !== 'object' || !('type' in msg)) return
+  const envelope = msg as { type: string }
+  switch (envelope.type) {
+    case 'state_delta':
+      attentionStore.applyDelta(msg as unknown as AttentionStateEnvelope)
+      prunePendingWithoutOverlay()
+      refreshProjection()
+      break
+    case 'snapshot': {
+      const snapshot = msg as unknown as AttentionStateEnvelope
+      attentionStore.applySnapshot(snapshot)
+      prunePendingWithoutOverlay()
+      refreshProjection()
+      if (connectionNeedsSnapshot) {
+        connectionNeedsSnapshot = false
+        resendPendingAfterSnapshot()
+      }
+      break
+    }
+    case 'mark_read_result': {
+      const result = msg as MarkReadResultWire & { type: string }
+      const staleEpoch = result.results.some(({ status }) => status === 'stale_epoch')
+      if (staleEpoch) cancelAllPending()
+      else cancelPending(result.requestId)
+      attentionStore.applyMarkReadResult(result)
+      refreshProjection()
+      break
+    }
+    case 'resync_required':
+      attentionStore.noteResyncRequired()
+      refreshProjection()
+      break
+    case 'bell':
+    case 'notify':
+      handleEvent(msg as LegacyEvent)
+      break
+  }
+}
+
+export function __pendingRequestCountForTest(): number {
+  return pendingRequests.size
+}
+
 function connectWs() {
-  if (ws) return
+  if (ws || protocolUpgradeStopped) return
+  const generation = connectGeneration
   const connect = async () => {
     let url: string
     if (isTauri()) {
       const origin = await getApiBase()
-      url = `${origin.replace(/^http/, 'ws')}/ws/notify`
+      url = `${origin.replace(/^http/, 'ws')}/ws/notify?v=1`
     } else {
       const proto = location.protocol === 'https:' ? 'wss:' : 'ws:'
-      url = `${proto}//${location.host}/ws/notify`
+      url = `${proto}//${location.host}/ws/notify?v=1`
     }
-    ws = new WebSocket(wsUrlWithToken(url))
-    ws.onopen = () => {
+    if (generation !== connectGeneration || protocolUpgradeStopped || ws) return
+    const socket = new WebSocket(wsUrlWithToken(url))
+    ws = socket
+    connectionNeedsSnapshot = true
+    socket.onopen = () => {
       reconnectDelay = 3000
     }
-    ws.onmessage = (e) => {
+    socket.onmessage = (event) => {
       try {
-        handleEvent(JSON.parse(e.data))
+        __dispatchServerMessageForTest(JSON.parse(event.data))
       } catch {}
     }
-    ws.onclose = () => {
-      ws = null
-      setTimeout(connect, reconnectDelay)
-      reconnectDelay = Math.min(reconnectDelay * 2, 30000)
-    }
-    ws.onerror = () => {}
+    socket.onclose = handleClose
+    socket.onerror = () => {}
   }
-  connect()
+  void connect()
+}
+
+export function __resetForTest() {
+  connectGeneration++
+  if (reconnectTimer !== null) clearTimeout(reconnectTimer)
+  reconnectTimer = null
+  cancelAllPending()
+  suppressClose = true
+  if (ws) {
+    ws.onclose = null
+    ws.close()
+  }
+  suppressClose = false
+  ws = null
+  notifications.value = []
+  panelVisible.value = false
+  for (const paneId of Object.keys(unreadByPane)) delete unreadByPane[paneId]
+  for (const paneId of Object.keys(firstUnreadAtByPane)) delete firstUnreadAtByPane[paneId]
+  attentionStore = createAttentionStore()
+  projectionVersion.value++
+  historyDedup.clear()
+  idCounter = 0
+  requestCounter = 0
+  cachedClientId = null
+  initialized = false
+  reconnectDelay = 3000
+  connectionNeedsSnapshot = false
+  protocolUpgradeStopped = false
+  toastInstance = null
+  goToHandler = null
 }
 
 export function useNotification() {
@@ -351,32 +724,57 @@ export function useNotification() {
     notifications,
     panelVisible,
     unreadByPane,
-    unreadCount,
+    firstUnreadAtByPane,
+    unreadAttentionCount,
+    historyCount,
     setGoToPaneHandler,
+    markPanesRead,
+    markNotifsRead,
     dismissOne(id: string) {
-      const item = notifications.value.find((n) => n.id === id)
-      notifications.value = notifications.value.filter((n) => n.id !== id)
-      const paneId = item?.paneId
-      if (paneId && !notifications.value.some((n) => n.paneId === paneId)) {
-        delete unreadByPane[paneId]
+      const item = notifications.value.find((notification) => notification.id === id)
+      notifications.value = notifications.value.filter((notification) => notification.id !== id)
+      if (!item || item.epoch !== attentionStore.epoch) return
+      if (item?.paneId && item.eventSeq) {
+        markPanesRead([{ paneId: item.paneId, throughEventSeq: item.eventSeq }], 'dismiss')
+      } else if (item?.notifId) {
+        markNotifsRead([item.notifId], 'dismiss')
       }
     },
     clearAll() {
       notifications.value = []
-      for (const k of Object.keys(unreadByPane)) delete unreadByPane[k]
       panelVisible.value = false
+      const panes = [...attentionStore.panes.entries()]
+        .filter(([, pane]) => pane.latestEventSeq > pane.readThroughSeq)
+        .map(([paneId, pane]) => ({ paneId, throughEventSeq: pane.latestEventSeq.toString() }))
+      const notifIds = [...attentionStore.notifs.entries()]
+        .filter(([, notif]) => !notif.read)
+        .map(([notifId]) => notifId)
+      const targets: OverlayTarget[] = [
+        ...panes.map(({ paneId, throughEventSeq }) => ({
+          paneId,
+          throughEventSeq: BigInt(throughEventSeq),
+        })),
+        ...notifIds.map((notifId) => ({ notifId })),
+      ]
+      createPending(
+        targets,
+        'clear_all',
+        panes,
+        notifIds.map((notifId) => ({ notifId }))
+      )
     },
     clearPaneUnread(paneId: string) {
-      delete unreadByPane[paneId]
+      markPanesRead([{ paneId }], 'pane_close')
     },
-    clearForPaneIds(paneIds: string[]) {
+    clearForPaneIds(paneIds: string[], reason: MarkReadReason = 'tab_activate') {
       const idSet = new Set(paneIds)
       notifications.value = notifications.value.filter(
-        (n) => !n.paneId || !idSet.has(n.paneId),
+        (notification) => !notification.paneId || !idSet.has(notification.paneId)
       )
-      for (const pid of paneIds) {
-        delete unreadByPane[pid]
-      }
+      markPanesRead(
+        paneIds.map((paneId) => ({ paneId })),
+        reason
+      )
     },
     togglePanel() {
       panelVisible.value = !panelVisible.value

--- a/frontend/src/composables/useSplitPane.ts
+++ b/frontend/src/composables/useSplitPane.ts
@@ -21,6 +21,8 @@ import { setActivePaneId } from './useTerminal'
 import { useI18n } from './useI18n'
 import { usePaneWarning } from './usePaneWarning'
 import { reconcilePaneMru, removePaneFromMru, touchPaneMru } from '../types/paneMru'
+import { getIsAppForeground } from './useAppForeground'
+import { markPaneReadIfUnread } from './useNotification'
 
 export function useSplitPane(opts: {
   tabs: Ref<Tab[]>
@@ -154,6 +156,7 @@ export function useSplitPane(opts: {
       clearAllZoom(tab.layout)
       persist()
       syncTabLayout(tab)
+      if (getIsAppForeground()) markPaneReadIfUnread(paneId, 'focus')
       nextTick(() => {
         // Blur all other panes first to prevent duplicate input in Tauri WKWebView
         for (const leaf of getAllLeaves(tab.layout)) {
@@ -325,6 +328,7 @@ export function useSplitPane(opts: {
 
   /** Handle broadcast input: send data to all other panes in the same tab */
   function onTerminalInput(sourcePaneId: string, data: string) {
+    if (getIsAppForeground()) markPaneReadIfUnread(sourcePaneId, 'terminal_input')
     const tab = findTabByPaneId(sourcePaneId)
     if (!tab || !tab.broadcastMode) return
 

--- a/frontend/src/test/AppPaneClose.test.ts
+++ b/frontend/src/test/AppPaneClose.test.ts
@@ -39,33 +39,49 @@ const localStorageMock = {
 ;(global as any).localStorage = localStorageMock
 
 // vi.mock factories are hoisted; vi.hoisted lets us share spies with them.
-const mocks = vi.hoisted(() => ({
-  closePane: vi.fn<(paneId: string) => Promise<boolean>>(),
-  splitPane: vi.fn(),
-  toggleBroadcast: vi.fn(),
-  toggleZoom: vi.fn(),
-  equalizePanes: vi.fn(),
-  focusPane: vi.fn(),
-  focusNext: vi.fn(),
-  focusPrev: vi.fn(),
-  keyboardResize: vi.fn(),
-  reorderPane: vi.fn(),
-  onTerminalInput: vi.fn(),
-  focusNeighbor: vi.fn(),
-  apiCreateTab: vi.fn(async () => ({
-    tab_id: 't-new',
-    pane_id: 'p-new',
-    layout: { type: 'leaf', paneId: 'p-new', title: 'Terminal', ratio: 1, zoomed: false },
-  })),
-  apiCloseTab: vi.fn(async () => {}),
-  clearForPaneIds: vi.fn(),
-  notificationItems: { value: [] as unknown[] },
-  unreadAttentionCount: { value: 0 },
-}))
+const mocks = vi.hoisted(() => {
+  let notificationRequestIdCounter = 0
+  return {
+    closePane: vi.fn<(paneId: string) => Promise<boolean>>(),
+    splitPane: vi.fn(),
+    toggleBroadcast: vi.fn(),
+    toggleZoom: vi.fn(),
+    equalizePanes: vi.fn(),
+    focusPane: vi.fn(),
+    focusNext: vi.fn(),
+    focusPrev: vi.fn(),
+    keyboardResize: vi.fn(),
+    reorderPane: vi.fn(),
+    onTerminalInput: vi.fn(),
+    focusNeighbor: vi.fn(),
+    apiCreateTab: vi.fn(async () => ({
+      tab_id: 't-new',
+      pane_id: 'p-new',
+      layout: { type: 'leaf', paneId: 'p-new', title: 'Terminal', ratio: 1, zoomed: false },
+    })),
+    apiCloseTab: vi.fn(async () => {}),
+    clearForPaneIds: vi.fn(),
+    notificationItems: { value: [] as unknown[] },
+    unreadAttentionCount: { value: 0 },
+    authFetch: vi.fn<(input: string, init?: RequestInit) => Promise<any>>(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: 'accepted', notifId: 'notif-1', eventSeq: '1' }),
+    })),
+    pushNotification: vi.fn(),
+    setActiveReadContext: vi.fn(),
+    evaluateActiveRead: vi.fn(),
+    stopForegroundGainSubscription: vi.fn(),
+    mintNotificationRequestId: vi.fn(() => `tab-nonce-${++notificationRequestIdCounter}`),
+    resetNotificationRequestIds: () => {
+      notificationRequestIdCounter = 0
+    },
+  }
+})
 
 vi.mock('../composables/apiBase', () => ({
   apiUrl: (path: string) => path,
-  authFetch: vi.fn(async () => ({ ok: true, json: async () => ({}) })),
+  authFetch: mocks.authFetch,
   getAuthToken: () => 'token',
   setAuthToken: () => {},
   getApiBase: async () => 'http://127.0.0.1:7681',
@@ -124,8 +140,16 @@ vi.mock('../composables/useNotification', () => ({
     setGoToPaneHandler: vi.fn(),
   }),
   aggregateSeverity: vi.fn(() => null),
-  pushNotification: vi.fn(),
+  pushNotification: mocks.pushNotification,
   setToastInstance: vi.fn(),
+  setActiveReadContext: mocks.setActiveReadContext,
+  evaluateActiveRead: mocks.evaluateActiveRead,
+  getNotificationClientId: () => 'client-stable',
+  mintNotificationRequestId: mocks.mintNotificationRequestId,
+}))
+vi.mock('../composables/useAppForeground', () => ({
+  getIsAppForeground: () => true,
+  onAppForegroundGain: vi.fn(() => mocks.stopForegroundGainSubscription),
 }))
 vi.mock('../composables/usePluginLoader', () => ({
   usePluginLoader: () => ({
@@ -295,6 +319,15 @@ afterEach(() => {
   mocks.clearForPaneIds.mockReset()
   mocks.notificationItems.value = []
   mocks.unreadAttentionCount.value = 0
+  mocks.authFetch.mockReset()
+  mocks.authFetch.mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => ({ status: 'accepted', notifId: 'notif-1', eventSeq: '1' }),
+  })
+  mocks.pushNotification.mockReset()
+  mocks.mintNotificationRequestId.mockClear()
+  mocks.resetNotificationRequestIds()
 })
 
 afterAll(() => {
@@ -483,6 +516,315 @@ describe('App.vue - notification goto flow', () => {
       expect.arrayContaining(['tab-1', 'pane-1', 'pane-2']),
       'goto'
     )
+  })
+})
+
+describe('App.vue - plugin notification bridge', () => {
+  function response(status: number, body: Record<string, unknown>) {
+    return { ok: status >= 200 && status < 300, status, json: async () => body }
+  }
+
+  async function flushBridge() {
+    for (let i = 0; i < 6; i++) await Promise.resolve()
+  }
+
+  it('POSTs pane-less plugin notifications and waits for the raised broadcast to insert history', async () => {
+    await mountWithTabs()
+    mocks.authFetch.mockClear()
+    mocks.pushNotification.mockClear()
+    ;(window as any).__dinotty_ui_notify('hello', 'warn', 'Plugin title')
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(mocks.authFetch).toHaveBeenCalledWith('/api/notify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        clientId: 'client-stable',
+        requestId: 'tab-nonce-1',
+        source: 'plugin',
+        type: 'warning',
+        title: 'Plugin title',
+        body: 'hello',
+      }),
+      signal: expect.any(AbortSignal),
+    })
+    expect(mocks.pushNotification).not.toHaveBeenCalled()
+  })
+
+  it('retries an accepted-but-response-lost request with the same requestId and does not insert locally', async () => {
+    await mountWithTabs()
+    mocks.authFetch.mockClear()
+    vi.useFakeTimers()
+    mocks.authFetch.mockRejectedValueOnce(new Error('network'))
+    mocks.authFetch.mockResolvedValueOnce(
+      response(200, { status: 'accepted', notifId: 'notif-2', eventSeq: '2' })
+    )
+    ;(window as any).__dinotty_ui_notify('offline', 'error')
+    await flushBridge()
+    await vi.advanceTimersByTimeAsync(1000)
+    await flushBridge()
+
+    expect(mocks.authFetch).toHaveBeenCalledTimes(2)
+    const requestBodies = mocks.authFetch.mock.calls.map(([, init]) => JSON.parse(init!.body as string))
+    expect(requestBodies[0].requestId).toBe(requestBodies[1].requestId)
+    expect(requestBodies[0]).toEqual(requestBodies[1])
+    expect(mocks.pushNotification).not.toHaveBeenCalled()
+  })
+
+  it('does not insert for a suppressed response', async () => {
+    await mountWithTabs()
+    mocks.authFetch.mockClear()
+    mocks.authFetch.mockResolvedValueOnce(response(200, { status: 'suppressed', reason: 'disabled' }))
+
+    ;(window as any).__dinotty_ui_notify('suppressed', 'info')
+    await flushBridge()
+
+    expect(mocks.authFetch).toHaveBeenCalledTimes(1)
+    expect(mocks.pushNotification).not.toHaveBeenCalled()
+  })
+
+  it('retries HTTP 503 responses regardless of body shape with the same requestId', async () => {
+    await mountWithTabs()
+    mocks.authFetch.mockClear()
+    vi.useFakeTimers()
+    mocks.authFetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        json: async () => {
+          throw new SyntaxError('truncated proxy response')
+        },
+      })
+      .mockResolvedValueOnce(response(503, { status: 'unexpected-proxy-shape' }))
+      .mockResolvedValueOnce(
+        response(200, { status: 'accepted', notifId: 'notif-3', eventSeq: '3' })
+      )
+
+    ;(window as any).__dinotty_ui_notify('busy', 'info')
+    await flushBridge()
+    await vi.advanceTimersByTimeAsync(3000)
+    await flushBridge()
+
+    expect(mocks.authFetch).toHaveBeenCalledTimes(3)
+    const requestBodies = mocks.authFetch.mock.calls.map(([, init]) => JSON.parse(init!.body as string))
+    expect(new Set(requestBodies.map(({ requestId }) => requestId))).toEqual(
+      new Set([requestBodies[0].requestId])
+    )
+    expect(requestBodies[1]).toEqual(requestBodies[0])
+    expect(requestBodies[2]).toEqual(requestBodies[0])
+    expect(mocks.pushNotification).not.toHaveBeenCalled()
+  })
+
+  it('gives separate jobs distinct requestIds while preserving each id across retries', async () => {
+    await mountWithTabs()
+    mocks.authFetch.mockClear()
+    vi.useFakeTimers()
+    const attemptsByRequestId = new Map<string, number>()
+    mocks.authFetch.mockImplementation(async (_input, init) => {
+      const request = JSON.parse(init!.body as string)
+      const attempt = (attemptsByRequestId.get(request.requestId) ?? 0) + 1
+      attemptsByRequestId.set(request.requestId, attempt)
+      if (attempt === 1) throw new Error('network')
+      return response(200, { status: 'accepted', notifId: request.requestId, eventSeq: '1' })
+    })
+
+    ;(window as any).__dinotty_ui_notify('first', 'info')
+    ;(window as any).__dinotty_ui_notify('second', 'warn')
+    await flushBridge()
+    await vi.advanceTimersByTimeAsync(1000)
+    await flushBridge()
+
+    const requests = mocks.authFetch.mock.calls.map(([, init]) => JSON.parse(init!.body as string))
+    const requestIdsByBody = new Map<string, Set<string>>()
+    for (const request of requests) {
+      const ids = requestIdsByBody.get(request.body) ?? new Set<string>()
+      ids.add(request.requestId)
+      requestIdsByBody.set(request.body, ids)
+    }
+    expect([...requestIdsByBody.keys()].sort()).toEqual(['first', 'second'])
+    expect(requestIdsByBody.get('first')?.size).toBe(1)
+    expect(requestIdsByBody.get('second')?.size).toBe(1)
+    expect([...requestIdsByBody.get('first')!][0]).not.toBe(
+      [...requestIdsByBody.get('second')!][0]
+    )
+    expect([...attemptsByRequestId.values()]).toEqual([2, 2])
+  })
+
+  it.each([400, 404, 409])(
+    'treats HTTP %s as terminal without retrying or inserting locally',
+    async (status) => {
+      await mountWithTabs()
+      mocks.authFetch.mockClear()
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+      mocks.authFetch.mockResolvedValueOnce(response(status, { status: 'terminal' }))
+
+      ;(window as any).__dinotty_ui_notify('rejected', 'info')
+      await flushBridge()
+
+      expect(mocks.authFetch).toHaveBeenCalledTimes(1)
+      expect(mocks.pushNotification).not.toHaveBeenCalled()
+      expect(consoleError).toHaveBeenCalledWith(
+        `[notification] plugin notify failed with HTTP ${status}`
+      )
+      consoleError.mockRestore()
+    }
+  )
+
+  it('falls back exactly once after all four retryable attempts fail', async () => {
+    await mountWithTabs()
+    mocks.authFetch.mockClear()
+    vi.useFakeTimers()
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    mocks.authFetch.mockRejectedValue(new Error('offline'))
+
+    ;(window as any).__dinotty_ui_notify('offline', 'error')
+    await flushBridge()
+    await vi.advanceTimersByTimeAsync(7000)
+    await flushBridge()
+
+    expect(mocks.authFetch).toHaveBeenCalledTimes(4)
+    expect(mocks.pushNotification).toHaveBeenCalledTimes(1)
+    expect(mocks.pushNotification).toHaveBeenCalledWith({
+      type: 'error',
+      title: 'Plugin',
+      body: 'offline',
+      source: 'plugin',
+    })
+    consoleError.mockRestore()
+  })
+
+  it('limits a failing notification burst to three concurrent fetches', async () => {
+    await mountWithTabs()
+    mocks.authFetch.mockClear()
+    mocks.pushNotification.mockClear()
+    vi.useFakeTimers()
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    let inFlight = 0
+    let maxInFlight = 0
+    const attemptsByBody = new Map<string, number>()
+    const requestIdsByBody = new Map<string, Set<string>>()
+    const attemptsByRequestId = new Map<string, number>()
+    mocks.authFetch.mockImplementation(
+      (_input, init) =>
+        new Promise((_, reject) => {
+          const request = JSON.parse(init!.body as string)
+          attemptsByBody.set(request.body, (attemptsByBody.get(request.body) ?? 0) + 1)
+          const ids = requestIdsByBody.get(request.body) ?? new Set<string>()
+          ids.add(request.requestId)
+          requestIdsByBody.set(request.body, ids)
+          attemptsByRequestId.set(
+            request.requestId,
+            (attemptsByRequestId.get(request.requestId) ?? 0) + 1
+          )
+          inFlight++
+          maxInFlight = Math.max(maxInFlight, inFlight)
+          setTimeout(() => {
+            inFlight--
+            reject(new Error('offline'))
+          }, 10)
+        })
+    )
+
+    for (let i = 0; i < 12; i++) {
+      ;(window as any).__dinotty_ui_notify(`burst-${i}`, 'info')
+    }
+    await flushBridge()
+    await vi.runAllTimersAsync()
+    await flushBridge()
+
+    expect(maxInFlight).toBe(3)
+    expect(mocks.authFetch).toHaveBeenCalledTimes(48)
+    expect([...attemptsByBody.keys()].sort()).toEqual(
+      Array.from({ length: 12 }, (_, i) => `burst-${i}`).sort()
+    )
+    expect([...attemptsByBody.values()]).toEqual(Array(12).fill(4))
+    expect([...requestIdsByBody.values()].every((ids) => ids.size === 1)).toBe(true)
+    expect(attemptsByRequestId.size).toBe(12)
+    expect([...attemptsByRequestId.values()]).toEqual(Array(12).fill(4))
+    consoleError.mockRestore()
+  })
+
+  it('aggregates overflow warnings while evicting the oldest queued jobs', async () => {
+    await mountWithTabs()
+    mocks.authFetch.mockClear()
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const pending: Array<{
+      body: string
+      resolve: (value: ReturnType<typeof response>) => void
+    }> = []
+    mocks.authFetch.mockImplementation(
+      (_input, init) =>
+        new Promise((resolve) => {
+          pending.push({ body: init!.body as string, resolve })
+        })
+    )
+
+    for (let i = 0; i < 72; i++) {
+      ;(window as any).__dinotty_ui_notify(`queued-${i}`, 'info')
+    }
+    await flushBridge()
+
+    expect(mocks.authFetch).toHaveBeenCalledTimes(3)
+    expect(consoleWarn).toHaveBeenCalledTimes(1)
+    expect(consoleWarn).toHaveBeenCalledWith(
+      '[notification] plugin notify bridge queue full; evicted 5 oldest pending jobs'
+    )
+    pending.splice(0, 3).forEach(({ resolve }) =>
+      resolve(response(200, { status: 'accepted', notifId: 'notif', eventSeq: '1' }))
+    )
+    await flushBridge()
+
+    const startedAfterSlotRelease = mocks.authFetch.mock.calls
+      .slice(3, 6)
+      .map(([, init]) => JSON.parse(init!.body as string).body)
+    expect(startedAfterSlotRelease).toEqual(['queued-8', 'queued-9', 'queued-10'])
+    pending.splice(0).forEach(({ resolve }) =>
+      resolve(response(200, { status: 'accepted', notifId: 'notif', eventSeq: '1' }))
+    )
+    await flushBridge()
+    consoleWarn.mockRestore()
+  })
+
+  it('aborts pending fetches on unmount without retrying, starting queued work, or falling back', async () => {
+    const wrapper = await mountWithTabs()
+    mocks.authFetch.mockClear()
+    mocks.pushNotification.mockClear()
+    const signals: AbortSignal[] = []
+    let abortEvents = 0
+    mocks.authFetch.mockImplementation(
+      (_input, init) =>
+        new Promise((_, reject) => {
+          const signal = init!.signal as AbortSignal
+          signals.push(signal)
+          signal.addEventListener('abort', () => {
+            abortEvents++
+            const error = new Error('aborted')
+            error.name = 'AbortError'
+            reject(error)
+          })
+        })
+    )
+
+    for (let i = 0; i < 4; i++) {
+      ;(window as any).__dinotty_ui_notify(`dispose-${i}`, 'error')
+    }
+    await flushBridge()
+    expect(mocks.authFetch).toHaveBeenCalledTimes(3)
+    expect(signals.every((signal) => !signal.aborted)).toBe(true)
+
+    wrapper.unmount()
+    mountedWrapper = undefined
+    await flushBridge()
+
+    expect(abortEvents).toBe(3)
+    expect(signals.every((signal) => signal.aborted)).toBe(true)
+    expect(mocks.authFetch).toHaveBeenCalledTimes(3)
+    const startedBodies = mocks.authFetch.mock.calls.map(([, init]) =>
+      JSON.parse(init!.body as string).body
+    )
+    expect(startedBodies).toEqual(['dispose-0', 'dispose-1', 'dispose-2'])
+    expect(mocks.pushNotification).not.toHaveBeenCalled()
   })
 })
 

--- a/frontend/src/test/AppPaneClose.test.ts
+++ b/frontend/src/test/AppPaneClose.test.ts
@@ -58,6 +58,9 @@ const mocks = vi.hoisted(() => ({
     layout: { type: 'leaf', paneId: 'p-new', title: 'Terminal', ratio: 1, zoomed: false },
   })),
   apiCloseTab: vi.fn(async () => {}),
+  clearForPaneIds: vi.fn(),
+  notificationItems: { value: [] as unknown[] },
+  unreadAttentionCount: { value: 0 },
 }))
 
 vi.mock('../composables/apiBase', () => ({
@@ -111,12 +114,13 @@ vi.mock('../composables/useKeybindings', () => ({
 vi.mock('../composables/useMonitor', () => ({ initMonitorHistory: () => {} }))
 vi.mock('../composables/useNotification', () => ({
   useNotification: () => ({
-    notifications: { value: [] },
-    unreadCount: { value: 0 },
+    notifications: mocks.notificationItems,
+    unreadAttentionCount: mocks.unreadAttentionCount,
+    historyCount: { value: 0 },
     unreadByPane: {},
     togglePanel: vi.fn(),
     clearPaneUnread: vi.fn(),
-    clearForPaneIds: vi.fn(),
+    clearForPaneIds: mocks.clearForPaneIds,
     setGoToPaneHandler: vi.fn(),
   }),
   aggregateSeverity: vi.fn(() => null),
@@ -217,6 +221,17 @@ const SplitContainerStub = defineComponent({
   },
 })
 
+const TabBarStub = defineComponent({
+  name: 'TabBar',
+  setup(_, { slots, expose }) {
+    expose({
+      hasTab: () => true,
+      scrollTabIntoView: vi.fn(),
+    })
+    return () => h('div', { class: 'tab-bar-stub' }, slots.right?.())
+  },
+})
+
 const ConfirmModalStub = defineComponent({
   name: 'ConfirmModal',
   props: ['visible', 'title', 'message', 'confirmText', 'cancelText'],
@@ -254,6 +269,7 @@ async function mountWithTabs() {
       plugins: [createPinia()],
       stubs: {
         SplitContainer: SplitContainerStub,
+        TabBar: TabBarStub,
         ConfirmCloseDialog: ConfirmCloseDialogStub,
         ConfirmModal: ConfirmModalStub,
       },
@@ -276,6 +292,9 @@ afterEach(() => {
   mountedWrapper = undefined
   vi.useRealTimers()
   localStorageMock.clear()
+  mocks.clearForPaneIds.mockReset()
+  mocks.notificationItems.value = []
+  mocks.unreadAttentionCount.value = 0
 })
 
 afterAll(() => {
@@ -394,6 +413,76 @@ describe('App.vue - onClosePane routes through confirmation gate', () => {
 
     expect(mocks.closePane).toHaveBeenCalledWith('pane-1')
     expect(mocks.apiCloseTab).not.toHaveBeenCalled()
+  })
+
+  it('marks a closed tab read only after the backend close succeeds', async () => {
+    settings.confirm_before_close_tab = false
+    mocks.closePane.mockResolvedValue(false)
+    let resolveClose!: () => void
+    mocks.apiCloseTab.mockImplementationOnce(
+      () => new Promise<void>((resolve) => (resolveClose = resolve))
+    )
+
+    const wrapper = await mountWithTabs()
+    mocks.clearForPaneIds.mockClear()
+    const splitContainer = wrapper.findComponent(SplitContainerStub)
+    splitContainer.vm.$emit('close', 'pane-1')
+    await nextTick()
+
+    expect(mocks.apiCloseTab).toHaveBeenCalledWith('tab-1')
+    expect(mocks.clearForPaneIds).not.toHaveBeenCalled()
+
+    resolveClose()
+    await Promise.resolve()
+    await nextTick()
+    expect(mocks.clearForPaneIds).toHaveBeenCalledWith(
+      expect.arrayContaining(['tab-1', 'pane-1', 'pane-2']),
+      'tab_close'
+    )
+  })
+
+  it('does not mark a tab read when the backend close fails', async () => {
+    settings.confirm_before_close_tab = false
+    mocks.closePane.mockResolvedValue(false)
+    mocks.apiCloseTab.mockRejectedValueOnce(new Error('close failed'))
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const wrapper = await mountWithTabs()
+    mocks.clearForPaneIds.mockClear()
+    const splitContainer = wrapper.findComponent(SplitContainerStub)
+    splitContainer.vm.$emit('close', 'pane-1')
+    await Promise.resolve()
+    await nextTick()
+
+    expect(mocks.clearForPaneIds).not.toHaveBeenCalled()
+  })
+})
+
+describe('App.vue - notification badge visibility', () => {
+  it('keeps the bell visible for authoritative unread attention with empty history', async () => {
+    mocks.notificationItems.value = []
+    mocks.unreadAttentionCount.value = 1
+
+    const wrapper = await mountWithTabs()
+
+    expect(wrapper.find('button.notif-btn').exists()).toBe(true)
+    expect(wrapper.find('.notif-badge').text()).toBe('1')
+  })
+})
+
+describe('App.vue - notification goto flow', () => {
+  it('passes the goto reason from the real NotificationPanel reveal path', async () => {
+    const wrapper = await mountWithTabs()
+    mocks.clearForPaneIds.mockClear()
+
+    await wrapper.findComponent({ name: 'NotificationPanel' }).vm.$emit('goto-pane', 'pane-1')
+    await Promise.resolve()
+    await nextTick()
+
+    expect(mocks.clearForPaneIds).toHaveBeenCalledWith(
+      expect.arrayContaining(['tab-1', 'pane-1', 'pane-2']),
+      'goto'
+    )
   })
 })
 

--- a/frontend/src/test/useNotification.aggregate.test.ts
+++ b/frontend/src/test/useNotification.aggregate.test.ts
@@ -29,6 +29,8 @@ vi.mock('../composables/apiBase', () => ({
 
 import { settings } from '../composables/useSettings'
 import {
+  __dispatchServerMessageForTest,
+  __resetForTest,
   useNotification,
   pushNotification,
   aggregateSeverity,
@@ -57,10 +59,25 @@ function unreadByPane(): Record<string, string> {
   return (useNotification() as any).unreadByPane as Record<string, string>
 }
 
+function seedUnread(entries: Array<[string, string, string]>) {
+  __dispatchServerMessageForTest({
+    type: 'snapshot',
+    epoch: 'test-epoch',
+    revision: '1',
+    panes: entries.map(([paneId, latestEventSeq, severity]) => ({
+      paneId,
+      latestEventSeq,
+      readThroughSeq: '0',
+      firstUnreadAt: 1,
+      severity,
+    })),
+    notifs: [],
+  })
+}
+
 describe('aggregateSeverity', () => {
   beforeEach(() => {
-    const notif = useNotification()
-    notif.clearAll()
+    __resetForTest()
     setConfig()
     toastSpy.mockClear()
     setToastInstance(toastSpy)
@@ -71,31 +88,37 @@ describe('aggregateSeverity', () => {
   })
 
   it('returns null when no pane has unread', () => {
-    pushNotification({ type: 'error', body: 'x', paneId: 'pane-a' })
+    seedUnread([['pane-a', '1', 'error']])
     expect(aggregateSeverity(['pane-b', 'pane-c'])).toBeNull()
   })
 
   it('returns the severity when single pane has unread', () => {
-    pushNotification({ type: 'warning', body: 'x', paneId: 'pane-a' })
+    seedUnread([['pane-a', '1', 'warning']])
     expect(aggregateSeverity(['pane-a'])).toBe('warning')
   })
 
   it('returns highest severity across multiple panes', () => {
-    pushNotification({ type: 'info', body: 'x', paneId: 'leaf-1' })
-    pushNotification({ type: 'error', body: 'x', paneId: 'leaf-2' })
-    pushNotification({ type: 'warning', body: 'x', paneId: 'leaf-3' })
+    seedUnread([
+      ['leaf-1', '1', 'info'],
+      ['leaf-2', '2', 'error'],
+      ['leaf-3', '3', 'warning'],
+    ])
     expect(aggregateSeverity(['leaf-1', 'leaf-2', 'leaf-3'])).toBe('error')
   })
 
   it('urgent beats error', () => {
-    pushNotification({ type: 'error', body: 'x', paneId: 'leaf-1' })
-    pushNotification({ type: 'urgent', body: 'x', paneId: 'leaf-2' })
+    seedUnread([
+      ['leaf-1', '1', 'error'],
+      ['leaf-2', '2', 'urgent'],
+    ])
     expect(aggregateSeverity(['leaf-1', 'leaf-2'])).toBe('urgent')
   })
 
   it('aggregates tab-level paneId together with leaf paneIds (split-pane scenario)', () => {
-    pushNotification({ type: 'info', body: 'x', paneId: 'tab-1' })
-    pushNotification({ type: 'error', body: 'x', paneId: 'leaf-2' })
+    seedUnread([
+      ['tab-1', '1', 'info'],
+      ['leaf-2', '2', 'error'],
+    ])
     const sev = aggregateSeverity(['tab-1', 'leaf-1', 'leaf-2'])
     expect(sev).toBe('error')
   })
@@ -103,14 +126,17 @@ describe('aggregateSeverity', () => {
 
 describe('clearForPaneIds', () => {
   beforeEach(() => {
-    const notif = useNotification()
-    notif.clearAll()
+    __resetForTest()
     setConfig()
     toastSpy.mockClear()
     setToastInstance(toastSpy)
   })
 
   it('removes unreadByPane entries for given paneIds', () => {
+    seedUnread([
+      ['pane-a', '1', 'error'],
+      ['pane-b', '2', 'info'],
+    ])
     pushNotification({ type: 'error', body: 'x', paneId: 'pane-a' })
     pushNotification({ type: 'info', body: 'x', paneId: 'pane-b' })
     expect(Object.keys(unreadByPane())).toHaveLength(2)
@@ -121,6 +147,10 @@ describe('clearForPaneIds', () => {
   })
 
   it('removes notifications whose paneId is in the set', () => {
+    seedUnread([
+      ['pane-a', '1', 'error'],
+      ['pane-b', '2', 'info'],
+    ])
     pushNotification({ type: 'error', body: 'x', paneId: 'pane-a' })
     pushNotification({ type: 'info', body: 'x', paneId: 'pane-b' })
 
@@ -131,6 +161,11 @@ describe('clearForPaneIds', () => {
   })
 
   it('clears both tab-level and leaf paneIds in one call (closeTab scenario)', () => {
+    seedUnread([
+      ['leaf-1', '1', 'error'],
+      ['leaf-2', '2', 'warning'],
+      ['pane-x', '3', 'info'],
+    ])
     pushNotification({ type: 'error', body: 'leaf1', paneId: 'leaf-1' })
     pushNotification({ type: 'warning', body: 'leaf2', paneId: 'leaf-2' })
     pushNotification({ type: 'info', body: 'other', paneId: 'pane-x' })
@@ -144,6 +179,7 @@ describe('clearForPaneIds', () => {
   })
 
   it('preserves notifications with no paneId (broadcast notifications)', () => {
+    seedUnread([['pane-a', '1', 'error']])
     pushNotification({ type: 'info', body: 'no pane', source: 'plugin' })
     pushNotification({ type: 'error', body: 'with pane', paneId: 'pane-a' })
 
@@ -154,6 +190,7 @@ describe('clearForPaneIds', () => {
   })
 
   it('is a no-op for unknown paneIds', () => {
+    seedUnread([['pane-a', '1', 'error']])
     pushNotification({ type: 'error', body: 'x', paneId: 'pane-a' })
     useNotification().clearForPaneIds(['nonexistent'])
     expect(unreadByPane()['pane-a']).toBe('error')

--- a/frontend/src/test/useNotification.push.test.ts
+++ b/frontend/src/test/useNotification.push.test.ts
@@ -31,6 +31,8 @@ vi.mock('../composables/apiBase', () => ({
 
 import { settings } from '../composables/useSettings'
 import {
+  __dispatchServerMessageForTest,
+  __resetForTest,
   useNotification,
   pushNotification,
   setToastInstance,
@@ -60,9 +62,7 @@ function unreadByPane(): Record<string, string> {
 
 describe('pushNotification - plugin notify path', () => {
   beforeEach(() => {
-    // Clear module-level state between tests.
-    const notif = useNotification()
-    notif.clearAll()
+    __resetForTest()
     setConfig()
     toastSpy.mockClear()
     setToastInstance(toastSpy)
@@ -82,8 +82,25 @@ describe('pushNotification - plugin notify path', () => {
     expect(Object.keys(unreadByPane())).toHaveLength(0)
   })
 
-  it('DOES set unreadByPane when paneId is present (terminal-style)', () => {
+  it('keeps unreadByPane authoritative even when a local push carries paneId', () => {
     pushNotification({ type: 'error', body: 'with pane', paneId: 'pane-1' })
+    expect(unreadByPane()['pane-1']).toBeUndefined()
+
+    __dispatchServerMessageForTest({
+      type: 'snapshot',
+      epoch: 'test-epoch',
+      revision: '1',
+      panes: [
+        {
+          paneId: 'pane-1',
+          latestEventSeq: '1',
+          readThroughSeq: '0',
+          firstUnreadAt: 1,
+          severity: 'error',
+        },
+      ],
+      notifs: [],
+    })
     expect(unreadByPane()['pane-1']).toBe('error')
   })
 

--- a/frontend/src/test/useSplitPaneMru.test.ts
+++ b/frontend/src/test/useSplitPaneMru.test.ts
@@ -6,12 +6,22 @@ const api = vi.hoisted(() => ({
   split: vi.fn(),
   close: vi.fn(),
 }))
+const triggers = vi.hoisted(() => ({
+  foreground: true,
+  markPaneReadIfUnread: vi.fn(),
+}))
 
 vi.mock('../composables/useTabApi', () => ({
   apiSplitPane: api.split,
   apiClosePane: api.close,
 }))
 vi.mock('../composables/useTerminal', () => ({ setActivePaneId: vi.fn() }))
+vi.mock('../composables/useAppForeground', () => ({
+  getIsAppForeground: () => triggers.foreground,
+}))
+vi.mock('../composables/useNotification', () => ({
+  markPaneReadIfUnread: triggers.markPaneReadIfUnread,
+}))
 
 import { useSplitPane } from '../composables/useSplitPane'
 
@@ -63,7 +73,10 @@ function setup() {
 }
 
 describe('useSplitPane MRU', () => {
-  beforeEach(() => vi.clearAllMocks())
+  beforeEach(() => {
+    vi.clearAllMocks()
+    triggers.foreground = true
+  })
 
   it('prepends the pane created and focused by splitPane', async () => {
     const { tab, subject } = setup()
@@ -78,6 +91,30 @@ describe('useSplitPane MRU', () => {
     subject.focusPane('a')
     expect(tab.paneMru).toEqual(['a', 'b', 'c'])
     expect(tab.activePaneId).toBe('a')
+    expect(triggers.markPaneReadIfUnread).toHaveBeenCalledWith('a', 'focus')
+  })
+
+  it('foreground-guards focus and terminal input read triggers', () => {
+    const { subject } = setup()
+    triggers.foreground = false
+    subject.focusPane('a')
+    subject.onTerminalInput('a', 'x')
+    expect(triggers.markPaneReadIfUnread).not.toHaveBeenCalled()
+  })
+
+  it('marks terminal input before the non-broadcast early return', () => {
+    const { tab, subject } = setup()
+    expect(tab.broadcastMode).toBe(false)
+    subject.onTerminalInput('b', 'x')
+    expect(triggers.markPaneReadIfUnread).toHaveBeenCalledWith('b', 'terminal_input')
+  })
+
+  it('broadcast relay sends do not mark sibling panes read', () => {
+    const { tab, subject } = setup()
+    tab.broadcastMode = true
+    subject.onTerminalInput('b', 'x')
+    expect(triggers.markPaneReadIfUnread).toHaveBeenCalledTimes(1)
+    expect(triggers.markPaneReadIfUnread).toHaveBeenCalledWith('b', 'terminal_input')
   })
 
   it('focuses the next MRU pane when the active pane closes', async () => {

--- a/src-tauri/src/embedded_server.rs
+++ b/src-tauri/src/embedded_server.rs
@@ -92,6 +92,12 @@ impl axum::extract::FromRef<AppState> for Arc<NotificationBroadcast> {
     }
 }
 
+impl axum::extract::FromRef<AppState> for (Arc<NotificationBroadcast>, Arc<SessionManager>) {
+    fn from_ref(state: &AppState) -> Self {
+        (state.notifier.clone(), state.manager.clone())
+    }
+}
+
 impl axum::extract::FromRef<AppState> for HistoryState {
     fn from_ref(state: &AppState) -> Self {
         state.history.clone()
@@ -483,6 +489,21 @@ pub fn run_server(
         let notifier = Arc::new(NotificationBroadcast::new());
         let settings_state = settings::create_settings_state();
         notifier.set_settings(settings_state.clone());
+        // Registering the notifier is independent of starting the reaper: a bind failure or
+        // startup-ordering issue here must never suppress the detached-session reaper itself
+        // (mirrors src/main.rs server wiring).
+        manager.register_notifier(Arc::clone(&notifier));
+        {
+            let notifier = Arc::clone(&notifier);
+            tokio::spawn(async move {
+                let mut interval = tokio::time::interval(notification::SWEEP_INTERVAL);
+                interval.tick().await;
+                loop {
+                    interval.tick().await;
+                    notifier.sweep(notification::now_ms());
+                }
+            });
+        }
         let history_state = HistoryState::new();
         let plugins = Arc::new(PluginManager::new());
         plugins.scan();

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -641,6 +641,9 @@ fn main() {
         rt.block_on(async move {
             let listener = embedded_server::bind_listener(port)
                 .unwrap_or_else(|e| panic!("failed to bind embedded server on port {port}: {e}"));
+            // The reaper must run unconditionally — a bind failure or notifier-registration
+            // ordering issue must never suppress it. Notification GC simply no-ops until
+            // run_server registers a notifier.
             mgr.start_cleanup_task();
             embedded_server::run_server(listener, mgr).await
         });

--- a/src/attention.rs
+++ b/src/attention.rs
@@ -3,6 +3,16 @@
 //! This module deliberately contains only data and deterministic ledger logic. Transport,
 //! locking, blocking dedup waiters, and producer validation belong to integration layers.
 
+#![allow(
+    clippy::expect_used,
+    clippy::field_reassign_with_default,
+    clippy::match_same_arms,
+    clippy::must_use_candidate,
+    clippy::needless_pass_by_value,
+    clippy::ref_option,
+    clippy::trivially_copy_pass_by_ref
+)]
+
 use std::collections::{HashMap, VecDeque};
 
 use serde::{Deserialize, Serialize};

--- a/src/attention.rs
+++ b/src/attention.rs
@@ -1,0 +1,1319 @@
+//! Backend-authoritative notification attention state.
+//!
+//! This module deliberately contains only data and deterministic ledger logic. Transport,
+//! locking, blocking dedup waiters, and producer validation belong to integration layers.
+
+use std::collections::{HashMap, VecDeque};
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::settings::NotificationConfig;
+
+/// Memory and retention bounds for attention state and request deduplication.
+pub const UNREAD_CAP: usize = 100;
+/// Maximum age of an unread event and retention period for fully-read identities.
+pub const UNREAD_TTL: u64 = 72 * 60 * 60 * 1_000;
+/// Maximum number of pane identities and pane-less notification identities, independently.
+pub const IDENTITY_CAP: usize = 512;
+/// Completed request replay horizon, measured from completion time.
+pub const DEDUP_TTL: u64 = 10 * 60 * 1_000;
+/// Maximum age of an unfinished reservation before it may be reclaimed.
+pub const RESERVATION_TIMEOUT: u64 = 30 * 1_000;
+
+mod decimal_string {
+    use serde::Serializer;
+
+    pub fn serialize<S>(value: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&value.to_string())
+    }
+}
+
+mod optional_decimal_string {
+    use serde::Serializer;
+
+    pub fn serialize<S>(value: &Option<u64>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(value) => serializer.serialize_some(&value.to_string()),
+            None => serializer.serialize_none(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    Info,
+    Success,
+    Warning,
+    Error,
+    Urgent,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UnreadEvent {
+    pub seq: u64,
+    pub occurred_at: u64,
+    pub severity: Severity,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PaneAttention {
+    pub read_through_seq: u64,
+    pub latest_event_seq: u64,
+    pub unread: VecDeque<UnreadEvent>,
+    pub read_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NotifAttention {
+    pub event_seq: u64,
+    pub occurred_at: u64,
+    pub severity: Severity,
+    pub read: bool,
+    pub read_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DedupEntry {
+    payload_hash: u64,
+    state: DedupState,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum DedupState {
+    InFlight { reserved_at: u64, generation: u64 },
+    Done { done_at: u64, outcome: DedupOutcome },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DedupOutcome {
+    MarkRead(MarkReadResult),
+    Producer(ProducerOutcome),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum ProducerOutcome {
+    #[serde(rename = "accepted")]
+    AcceptedPane {
+        #[serde(rename = "paneId")]
+        pane_id: String,
+        #[serde(rename = "eventSeq", with = "decimal_string")]
+        event_seq: u64,
+        #[serde(with = "decimal_string")]
+        revision: u64,
+    },
+    #[serde(rename = "accepted")]
+    AcceptedNotif {
+        #[serde(rename = "notifId")]
+        notif_id: String,
+        #[serde(rename = "eventSeq", with = "decimal_string")]
+        event_seq: u64,
+        #[serde(with = "decimal_string")]
+        revision: u64,
+    },
+    Suppressed {
+        reason: String,
+    },
+    NotFound,
+}
+
+#[derive(Clone, Debug)]
+pub struct AttentionLedger {
+    epoch: String,
+    next_event_seq: u64,
+    next_dedup_generation: u64,
+    revision: u64,
+    panes: HashMap<String, PaneAttention>,
+    notifs: HashMap<String, NotifAttention>,
+    dedup: HashMap<(String, String), DedupEntry>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StateDelta {
+    pub epoch: String,
+    #[serde(with = "decimal_string")]
+    pub revision: u64,
+    pub panes: Vec<PaneDelta>,
+    pub notifs: Vec<NotifDelta>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PaneDelta {
+    pub pane_id: String,
+    #[serde(with = "optional_decimal_string")]
+    pub latest_event_seq: Option<u64>,
+    #[serde(with = "optional_decimal_string")]
+    pub read_through_seq: Option<u64>,
+    pub first_unread_at: Option<u64>,
+    pub severity: Option<Severity>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub removed: Option<bool>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NotifDelta {
+    pub notif_id: String,
+    pub read: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub removed: Option<bool>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Snapshot {
+    pub epoch: String,
+    #[serde(with = "decimal_string")]
+    pub revision: u64,
+    pub panes: Vec<PaneDelta>,
+    pub notifs: Vec<NotifDelta>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MarkReadResult {
+    pub request_id: String,
+    pub epoch: String,
+    #[serde(with = "optional_decimal_string")]
+    pub applied_at_revision: Option<u64>,
+    pub results: Vec<TargetResult>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct TargetResult {
+    pub target: AttentionTarget,
+    pub status: TargetStatus,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum AttentionTarget {
+    Pane {
+        #[serde(rename = "paneId")]
+        pane_id: String,
+    },
+    Notif {
+        #[serde(rename = "notifId")]
+        notif_id: String,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TargetStatus {
+    Applied,
+    StaleEpoch,
+    Invalid,
+    NotFound,
+    Conflict,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ReserveResult {
+    Reserved { generation: u64 },
+    Replay(DedupOutcome),
+    Conflict,
+    InFlight,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum IngestSource {
+    Bell { debounce_duplicate: bool },
+    OscNotify,
+    CommandComplete { matched_rule: bool },
+    KeywordMatch { matched_rule: bool },
+    Plugin,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum IngestGateResult {
+    Accepted,
+    Suppressed(String),
+}
+
+/// Evaluates the configuration-dependent ingest gate before an event sequence is allocated.
+///
+/// `matched_rule` and `debounce_duplicate` must be computed by the caller from the current
+/// configuration and attention state.
+pub fn evaluate_ingest_gate(cfg: &NotificationConfig, source: IngestSource) -> IngestGateResult {
+    if !cfg.enabled {
+        return IngestGateResult::Suppressed("notification_disabled".into());
+    }
+
+    match source {
+        IngestSource::Bell { .. } if !cfg.bell.enabled => {
+            IngestGateResult::Suppressed("bell_disabled".into())
+        }
+        IngestSource::Bell { debounce_duplicate: true } => {
+            IngestGateResult::Suppressed("bell_debounce_duplicate".into())
+        }
+        IngestSource::Bell { debounce_duplicate: false } | IngestSource::Plugin => {
+            IngestGateResult::Accepted
+        }
+        IngestSource::OscNotify if cfg.osc_notify => IngestGateResult::Accepted,
+        IngestSource::OscNotify => IngestGateResult::Suppressed("osc_notify_disabled".into()),
+        IngestSource::CommandComplete { matched_rule }
+            if cfg.command_complete.enabled && matched_rule =>
+        {
+            IngestGateResult::Accepted
+        }
+        IngestSource::CommandComplete { .. } => {
+            IngestGateResult::Suppressed("command_complete_not_matched".into())
+        }
+        IngestSource::KeywordMatch { matched_rule } if matched_rule => IngestGateResult::Accepted,
+        IngestSource::KeywordMatch { .. } => {
+            IngestGateResult::Suppressed("keyword_match_not_matched".into())
+        }
+    }
+}
+
+impl AttentionLedger {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_epoch(Uuid::new_v4().to_string())
+    }
+
+    #[must_use]
+    pub fn with_epoch(epoch: String) -> Self {
+        Self {
+            epoch,
+            next_event_seq: 1,
+            next_dedup_generation: 1,
+            revision: 0,
+            panes: HashMap::new(),
+            notifs: HashMap::new(),
+            dedup: HashMap::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn epoch(&self) -> &str {
+        &self.epoch
+    }
+
+    #[must_use]
+    pub fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    pub fn record_pane_event(
+        &mut self,
+        pane_id: impl Into<String>,
+        occurred_at: u64,
+        severity: Severity,
+        now_ms: u64,
+    ) -> (u64, StateDelta) {
+        let mut pane_deltas = Vec::new();
+        let mut notif_deltas = Vec::new();
+        self.expire_into(now_ms, &mut pane_deltas, &mut notif_deltas);
+
+        let pane_id = pane_id.into();
+        let event_seq = self.take_event_seq();
+        let pane = self.panes.entry(pane_id.clone()).or_insert_with(|| PaneAttention {
+            read_through_seq: 0,
+            latest_event_seq: 0,
+            unread: VecDeque::new(),
+            read_at: None,
+        });
+        pane.latest_event_seq = event_seq;
+        pane.unread.push_back(UnreadEvent { seq: event_seq, occurred_at, severity });
+        pane.read_at = None;
+
+        while pane.unread.len() > UNREAD_CAP {
+            if let Some(dropped) = pane.unread.pop_front() {
+                tracing::warn!(
+                    pane_id,
+                    event_seq = dropped.seq,
+                    "[unread-drop] per-pane unread cap exceeded"
+                );
+            }
+        }
+
+        upsert_pane_delta(&mut pane_deltas, self.pane_delta(&pane_id));
+        self.enforce_identity_caps(&mut pane_deltas, &mut notif_deltas);
+        let revision = self.bump_revision();
+        (event_seq, self.delta(revision, pane_deltas, notif_deltas))
+    }
+
+    pub fn record_notif_event(
+        &mut self,
+        notif_id: impl Into<String>,
+        occurred_at: u64,
+        severity: Severity,
+        now_ms: u64,
+    ) -> (u64, StateDelta) {
+        let mut pane_deltas = Vec::new();
+        let mut notif_deltas = Vec::new();
+        self.expire_into(now_ms, &mut pane_deltas, &mut notif_deltas);
+
+        let notif_id = notif_id.into();
+        let event_seq = self.take_event_seq();
+        self.notifs.insert(
+            notif_id.clone(),
+            NotifAttention { event_seq, occurred_at, severity, read: false, read_at: None },
+        );
+
+        upsert_notif_delta(&mut notif_deltas, self.notif_delta(&notif_id));
+        self.enforce_identity_caps(&mut pane_deltas, &mut notif_deltas);
+        let revision = self.bump_revision();
+        (event_seq, self.delta(revision, pane_deltas, notif_deltas))
+    }
+
+    pub fn mark_read(
+        &mut self,
+        epoch: &str,
+        panes: &[(String, u64)],
+        notifs: &[String],
+        now_ms: u64,
+    ) -> (Option<StateDelta>, Vec<TargetResult>, Option<u64>) {
+        let mut pane_deltas = Vec::new();
+        let mut notif_deltas = Vec::new();
+        self.expire_into(now_ms, &mut pane_deltas, &mut notif_deltas);
+
+        if epoch != self.epoch {
+            let results = panes
+                .iter()
+                .map(|(pane_id, _)| TargetResult {
+                    target: AttentionTarget::Pane { pane_id: pane_id.clone() },
+                    status: TargetStatus::StaleEpoch,
+                })
+                .chain(notifs.iter().map(|notif_id| TargetResult {
+                    target: AttentionTarget::Notif { notif_id: notif_id.clone() },
+                    status: TargetStatus::StaleEpoch,
+                }))
+                .collect();
+            self.enforce_identity_caps(&mut pane_deltas, &mut notif_deltas);
+            let delta = self.finish_delta(pane_deltas, notif_deltas);
+            return (delta, results, None);
+        }
+
+        let mut results = Vec::with_capacity(panes.len() + notifs.len());
+        let mut accepted_any = false;
+        let mut changed_panes = Vec::new();
+        let mut changed_notifs = Vec::new();
+
+        for (pane_id, through_seq) in panes {
+            let status = match self.panes.get_mut(pane_id) {
+                None => TargetStatus::NotFound,
+                Some(pane) if *through_seq > pane.latest_event_seq => TargetStatus::Invalid,
+                Some(pane) => {
+                    accepted_any = true;
+                    let old_watermark = pane.read_through_seq;
+                    let was_unread = !pane.unread.is_empty();
+                    pane.read_through_seq = pane.read_through_seq.max(*through_seq);
+                    while pane
+                        .unread
+                        .front()
+                        .is_some_and(|event| event.seq <= pane.read_through_seq)
+                    {
+                        pane.unread.pop_front();
+                    }
+                    if pane.unread.is_empty() && was_unread {
+                        pane.read_through_seq = pane.latest_event_seq;
+                        pane.read_at = Some(now_ms);
+                    }
+                    if pane.read_through_seq != old_watermark
+                        || (was_unread && pane.unread.is_empty())
+                    {
+                        push_unique(&mut changed_panes, pane_id);
+                    }
+                    TargetStatus::Applied
+                }
+            };
+            results.push(TargetResult {
+                target: AttentionTarget::Pane { pane_id: pane_id.clone() },
+                status,
+            });
+        }
+
+        for notif_id in notifs {
+            let status = match self.notifs.get_mut(notif_id) {
+                None => TargetStatus::NotFound,
+                Some(notif) => {
+                    accepted_any = true;
+                    if !notif.read {
+                        notif.read = true;
+                        notif.read_at = Some(now_ms);
+                        push_unique(&mut changed_notifs, notif_id);
+                    }
+                    TargetStatus::Applied
+                }
+            };
+            results.push(TargetResult {
+                target: AttentionTarget::Notif { notif_id: notif_id.clone() },
+                status,
+            });
+        }
+
+        for id in changed_panes {
+            upsert_pane_delta(&mut pane_deltas, self.pane_delta(&id));
+        }
+        for id in changed_notifs {
+            upsert_notif_delta(&mut notif_deltas, self.notif_delta(&id));
+        }
+        self.enforce_identity_caps(&mut pane_deltas, &mut notif_deltas);
+
+        let delta = self.finish_delta(pane_deltas, notif_deltas);
+        let applied_at_revision = accepted_any.then_some(self.revision);
+        (delta, results, applied_at_revision)
+    }
+
+    pub fn pane_closed(&mut self, pane_id: &str, now_ms: u64) -> Option<StateDelta> {
+        let mut pane_deltas = Vec::new();
+        let mut notif_deltas = Vec::new();
+        self.expire_into(now_ms, &mut pane_deltas, &mut notif_deltas);
+        if self.panes.remove(pane_id).is_some() {
+            upsert_pane_delta(&mut pane_deltas, PaneDelta::removed(pane_id));
+        }
+        self.enforce_identity_caps(&mut pane_deltas, &mut notif_deltas);
+        self.finish_delta(pane_deltas, notif_deltas)
+    }
+
+    /// Reserves a deduplication key for a caller that will mutate and complete under one lock.
+    ///
+    /// The integration layer normally holds one lock across reserve → mutate → complete. The
+    /// generation guard protects the detached/reclaimed case, where a stale owner may finish
+    /// after another caller has reclaimed the reservation.
+    pub fn reserve(
+        &mut self,
+        client_id: impl Into<String>,
+        request_id: impl Into<String>,
+        payload_hash: u64,
+        now_ms: u64,
+    ) -> ReserveResult {
+        let key = (client_id.into(), request_id.into());
+        if let Some(entry) = self.dedup.get(&key) {
+            match &entry.state {
+                DedupState::InFlight { reserved_at, .. }
+                    if is_expired(*reserved_at, RESERVATION_TIMEOUT, now_ms) => {}
+                DedupState::Done { done_at, .. } if is_expired(*done_at, DEDUP_TTL, now_ms) => {}
+                DedupState::InFlight { .. } if entry.payload_hash != payload_hash => {
+                    return ReserveResult::Conflict;
+                }
+                DedupState::InFlight { .. } => return ReserveResult::InFlight,
+                DedupState::Done { .. } if entry.payload_hash != payload_hash => {
+                    return ReserveResult::Conflict;
+                }
+                DedupState::Done { outcome, .. } => {
+                    return ReserveResult::Replay(outcome.clone());
+                }
+            }
+        }
+
+        let generation = self.take_dedup_generation();
+        self.dedup.insert(
+            key,
+            DedupEntry {
+                payload_hash,
+                state: DedupState::InFlight { reserved_at: now_ms, generation },
+            },
+        );
+        ReserveResult::Reserved { generation }
+    }
+
+    pub fn complete(
+        &mut self,
+        key: &(String, String),
+        generation: u64,
+        outcome: DedupOutcome,
+        now_ms: u64,
+    ) -> bool {
+        let Some(entry) = self.dedup.get_mut(key) else {
+            return false;
+        };
+        match entry.state {
+            DedupState::InFlight { generation: active_generation, .. }
+                if active_generation == generation =>
+            {
+                entry.state = DedupState::Done { done_at: now_ms, outcome };
+                true
+            }
+            DedupState::InFlight { .. } | DedupState::Done { .. } => false,
+        }
+    }
+
+    pub fn sweep(&mut self, now_ms: u64) -> Option<StateDelta> {
+        let mut pane_deltas = Vec::new();
+        let mut notif_deltas = Vec::new();
+        self.expire_into(now_ms, &mut pane_deltas, &mut notif_deltas);
+        self.enforce_identity_caps(&mut pane_deltas, &mut notif_deltas);
+        self.finish_delta(pane_deltas, notif_deltas)
+    }
+
+    #[must_use]
+    pub fn snapshot(&self) -> Snapshot {
+        let mut panes: Vec<_> = self.panes.keys().map(|id| self.pane_delta(id)).collect();
+        let mut notifs: Vec<_> = self.notifs.keys().map(|id| self.notif_delta(id)).collect();
+        panes.sort_by(|a, b| a.pane_id.cmp(&b.pane_id));
+        notifs.sort_by(|a, b| a.notif_id.cmp(&b.notif_id));
+        Snapshot { epoch: self.epoch.clone(), revision: self.revision, panes, notifs }
+    }
+
+    #[must_use]
+    pub fn first_unread_at(&self, pane_id: &str) -> Option<u64> {
+        self.panes.get(pane_id)?.unread.front().map(|event| event.occurred_at)
+    }
+
+    fn expire_into(
+        &mut self,
+        now_ms: u64,
+        pane_deltas: &mut Vec<PaneDelta>,
+        notif_deltas: &mut Vec<NotifDelta>,
+    ) {
+        self.sweep_dedup(now_ms);
+
+        let mut changed_panes = Vec::new();
+        let mut changed_notifs = Vec::new();
+        let mut removed_panes = Vec::new();
+        let mut removed_notifs = Vec::new();
+
+        for (pane_id, pane) in &mut self.panes {
+            let old_unread_len = pane.unread.len();
+            let was_unread = !pane.unread.is_empty();
+            while pane
+                .unread
+                .front()
+                .is_some_and(|event| is_expired(event.occurred_at, UNREAD_TTL, now_ms))
+            {
+                pane.unread.pop_front();
+            }
+            if was_unread && pane.unread.is_empty() {
+                pane.read_through_seq = pane.latest_event_seq;
+                pane.read_at = Some(now_ms);
+                push_unique(&mut changed_panes, pane_id);
+            } else if pane.unread.len() < old_unread_len {
+                push_unique(&mut changed_panes, pane_id);
+            }
+        }
+
+        for (notif_id, notif) in &mut self.notifs {
+            if !notif.read && is_expired(notif.occurred_at, UNREAD_TTL, now_ms) {
+                notif.read = true;
+                notif.read_at = Some(now_ms);
+                push_unique(&mut changed_notifs, notif_id);
+            }
+        }
+
+        self.panes.retain(|pane_id, pane| {
+            let collect = pane.unread.is_empty()
+                && pane.read_at.is_some_and(|read_at| is_expired(read_at, UNREAD_TTL, now_ms));
+            if collect {
+                removed_panes.push(pane_id.clone());
+            }
+            !collect
+        });
+        self.notifs.retain(|notif_id, notif| {
+            let collect = notif.read
+                && notif.read_at.is_some_and(|read_at| is_expired(read_at, UNREAD_TTL, now_ms));
+            if collect {
+                removed_notifs.push(notif_id.clone());
+            }
+            !collect
+        });
+
+        for id in changed_panes {
+            if self.panes.contains_key(&id) {
+                upsert_pane_delta(pane_deltas, self.pane_delta(&id));
+            }
+        }
+        for id in changed_notifs {
+            if self.notifs.contains_key(&id) {
+                upsert_notif_delta(notif_deltas, self.notif_delta(&id));
+            }
+        }
+        for id in removed_panes {
+            upsert_pane_delta(pane_deltas, PaneDelta::removed(&id));
+        }
+        for id in removed_notifs {
+            upsert_notif_delta(notif_deltas, NotifDelta::removed(&id));
+        }
+    }
+
+    fn sweep_dedup(&mut self, now_ms: u64) {
+        self.dedup.retain(|_, entry| match &entry.state {
+            DedupState::InFlight { reserved_at, .. } => {
+                !is_expired(*reserved_at, RESERVATION_TIMEOUT, now_ms)
+            }
+            DedupState::Done { done_at, .. } => !is_expired(*done_at, DEDUP_TTL, now_ms),
+        });
+    }
+
+    fn enforce_identity_caps(
+        &mut self,
+        pane_deltas: &mut Vec<PaneDelta>,
+        notif_deltas: &mut Vec<NotifDelta>,
+    ) {
+        while self.panes.len() > IDENTITY_CAP {
+            let pane_id = self
+                .panes
+                .iter()
+                .filter(|(_, pane)| pane.unread.is_empty())
+                .min_by(|(left_id, left), (right_id, right)| {
+                    (left.read_at.unwrap_or(0), left.latest_event_seq, left_id.as_str()).cmp(&(
+                        right.read_at.unwrap_or(0),
+                        right.latest_event_seq,
+                        right_id.as_str(),
+                    ))
+                })
+                .or_else(|| {
+                    self.panes.iter().min_by(|(left_id, left), (right_id, right)| {
+                        let left_head = left.unread.front().expect("unread victim has a head");
+                        let right_head = right.unread.front().expect("unread victim has a head");
+                        (left_head.occurred_at, left_head.seq, left_id.as_str()).cmp(&(
+                            right_head.occurred_at,
+                            right_head.seq,
+                            right_id.as_str(),
+                        ))
+                    })
+                })
+                .map(|(id, _)| id.clone())
+                .expect("over-cap pane map cannot be empty");
+            let evicted_unread =
+                self.panes.get(&pane_id).is_some_and(|pane| !pane.unread.is_empty());
+            self.panes.remove(&pane_id);
+            if evicted_unread {
+                tracing::warn!(pane_id, "[identity-evict] evicting live unread pane identity");
+            }
+            upsert_pane_delta(pane_deltas, PaneDelta::removed(&pane_id));
+        }
+
+        while self.notifs.len() > IDENTITY_CAP {
+            let notif_id = self
+                .notifs
+                .iter()
+                .filter(|(_, notif)| notif.read)
+                .min_by(|(left_id, left), (right_id, right)| {
+                    (left.read_at.unwrap_or(0), left.event_seq, left_id.as_str()).cmp(&(
+                        right.read_at.unwrap_or(0),
+                        right.event_seq,
+                        right_id.as_str(),
+                    ))
+                })
+                .or_else(|| {
+                    self.notifs.iter().min_by(|(left_id, left), (right_id, right)| {
+                        (left.occurred_at, left.event_seq, left_id.as_str()).cmp(&(
+                            right.occurred_at,
+                            right.event_seq,
+                            right_id.as_str(),
+                        ))
+                    })
+                })
+                .map(|(id, _)| id.clone())
+                .expect("over-cap notification map cannot be empty");
+            let evicted_unread = self.notifs.get(&notif_id).is_some_and(|notif| !notif.read);
+            self.notifs.remove(&notif_id);
+            if evicted_unread {
+                tracing::warn!(
+                    notif_id,
+                    "[identity-evict] evicting live unread notification identity"
+                );
+            }
+            upsert_notif_delta(notif_deltas, NotifDelta::removed(&notif_id));
+        }
+    }
+
+    fn pane_delta(&self, pane_id: &str) -> PaneDelta {
+        let pane = &self.panes[pane_id];
+        PaneDelta {
+            pane_id: pane_id.to_owned(),
+            latest_event_seq: Some(pane.latest_event_seq),
+            read_through_seq: Some(pane.read_through_seq),
+            first_unread_at: pane.unread.front().map(|event| event.occurred_at),
+            severity: pane.unread.iter().map(|event| event.severity).max(),
+            removed: None,
+        }
+    }
+
+    fn notif_delta(&self, notif_id: &str) -> NotifDelta {
+        NotifDelta {
+            notif_id: notif_id.to_owned(),
+            read: Some(self.notifs[notif_id].read),
+            removed: None,
+        }
+    }
+
+    fn delta(&self, revision: u64, panes: Vec<PaneDelta>, notifs: Vec<NotifDelta>) -> StateDelta {
+        StateDelta { epoch: self.epoch.clone(), revision, panes, notifs }
+    }
+
+    fn finish_delta(
+        &mut self,
+        panes: Vec<PaneDelta>,
+        notifs: Vec<NotifDelta>,
+    ) -> Option<StateDelta> {
+        if panes.is_empty() && notifs.is_empty() {
+            return None;
+        }
+        let revision = self.bump_revision();
+        Some(self.delta(revision, panes, notifs))
+    }
+
+    fn take_event_seq(&mut self) -> u64 {
+        let event_seq = self.next_event_seq;
+        self.next_event_seq = self.next_event_seq.checked_add(1).expect("event sequence exhausted");
+        event_seq
+    }
+
+    fn take_dedup_generation(&mut self) -> u64 {
+        let generation = self.next_dedup_generation;
+        self.next_dedup_generation = self
+            .next_dedup_generation
+            .checked_add(1)
+            .expect("dedup reservation generation exhausted");
+        generation
+    }
+
+    fn bump_revision(&mut self) -> u64 {
+        self.revision = self.revision.checked_add(1).expect("attention revision exhausted");
+        self.revision
+    }
+}
+
+impl Default for AttentionLedger {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PaneDelta {
+    fn removed(pane_id: &str) -> Self {
+        Self {
+            pane_id: pane_id.to_owned(),
+            latest_event_seq: None,
+            read_through_seq: None,
+            first_unread_at: None,
+            severity: None,
+            removed: Some(true),
+        }
+    }
+}
+
+impl NotifDelta {
+    fn removed(notif_id: &str) -> Self {
+        Self { notif_id: notif_id.to_owned(), read: None, removed: Some(true) }
+    }
+}
+
+fn is_expired(start: u64, duration: u64, now_ms: u64) -> bool {
+    now_ms.saturating_sub(start) >= duration
+}
+
+fn upsert_pane_delta(deltas: &mut Vec<PaneDelta>, delta: PaneDelta) {
+    if let Some(existing) = deltas.iter_mut().find(|existing| existing.pane_id == delta.pane_id) {
+        *existing = delta;
+    } else {
+        deltas.push(delta);
+    }
+}
+
+fn upsert_notif_delta(deltas: &mut Vec<NotifDelta>, delta: NotifDelta) {
+    if let Some(existing) = deltas.iter_mut().find(|existing| existing.notif_id == delta.notif_id) {
+        *existing = delta;
+    } else {
+        deltas.push(delta);
+    }
+}
+
+fn push_unique(values: &mut Vec<String>, value: &str) {
+    if !values.iter().any(|existing| existing == value) {
+        values.push(value.to_owned());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Blocking-waiter semantics belong to the integration layer and are not tested here.
+
+    use super::*;
+
+    fn ledger() -> AttentionLedger {
+        AttentionLedger::with_epoch("epoch-a".into())
+    }
+
+    fn pane(id: &str, seq: u64) -> (String, u64) {
+        (id.into(), seq)
+    }
+
+    #[test]
+    fn first_event_and_same_pane_keep_exact_first_unread_at() {
+        let mut ledger = ledger();
+        ledger.record_pane_event("p", 100, Severity::Info, 100);
+        ledger.record_pane_event("p", 250, Severity::Urgent, 250);
+        assert_eq!(ledger.first_unread_at("p"), Some(100));
+        assert_eq!(ledger.panes["p"].unread.len(), 2);
+    }
+
+    #[test]
+    fn watermark_pop_is_exact_and_stale_receipt_cannot_clear_newer() {
+        let mut ledger = ledger();
+        let (first, _) = ledger.record_pane_event("p", 100, Severity::Info, 100);
+        let (second, _) = ledger.record_pane_event("p", 200, Severity::Warning, 200);
+        let (third, _) = ledger.record_pane_event("p", 300, Severity::Error, 300);
+        let epoch = ledger.epoch.clone();
+
+        let (delta, _, _) = ledger.mark_read(&epoch, &[pane("p", second)], &[], 400);
+        assert!(delta.is_some());
+        assert_eq!(ledger.first_unread_at("p"), Some(300));
+        assert_eq!(ledger.panes["p"].read_through_seq, second);
+
+        let (delta, results, applied) = ledger.mark_read(&epoch, &[pane("p", first)], &[], 500);
+        assert!(delta.is_none());
+        assert_eq!(results[0].status, TargetStatus::Applied);
+        assert_eq!(applied, Some(ledger.revision));
+        assert_eq!(ledger.panes["p"].unread.front().map(|event| event.seq), Some(third));
+    }
+
+    #[test]
+    fn union_of_reads_uses_max_watermark_and_replay_is_idempotent() {
+        let mut ledger = ledger();
+        let (_, _) = ledger.record_pane_event("p", 10, Severity::Info, 10);
+        let (second, _) = ledger.record_pane_event("p", 20, Severity::Info, 20);
+        let (third, _) = ledger.record_pane_event("p", 30, Severity::Info, 30);
+        let epoch = ledger.epoch.clone();
+        ledger.mark_read(&epoch, &[pane("p", second)], &[], 40);
+        ledger.mark_read(&epoch, &[pane("p", third)], &[], 50);
+        let revision = ledger.revision;
+        let (delta, result, applied) = ledger.mark_read(&epoch, &[pane("p", second)], &[], 60);
+        assert!(delta.is_none());
+        assert_eq!(result[0].status, TargetStatus::Applied);
+        assert_eq!(applied, Some(revision));
+        assert_eq!(ledger.panes["p"].read_through_seq, third);
+    }
+
+    #[test]
+    fn invalid_watermark_is_rejected_not_clamped_per_target() {
+        let mut ledger = ledger();
+        let (latest, _) = ledger.record_pane_event("p", 10, Severity::Info, 10);
+        let epoch = ledger.epoch.clone();
+        let (delta, results, applied) =
+            ledger.mark_read(&epoch, &[pane("p", latest + 1), pane("missing", 1)], &[], 20);
+        assert!(delta.is_none());
+        assert_eq!(results[0].status, TargetStatus::Invalid);
+        assert_eq!(results[1].status, TargetStatus::NotFound);
+        assert_eq!(applied, None);
+        assert_eq!(ledger.panes["p"].read_through_seq, 0);
+    }
+
+    #[test]
+    fn foreign_epoch_is_stale_and_new_epoch_starts_empty() {
+        let mut ledger = ledger();
+        ledger.record_pane_event("p", 10, Severity::Info, 10);
+        let (delta, results, applied) =
+            ledger.mark_read("epoch-b", &[pane("p", 1)], &["n".into()], 20);
+        assert!(delta.is_none());
+        assert!(results.iter().all(|result| result.status == TargetStatus::StaleEpoch));
+        assert_eq!(applied, None);
+        let reset = AttentionLedger::with_epoch("epoch-b".into());
+        assert!(reset.panes.is_empty());
+        assert_eq!(reset.revision, 0);
+    }
+
+    #[test]
+    fn snapshot_matches_state_and_revisions_are_monotonic() {
+        let mut ledger = ledger();
+        let (_, first) = ledger.record_pane_event("p", 10, Severity::Warning, 10);
+        let (_, second) = ledger.record_notif_event("n", 20, Severity::Error, 20);
+        let snapshot = ledger.snapshot();
+        assert!(first.revision < second.revision);
+        assert_eq!(snapshot.revision, second.revision);
+        assert_eq!(snapshot.panes, vec![ledger.pane_delta("p")]);
+        assert_eq!(snapshot.notifs, vec![ledger.notif_delta("n")]);
+
+        let json = serde_json::to_value(snapshot).unwrap();
+        assert_eq!(json["revision"], "2");
+        assert_eq!(json["panes"][0]["latestEventSeq"], "1");
+    }
+
+    #[test]
+    fn ingest_gate_table_covers_every_source_and_rule_predicate() {
+        let mut cfg = NotificationConfig::default();
+        assert_eq!(
+            evaluate_ingest_gate(&cfg, IngestSource::Bell { debounce_duplicate: false }),
+            IngestGateResult::Accepted
+        );
+        assert!(matches!(
+            evaluate_ingest_gate(&cfg, IngestSource::Bell { debounce_duplicate: true }),
+            IngestGateResult::Suppressed(_)
+        ));
+        assert_eq!(evaluate_ingest_gate(&cfg, IngestSource::OscNotify), IngestGateResult::Accepted);
+        assert!(matches!(
+            evaluate_ingest_gate(&cfg, IngestSource::CommandComplete { matched_rule: true }),
+            IngestGateResult::Suppressed(_)
+        ));
+        cfg.command_complete.enabled = true;
+        assert_eq!(
+            evaluate_ingest_gate(&cfg, IngestSource::CommandComplete { matched_rule: true }),
+            IngestGateResult::Accepted
+        );
+        assert!(matches!(
+            evaluate_ingest_gate(&cfg, IngestSource::CommandComplete { matched_rule: false }),
+            IngestGateResult::Suppressed(_)
+        ));
+        assert_eq!(
+            evaluate_ingest_gate(&cfg, IngestSource::KeywordMatch { matched_rule: true }),
+            IngestGateResult::Accepted
+        );
+        assert!(matches!(
+            evaluate_ingest_gate(&cfg, IngestSource::KeywordMatch { matched_rule: false }),
+            IngestGateResult::Suppressed(_)
+        ));
+        assert_eq!(evaluate_ingest_gate(&cfg, IngestSource::Plugin), IngestGateResult::Accepted);
+
+        cfg.osc_notify = false;
+        assert!(matches!(
+            evaluate_ingest_gate(&cfg, IngestSource::OscNotify),
+            IngestGateResult::Suppressed(_)
+        ));
+        cfg.bell.enabled = false;
+        assert!(matches!(
+            evaluate_ingest_gate(&cfg, IngestSource::Bell { debounce_duplicate: false }),
+            IngestGateResult::Suppressed(_)
+        ));
+        cfg.enabled = false;
+        assert!(matches!(
+            evaluate_ingest_gate(&cfg, IngestSource::Plugin),
+            IngestGateResult::Suppressed(_)
+        ));
+    }
+
+    #[test]
+    fn plugin_target_models_are_distinct() {
+        let mut ledger = ledger();
+        ledger.record_notif_event("plugin-notif", 10, Severity::Info, 10);
+        ledger.record_pane_event("plugin-pane", 20, Severity::Success, 20);
+        assert!(ledger.notifs.contains_key("plugin-notif"));
+        assert!(!ledger.notifs.contains_key("plugin-pane"));
+        assert!(ledger.panes.contains_key("plugin-pane"));
+    }
+
+    #[test]
+    fn fully_read_entries_are_garbage_collected_after_retention() {
+        let mut ledger = ledger();
+        let (seq, _) = ledger.record_pane_event("p", 1, Severity::Info, 1);
+        ledger.record_notif_event("n", 1, Severity::Info, 1);
+        let epoch = ledger.epoch.clone();
+        ledger.mark_read(&epoch, &[pane("p", seq)], &["n".into()], 10);
+        let delta = ledger.sweep(10 + UNREAD_TTL).unwrap();
+        assert!(ledger.panes.is_empty());
+        assert!(ledger.notifs.is_empty());
+        assert_eq!(delta.panes[0].removed, Some(true));
+        assert_eq!(delta.notifs[0].removed, Some(true));
+    }
+
+    #[test]
+    fn unread_cap_drops_oldest_and_keeps_exact_next_head() {
+        let mut ledger = ledger();
+        for index in 0..=UNREAD_CAP {
+            ledger.record_pane_event("p", index as u64, Severity::Info, index as u64);
+        }
+        assert_eq!(ledger.panes["p"].unread.len(), UNREAD_CAP);
+        assert_eq!(ledger.first_unread_at("p"), Some(1));
+    }
+
+    #[test]
+    fn unread_ttl_transitions_pane_and_notif_to_read() {
+        let mut ledger = ledger();
+        let (seq, _) = ledger.record_pane_event("p", 10, Severity::Info, 10);
+        ledger.record_notif_event("n", 10, Severity::Info, 10);
+        let delta = ledger.sweep(10 + UNREAD_TTL).unwrap();
+        assert_eq!(ledger.panes["p"].read_through_seq, seq);
+        assert!(ledger.panes["p"].unread.is_empty());
+        assert!(ledger.notifs["n"].read);
+        assert_eq!(delta.panes.len(), 1);
+        assert_eq!(delta.notifs.len(), 1);
+    }
+
+    #[test]
+    fn identity_cap_mixed_state_evicts_fully_read_first_even_pre_ttl() {
+        let mut ledger = ledger();
+        let (seq, _) = ledger.record_pane_event("read-me", 50, Severity::Info, 50);
+        let epoch = ledger.epoch.clone();
+        ledger.mark_read(&epoch, &[pane("read-me", seq)], &[], 1_000);
+        for index in 0..(IDENTITY_CAP - 1) {
+            ledger.record_pane_event(
+                format!("live-{index}"),
+                index as u64 + 100,
+                Severity::Info,
+                index as u64 + 100,
+            );
+        }
+        ledger.record_pane_event("new-live", 2_000, Severity::Info, 2_000);
+        assert!(!ledger.panes.contains_key("read-me"));
+        assert!(ledger.panes.contains_key("live-0"));
+        assert!(ledger.panes.contains_key("new-live"));
+        assert_eq!(ledger.panes.len(), IDENTITY_CAP);
+    }
+
+    #[test]
+    fn all_unread_identity_cap_evicts_oldest_first_unread() {
+        let mut ledger = ledger();
+        for index in 0..=IDENTITY_CAP {
+            ledger.record_pane_event(format!("p-{index}"), 10, Severity::Info, 10);
+        }
+        assert!(!ledger.panes.contains_key("p-0"));
+        assert_eq!(ledger.panes.len(), IDENTITY_CAP);
+    }
+
+    #[test]
+    fn unread_notif_identity_cap_breaks_timestamp_ties_by_event_sequence() {
+        let mut ledger = ledger();
+        for index in 0..=IDENTITY_CAP {
+            ledger.record_notif_event(format!("n-{index}"), 10, Severity::Info, 10);
+        }
+        assert!(!ledger.notifs.contains_key("n-0"));
+        assert!(ledger.notifs.contains_key(&format!("n-{IDENTITY_CAP}")));
+        assert_eq!(ledger.notifs.len(), IDENTITY_CAP);
+    }
+
+    #[test]
+    fn mutation_touch_expiry_is_folded_into_each_mutations_single_delta() {
+        let mut pane_record = ledger();
+        pane_record.record_pane_event("expired-pane", 0, Severity::Info, 0);
+        pane_record.record_notif_event("expired-notif", 0, Severity::Info, 0);
+        let before = pane_record.revision;
+        let (_, delta) =
+            pane_record.record_pane_event("fresh-pane", UNREAD_TTL, Severity::Success, UNREAD_TTL);
+        assert_eq!(delta.revision, before + 1);
+        assert_eq!(delta.panes.len(), 2);
+        assert_eq!(delta.notifs.len(), 1);
+        assert!(pane_record.panes["expired-pane"].unread.is_empty());
+        assert!(pane_record.notifs["expired-notif"].read);
+
+        let mut notif_record = ledger();
+        notif_record.record_pane_event("expired-pane", 0, Severity::Info, 0);
+        let before = notif_record.revision;
+        let (_, delta) = notif_record.record_notif_event(
+            "fresh-notif",
+            UNREAD_TTL,
+            Severity::Success,
+            UNREAD_TTL,
+        );
+        assert_eq!(delta.revision, before + 1);
+        assert_eq!(delta.panes.len(), 1);
+        assert_eq!(delta.notifs.len(), 1);
+
+        let mut mark_read = ledger();
+        mark_read.record_notif_event("expired-notif", 0, Severity::Info, 0);
+        let (seq, _) = mark_read.record_pane_event("live-pane", 1, Severity::Info, 1);
+        let epoch = mark_read.epoch.clone();
+        let before = mark_read.revision;
+        let (delta, _, applied) =
+            mark_read.mark_read(&epoch, &[pane("live-pane", seq)], &[], UNREAD_TTL);
+        let delta = delta.unwrap();
+        assert_eq!(delta.revision, before + 1);
+        assert_eq!(applied, Some(delta.revision));
+        assert_eq!(delta.panes.len(), 1);
+        assert_eq!(delta.notifs.len(), 1);
+
+        let mut pane_close = ledger();
+        pane_close.record_notif_event("expired-notif", 0, Severity::Info, 0);
+        pane_close.record_pane_event("closing-pane", 1, Severity::Info, 1);
+        let before = pane_close.revision;
+        let delta = pane_close.pane_closed("closing-pane", UNREAD_TTL).unwrap();
+        assert_eq!(delta.revision, before + 1);
+        assert_eq!(delta.panes, vec![PaneDelta::removed("closing-pane")]);
+        assert_eq!(delta.notifs.len(), 1);
+    }
+
+    #[test]
+    fn pane_close_emits_removal_delta() {
+        let mut ledger = ledger();
+        ledger.record_pane_event("p", 10, Severity::Info, 10);
+        let delta = ledger.pane_closed("p", 11).unwrap();
+        assert_eq!(delta.panes, vec![PaneDelta::removed("p")]);
+        assert!(!ledger.panes.contains_key("p"));
+        assert!(ledger.pane_closed("p", 12).is_none());
+    }
+
+    fn suppressed(reason: &str) -> DedupOutcome {
+        DedupOutcome::Producer(ProducerOutcome::Suppressed { reason: reason.into() })
+    }
+
+    fn key(client_id: &str, request_id: &str) -> (String, String) {
+        (client_id.into(), request_id.into())
+    }
+
+    fn generation(result: ReserveResult) -> u64 {
+        match result {
+            ReserveResult::Reserved { generation } => generation,
+            other => panic!("expected reservation, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dedup_in_flight_replay_and_conflict_state_machine() {
+        let mut ledger = ledger();
+        let generation = generation(ledger.reserve("c", "r", 7, 100));
+        assert_eq!(ledger.reserve("c", "r", 7, 101), ReserveResult::InFlight);
+        assert_eq!(ledger.reserve("c", "r", 8, 101), ReserveResult::Conflict);
+        let outcome = suppressed("disabled");
+        assert!(ledger.complete(&key("c", "r"), generation, outcome.clone(), 200));
+        assert_eq!(ledger.reserve("c", "r", 7, 201), ReserveResult::Replay(outcome));
+    }
+
+    #[test]
+    fn reservation_timeout_reclaims_zombie_without_permanent_block() {
+        let mut ledger = ledger();
+        let first = generation(ledger.reserve("c", "r", 7, 100));
+        assert_eq!(
+            ledger.reserve("c", "r", 7, 100 + RESERVATION_TIMEOUT - 1),
+            ReserveResult::InFlight
+        );
+        let second = generation(ledger.reserve("c", "r", 8, 100 + RESERVATION_TIMEOUT));
+        assert_ne!(first, second);
+        assert_eq!(ledger.dedup.len(), 1);
+    }
+
+    #[test]
+    fn dedup_ttl_starts_at_done_time_and_never_evicts_in_flight_early() {
+        let mut ledger = ledger();
+        ledger.reserve("c", "in-flight", 1, 0);
+        let generation = generation(ledger.reserve("c", "done", 2, 0));
+        ledger.complete(&key("c", "done"), generation, suppressed("x"), 1_000);
+        ledger.sweep(DEDUP_TTL);
+        assert!(ledger.dedup.contains_key(&("c".into(), "done".into())));
+        assert!(!ledger.dedup.contains_key(&("c".into(), "in-flight".into())));
+        ledger.sweep(1_000 + DEDUP_TTL);
+        assert!(!ledger.dedup.contains_key(&("c".into(), "done".into())));
+    }
+
+    #[test]
+    fn suppressed_outcome_is_cached_across_settings_change() {
+        let mut ledger = ledger();
+        let mut cfg = NotificationConfig::default();
+        cfg.enabled = false;
+        let gate = evaluate_ingest_gate(&cfg, IngestSource::Plugin);
+        assert!(matches!(gate, IngestGateResult::Suppressed(_)));
+        let generation = generation(ledger.reserve("c", "r", 1, 0));
+        let outcome = suppressed("notification_disabled");
+        ledger.complete(&key("c", "r"), generation, outcome.clone(), 1);
+        cfg.enabled = true;
+        assert_eq!(evaluate_ingest_gate(&cfg, IngestSource::Plugin), IngestGateResult::Accepted);
+        assert_eq!(ledger.reserve("c", "r", 1, 2), ReserveResult::Replay(outcome));
+    }
+
+    #[test]
+    fn multi_pane_batch_uses_one_revision_and_one_delta() {
+        let mut ledger = ledger();
+        let (a, _) = ledger.record_pane_event("a", 10, Severity::Info, 10);
+        let (b, _) = ledger.record_pane_event("b", 20, Severity::Info, 20);
+        let epoch = ledger.epoch.clone();
+        let before = ledger.revision;
+        let (delta, results, applied) =
+            ledger.mark_read(&epoch, &[pane("a", a), pane("b", b)], &[], 30);
+        let delta = delta.unwrap();
+        assert_eq!(ledger.revision, before + 1);
+        assert_eq!(delta.revision, ledger.revision);
+        assert_eq!(applied, Some(ledger.revision));
+        assert_eq!(delta.panes.len(), 2);
+        assert!(results.iter().all(|result| result.status == TargetStatus::Applied));
+    }
+
+    #[test]
+    fn detached_style_reserved_mutation_can_commit_and_install_outcome() {
+        let mut ledger = ledger();
+        let generation = generation(ledger.reserve("c", "r", 1, 0));
+        let (seq, delta) = ledger.record_pane_event("p", 10, Severity::Info, 10);
+        let outcome = DedupOutcome::Producer(ProducerOutcome::AcceptedPane {
+            pane_id: "p".into(),
+            event_seq: seq,
+            revision: delta.revision,
+        });
+        assert!(ledger.complete(&key("c", "r"), generation, outcome.clone(), 11));
+        assert_eq!(ledger.reserve("c", "r", 1, 12), ReserveResult::Replay(outcome));
+        assert_eq!(ledger.panes["p"].latest_event_seq, seq);
+    }
+
+    #[test]
+    fn stale_owner_completion_after_reclaim_is_rejected_without_mutation() {
+        let mut ledger = ledger();
+        let old_generation = generation(ledger.reserve("c", "r", 1, 100));
+        let new_generation = generation(ledger.reserve("c", "r", 2, 100 + RESERVATION_TIMEOUT));
+        let reclaimed_entry = ledger.dedup[&key("c", "r")].clone();
+
+        assert!(!ledger.complete(&key("c", "r"), old_generation, suppressed("stale"), 200));
+        assert_eq!(ledger.dedup[&key("c", "r")], reclaimed_entry);
+
+        let outcome = suppressed("fresh");
+        assert!(ledger.complete(&key("c", "r"), new_generation, outcome.clone(), 201));
+        assert_eq!(ledger.reserve("c", "r", 2, 202), ReserveResult::Replay(outcome));
+    }
+
+    #[test]
+    fn completion_cannot_overwrite_already_done_entry() {
+        let mut ledger = ledger();
+        let generation = generation(ledger.reserve("c", "r", 1, 0));
+        let original = suppressed("original");
+        assert!(ledger.complete(&key("c", "r"), generation, original.clone(), 10));
+        let done_entry = ledger.dedup[&key("c", "r")].clone();
+
+        assert!(!ledger.complete(&key("c", "r"), generation, suppressed("replacement"), 20));
+        assert_eq!(ledger.dedup[&key("c", "r")], done_entry);
+        assert_eq!(ledger.reserve("c", "r", 1, 21), ReserveResult::Replay(original));
+    }
+
+    #[test]
+    fn completed_same_key_different_payload_is_conflict() {
+        let mut ledger = ledger();
+        let generation = generation(ledger.reserve("c", "r", 1, 0));
+        assert!(ledger.complete(&key("c", "r"), generation, suppressed("cached"), 1));
+        assert_eq!(ledger.reserve("c", "r", 2, 2), ReserveResult::Conflict);
+    }
+
+    #[test]
+    fn reclaim_then_fresh_reserve_cycle_completes_and_replays() {
+        let mut ledger = ledger();
+        let old_generation = generation(ledger.reserve("c", "r", 1, 0));
+        let new_generation = generation(ledger.reserve("c", "r", 2, RESERVATION_TIMEOUT));
+        assert_ne!(old_generation, new_generation);
+
+        let outcome = suppressed("new-owner");
+        assert!(ledger.complete(&key("c", "r"), new_generation, outcome.clone(), 31_000));
+        assert_eq!(ledger.reserve("c", "r", 2, 31_001), ReserveResult::Replay(outcome));
+    }
+
+    #[test]
+    fn accepted_outcome_variants_preserve_exact_wire_shape() {
+        let pane = serde_json::to_value(ProducerOutcome::AcceptedPane {
+            pane_id: "p".into(),
+            event_seq: 7,
+            revision: 8,
+        })
+        .unwrap();
+        assert_eq!(
+            pane,
+            serde_json::json!({
+                "status": "accepted",
+                "paneId": "p",
+                "eventSeq": "7",
+                "revision": "8"
+            })
+        );
+
+        let notif = serde_json::to_value(ProducerOutcome::AcceptedNotif {
+            notif_id: "n".into(),
+            event_seq: 9,
+            revision: 10,
+        })
+        .unwrap();
+        assert_eq!(
+            notif,
+            serde_json::json!({
+                "status": "accepted",
+                "notifId": "n",
+                "eventSeq": "9",
+                "revision": "10"
+            })
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
 )]
 
 pub mod agent;
+pub mod attention;
 pub mod audit;
 pub mod auth;
 pub mod event_bus;

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,6 +178,12 @@ impl axum::extract::FromRef<AppState> for Arc<NotificationBroadcast> {
     }
 }
 
+impl axum::extract::FromRef<AppState> for (Arc<NotificationBroadcast>, Arc<SessionManager>) {
+    fn from_ref(state: &AppState) -> Self {
+        (state.notifier.clone(), state.manager.clone())
+    }
+}
+
 impl axum::extract::FromRef<AppState> for HistoryState {
     fn from_ref(state: &AppState) -> Self {
         state.history.clone()
@@ -641,7 +647,6 @@ async fn main() {
 
     let port = parse_port();
     let manager = Arc::new(SessionManager::new());
-    manager.start_cleanup_task();
 
     let monitor_state = MonitorState::new();
     monitor_state.clone().start_collector();
@@ -649,6 +654,19 @@ async fn main() {
     let notifier = Arc::new(NotificationBroadcast::new());
     let settings_state = settings::create_settings_state();
     notifier.set_settings(settings_state.clone());
+    manager.register_notifier(Arc::clone(&notifier));
+    manager.start_cleanup_task();
+    {
+        let notifier = Arc::clone(&notifier);
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(notification::SWEEP_INTERVAL);
+            interval.tick().await;
+            loop {
+                interval.tick().await;
+                notifier.sweep(notification::now_ms());
+            }
+        });
+    }
     let history_state = HistoryState::new();
 
     // Load token from dedicated file or env var; empty means first-time setup

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -1,3 +1,14 @@
+#![allow(
+    clippy::duration_suboptimal_units,
+    clippy::expect_used,
+    clippy::if_not_else,
+    clippy::manual_let_else,
+    clippy::must_use_candidate,
+    clippy::needless_pass_by_value,
+    clippy::too_many_lines,
+    clippy::unused_async
+)]
+
 use axum::{
     extract::{rejection::JsonRejection, State},
     http::StatusCode,
@@ -894,11 +905,10 @@ pub async fn post_notify(
             (StatusCode::CONFLICT, Json(serde_json::json!({ "status": "conflict" })))
                 .into_response()
         }
-        ProducerProcessResult::Retry => (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(serde_json::json!({ "status": "retry" })),
-        )
-            .into_response(),
+        ProducerProcessResult::Retry => {
+            (StatusCode::SERVICE_UNAVAILABLE, Json(serde_json::json!({ "status": "retry" })))
+                .into_response()
+        }
         ProducerProcessResult::Malformed(error) => {
             (StatusCode::BAD_REQUEST, Json(serde_json::json!({ "error": error }))).into_response()
         }
@@ -1491,10 +1501,17 @@ mod tests {
         let suppressed_request = notify_request(Some("hook-client"), Some("hook-suppressed"), None);
         let suppressed = notifier.process_notify(suppressed_request.clone(), |_| true);
         assert!(
-            matches!(suppressed, ProducerProcessResult::Outcome(ProducerOutcome::Suppressed { .. })),
+            matches!(
+                suppressed,
+                ProducerProcessResult::Outcome(ProducerOutcome::Suppressed { .. })
+            ),
             "expected a suppressed outcome, got {suppressed:?}"
         );
-        assert_eq!(notifier.hook_invocation_count(), 1, "suppressed events must never invoke hooks");
+        assert_eq!(
+            notifier.hook_invocation_count(),
+            1,
+            "suppressed events must never invoke hooks"
+        );
 
         // Re-enable, then replay the SAME suppressed key — must return the cached suppressed
         // outcome (not re-evaluate the gate), and must still never invoke hooks.

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -1,26 +1,150 @@
-use axum::{extract::State, response::IntoResponse, Json};
+use axum::{
+    extract::{rejection::JsonRejection, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
-use std::time::Instant;
-use tokio::sync::broadcast;
+use std::collections::{HashMap, VecDeque};
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc, Mutex,
+};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use tokio::sync::{mpsc, watch};
+use uuid::Uuid;
 
 use crate::{
+    attention::{
+        evaluate_ingest_gate, AttentionLedger, DedupOutcome, IngestGateResult, IngestSource,
+        MarkReadResult, ProducerOutcome, ReserveResult, Severity, Snapshot, StateDelta,
+        TargetResult, TargetStatus,
+    },
     platform::{process::CommandNoWindowExt, shell},
-    settings::SettingsState,
+    session::SessionManager,
+    settings::{NotificationConfig, SettingsState},
 };
+
+/// Notification WebSocket protocol and queue limits. Data uses a bounded wakeup lane plus the
+/// mutex-owned FIFO so overflowing clients can selectively discard state deltas. Control messages
+/// are independently bounded and are never silently dropped.
+pub const MIN_PROTOCOL_VERSION: u64 = 1;
+pub const CLOSE_UPGRADE_REQUIRED: u16 = 4001;
+pub const DATA_QUEUE_MSGS: usize = 256;
+pub const DATA_QUEUE_BYTES: usize = 1024 * 1024;
+pub const CONTROL_QUEUE_MSGS: usize = 64;
+pub const DRAIN_STALL_MS: u64 = 10_000;
+pub const SWEEP_INTERVAL: Duration = Duration::from_secs(60);
+
+pub type ConnId = u64;
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
-pub enum NotificationEvent {
-    Bell { pane_id: String },
-    Notify { pane_id: String, title: Option<String>, body: String, notification_type: String },
+pub enum ServerEnvelope {
+    // These two variants intentionally retain the legacy `type:"bell"|"notify"` shape. The
+    // protocol-v1 dispatcher recognizes the added `v` and authoritative identity fields first.
+    Bell {
+        v: u64,
+        pane_id: String,
+        title: Option<String>,
+        body: String,
+        notification_type: String,
+        #[serde(rename = "eventSeq")]
+        event_seq: String,
+        #[serde(rename = "occurredAt")]
+        occurred_at: u64,
+        severity: Severity,
+        #[serde(rename = "notifId", skip_serializing_if = "Option::is_none")]
+        notif_id: Option<String>,
+    },
+    Notify {
+        v: u64,
+        pane_id: String,
+        title: Option<String>,
+        body: String,
+        notification_type: String,
+        #[serde(rename = "eventSeq")]
+        event_seq: String,
+        #[serde(rename = "occurredAt")]
+        occurred_at: u64,
+        severity: Severity,
+        #[serde(rename = "notifId", skip_serializing_if = "Option::is_none")]
+        notif_id: Option<String>,
+    },
+    // Epoch is deliberately carried inside Snapshot/StateDelta instead of a separate envelope.
+    StateDelta {
+        #[serde(flatten)]
+        delta: StateDelta,
+    },
+    Snapshot {
+        #[serde(flatten)]
+        snapshot: Snapshot,
+    },
+    MarkReadResult {
+        #[serde(flatten)]
+        result: MarkReadResult,
+    },
+    ResyncRequired {
+        v: u64,
+    },
+}
+
+impl ServerEnvelope {
+    fn is_state_delta(&self) -> bool {
+        matches!(self, Self::StateDelta { .. })
+    }
+
+    pub fn revision(&self) -> Option<u64> {
+        match self {
+            Self::StateDelta { delta } => Some(delta.revision),
+            Self::Snapshot { snapshot } => Some(snapshot.revision),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct QueuedData {
+    envelope: ServerEnvelope,
+    bytes: usize,
+}
+
+#[derive(Debug)]
+struct ClientHandle {
+    data: VecDeque<QueuedData>,
+    data_bytes: usize,
+    data_wake: mpsc::Sender<()>,
+    control: mpsc::Sender<ServerEnvelope>,
+    disconnect: watch::Sender<bool>,
+    needs_snapshot: bool,
+    resync_enqueued: bool,
+    disconnect_requested: bool,
+}
+
+#[derive(Debug)]
+pub struct ClientRegistration {
+    pub conn_id: ConnId,
+    pub data_wake: mpsc::Receiver<()>,
+    pub control: mpsc::Receiver<ServerEnvelope>,
+    pub disconnect: watch::Receiver<bool>,
+}
+
+#[derive(Debug)]
+struct LedgerHub {
+    ledger: AttentionLedger,
+    clients: HashMap<ConnId, ClientHandle>,
 }
 
 pub struct NotificationBroadcast {
-    tx: broadcast::Sender<NotificationEvent>,
+    hub: Mutex<LedgerHub>,
+    next_conn_id: AtomicU64,
     bell_debounce: Mutex<HashMap<String, Instant>>,
     settings: Mutex<Option<SettingsState>>,
+    /// Counts `run_hooks` invocations (not actual hook commands run — that additionally
+    /// requires configured+enabled hooks). Lets tests assert the once-on-accept-only contract
+    /// without spawning real OS processes.
+    hook_invocations: AtomicU64,
 }
 
 impl Default for NotificationBroadcast {
@@ -32,39 +156,100 @@ impl Default for NotificationBroadcast {
 impl NotificationBroadcast {
     #[must_use]
     pub fn new() -> Self {
-        let (tx, _) = broadcast::channel(256);
-        Self { tx, bell_debounce: Mutex::new(HashMap::new()), settings: Mutex::new(None) }
+        Self {
+            hub: Mutex::new(LedgerHub { ledger: AttentionLedger::new(), clients: HashMap::new() }),
+            next_conn_id: AtomicU64::new(1),
+            bell_debounce: Mutex::new(HashMap::new()),
+            settings: Mutex::new(None),
+            hook_invocations: AtomicU64::new(0),
+        }
     }
 
     pub fn set_settings(&self, state: SettingsState) {
         *self.settings.lock().unwrap_or_else(std::sync::PoisonError::into_inner) = Some(state);
     }
 
-    pub fn subscribe(&self) -> broadcast::Receiver<NotificationEvent> {
-        self.tx.subscribe()
+    pub fn register_client(&self) -> ClientRegistration {
+        let conn_id = self.next_conn_id.fetch_add(1, Ordering::Relaxed);
+        // Capacity 1: the wake channel only needs to signal "there is data", never to carry one
+        // token per queued message. A `Full` try_send is therefore a successful coalesce, not
+        // backpressure — see `enqueue_data_direct`.
+        let (data_wake_tx, data_wake) = mpsc::channel(1);
+        let (control_tx, control) = mpsc::channel(CONTROL_QUEUE_MSGS);
+        let (disconnect_tx, disconnect) = watch::channel(false);
+        let mut hub = self.hub.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let snapshot = hub.ledger.snapshot();
+        let mut client = ClientHandle {
+            data: VecDeque::new(),
+            data_bytes: 0,
+            data_wake: data_wake_tx,
+            control: control_tx,
+            disconnect: disconnect_tx,
+            needs_snapshot: false,
+            resync_enqueued: false,
+            disconnect_requested: false,
+        };
+        enqueue_data_direct(&mut client, ServerEnvelope::Snapshot { snapshot });
+        hub.clients.insert(conn_id, client);
+        ClientRegistration { conn_id, data_wake, control, disconnect }
+    }
+
+    pub fn unregister_client(&self, conn_id: ConnId) {
+        self.hub.lock().unwrap_or_else(std::sync::PoisonError::into_inner).clients.remove(&conn_id);
+    }
+
+    pub fn take_data(&self, conn_id: ConnId) -> Option<ServerEnvelope> {
+        let mut hub = self.hub.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let queued = hub.clients.get_mut(&conn_id)?.data.pop_front()?;
+        let client = hub.clients.get_mut(&conn_id)?;
+        client.data_bytes = client.data_bytes.saturating_sub(queued.bytes);
+        schedule_recovery_snapshot(&mut hub, conn_id);
+        Some(queued.envelope)
     }
 
     pub fn send_bell(&self, pane_id: &str) {
-        let debounce_ms = {
-            let guard = self.settings.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-            match guard.as_ref() {
-                Some(state) => {
-                    state.try_read().map_or(300, |settings| settings.notification.bell.debounce_ms)
-                }
-                None => 300,
+        let cfg = self.notification_config();
+        let debounce_duplicate = {
+            let mut map =
+                self.bell_debounce.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            let now = Instant::now();
+            let duplicate = map.get(pane_id).is_some_and(|last| {
+                now.duration_since(*last).as_millis() < u128::from(cfg.bell.debounce_ms)
+            });
+            map.retain(|_, last| now.duration_since(*last).as_secs() < 60);
+            if !duplicate {
+                map.insert(pane_id.to_string(), now);
             }
+            duplicate
         };
-        let mut map = self.bell_debounce.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-        let now = Instant::now();
-        if let Some(last) = map.get(pane_id) {
-            if now.duration_since(*last).as_millis() < u128::from(debounce_ms) {
-                return;
-            }
+        if !matches!(
+            evaluate_ingest_gate(&cfg, IngestSource::Bell { debounce_duplicate }),
+            IngestGateResult::Accepted
+        ) {
+            return;
         }
-        map.retain(|_, last| now.duration_since(*last).as_secs() < 60);
-        map.insert(pane_id.to_string(), now);
-        drop(map);
-        let _ = self.tx.send(NotificationEvent::Bell { pane_id: pane_id.to_string() });
+
+        let occurred_at = now_ms();
+        {
+            let mut hub = self.hub.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            let (event_seq, delta) =
+                hub.ledger.record_pane_event(pane_id, occurred_at, Severity::Info, occurred_at);
+            broadcast_data(
+                &mut hub,
+                ServerEnvelope::StateDelta { delta },
+                Some(ServerEnvelope::Bell {
+                    v: MIN_PROTOCOL_VERSION,
+                    pane_id: pane_id.to_string(),
+                    title: None,
+                    body: "Bell".into(),
+                    notification_type: "bell".into(),
+                    event_seq: event_seq.to_string(),
+                    occurred_at,
+                    severity: Severity::Info,
+                    notif_id: None,
+                }),
+            );
+        }
         self.run_hooks("bell", pane_id, None, "Bell");
     }
 
@@ -75,16 +260,266 @@ impl NotificationBroadcast {
         body: &str,
         notification_type: &str,
     ) {
-        let _ = self.tx.send(NotificationEvent::Notify {
-            pane_id: pane_id.to_string(),
-            title: title.map(String::from),
-            body: body.to_string(),
-            notification_type: notification_type.to_string(),
-        });
+        let cfg = self.notification_config();
+        if !matches!(
+            evaluate_ingest_gate(&cfg, IngestSource::OscNotify),
+            IngestGateResult::Accepted
+        ) {
+            return;
+        }
+        let severity = severity_from_type(notification_type).unwrap_or(Severity::Info);
+        let occurred_at = now_ms();
+        {
+            let mut hub = self.hub.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            let (event_seq, delta) =
+                hub.ledger.record_pane_event(pane_id, occurred_at, severity, occurred_at);
+            broadcast_data(
+                &mut hub,
+                ServerEnvelope::StateDelta { delta },
+                Some(ServerEnvelope::Notify {
+                    v: MIN_PROTOCOL_VERSION,
+                    pane_id: pane_id.to_string(),
+                    title: title.map(String::from),
+                    body: body.to_string(),
+                    notification_type: notification_type.to_string(),
+                    event_seq: event_seq.to_string(),
+                    occurred_at,
+                    severity,
+                    notif_id: None,
+                }),
+            );
+        }
         self.run_hooks(notification_type, pane_id, title, body);
     }
 
+    pub fn apply_mark_read(&self, conn_id: ConnId, request: &MarkReadRequest) {
+        let now = now_ms();
+        let payload_hash = payload_hash(&("notification.mark_read", request));
+        let key = (request.client_id.clone(), request.request_id.clone());
+        let mut hub = self.hub.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let outcome = match hub.ledger.reserve(&key.0, &key.1, payload_hash, now) {
+            ReserveResult::Replay(DedupOutcome::MarkRead(result)) => {
+                enqueue_control(&mut hub, conn_id, ServerEnvelope::MarkReadResult { result });
+                return;
+            }
+            ReserveResult::InFlight => {
+                // Only reachable during a zombie RESERVATION_TIMEOUT window under the
+                // synchronous critical section. Per design C3-03, an in-flight duplicate must
+                // NOT get a conflict verdict (that would make the client drop its overlay) — send
+                // no reply at all; the client's own ack-timeout resend will later hit either
+                // Done(replay) or a reclaimed key (fresh apply).
+                tracing::debug!(
+                    "mark_read reservation in-flight for {:?}; suppressing reply, awaiting resend",
+                    key
+                );
+                return;
+            }
+            ReserveResult::Replay(_) | ReserveResult::Conflict => {
+                conflict_mark_read(request, hub.ledger.epoch())
+            }
+            ReserveResult::Reserved { generation } => {
+                let panes: Vec<_> = request
+                    .panes
+                    .iter()
+                    .filter_map(|pane| {
+                        pane.through_event_seq
+                            .parse::<u64>()
+                            .ok()
+                            .map(|seq| (pane.pane_id.clone(), seq))
+                    })
+                    .collect();
+                let notifs: Vec<_> =
+                    request.notifs.iter().map(|notif| notif.notif_id.clone()).collect();
+                let (delta, results, applied_at_revision) =
+                    hub.ledger.mark_read(&request.epoch, &panes, &notifs, now);
+                let result = MarkReadResult {
+                    request_id: request.request_id.clone(),
+                    epoch: hub.ledger.epoch().to_string(),
+                    applied_at_revision,
+                    results,
+                };
+                let installed = hub.ledger.complete(
+                    &key,
+                    generation,
+                    DedupOutcome::MarkRead(result.clone()),
+                    now,
+                );
+                debug_assert!(installed);
+                if let Some(delta) = delta {
+                    broadcast_data(&mut hub, ServerEnvelope::StateDelta { delta }, None);
+                }
+                result
+            }
+        };
+        enqueue_control(&mut hub, conn_id, ServerEnvelope::MarkReadResult { result: outcome });
+    }
+
+    pub fn sweep(&self, now: u64) {
+        let mut hub = self.hub.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(delta) = hub.ledger.sweep(now) {
+            broadcast_data(&mut hub, ServerEnvelope::StateDelta { delta }, None);
+        }
+    }
+
+    /// Notifies the ledger that a pane was authoritatively removed (tab/pane close, or the
+    /// detached-session reaper), broadcasting the resulting removal delta if the pane had any
+    /// attention state. Safe to call for a pane the ledger never tracked (no-op).
+    pub fn pane_closed(&self, pane_id: &str) {
+        let now = now_ms();
+        let mut hub = self.hub.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(delta) = hub.ledger.pane_closed(pane_id, now) {
+            broadcast_data(&mut hub, ServerEnvelope::StateDelta { delta }, None);
+        }
+    }
+
+    fn notification_config(&self) -> NotificationConfig {
+        let guard = self.settings.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard
+            .as_ref()
+            .and_then(|state| state.try_read().ok().map(|settings| settings.notification.clone()))
+            .unwrap_or_default()
+    }
+
+    fn process_notify<F>(&self, req: NotifyRequest, pane_is_live: F) -> ProducerProcessResult
+    where
+        F: FnOnce(&str) -> bool,
+    {
+        let severity = match severity_from_type(&req.notification_type) {
+            Some(severity) => severity,
+            None => return ProducerProcessResult::Malformed("invalid notification type".into()),
+        };
+        if req.source.as_deref().is_some_and(|source| source != "plugin") {
+            return ProducerProcessResult::Malformed("invalid source".into());
+        }
+        if req.client_id.is_some() != req.request_id.is_some() {
+            return ProducerProcessResult::Malformed(
+                "clientId and requestId must be provided together".into(),
+            );
+        }
+        let pane_id = req.pane_id.as_deref().filter(|id| !id.is_empty()).map(str::to_owned);
+        if pane_id.as_ref().is_some_and(|id| Uuid::parse_str(id).is_err()) {
+            return ProducerProcessResult::Malformed("invalid paneId".into());
+        }
+
+        let client_id = req.client_id.clone().unwrap_or_else(|| Uuid::new_v4().to_string());
+        let request_id = req.request_id.clone().unwrap_or_else(|| Uuid::new_v4().to_string());
+        if client_id.is_empty() || request_id.is_empty() {
+            return ProducerProcessResult::Malformed("clientId/requestId must not be empty".into());
+        }
+        let payload_hash = payload_hash(&("producer.notify", &req));
+        let key = (client_id.clone(), request_id.clone());
+        let cfg = self.notification_config();
+        let now = now_ms();
+        let mut pane_is_live = Some(pane_is_live);
+        // Hooks (spec §10) must fire exactly once, ONLY on a newly-accepted event — never on
+        // suppressed/not_found/replay/conflict — and must run AFTER the hub lock is released
+        // (run_hooks takes the settings lock and spawns processes; it must not run under the
+        // hub mutex). Stash what to call here; fire it once the guard below is dropped.
+        let mut accepted_hook: Option<(String, String, Option<String>, String)> = None;
+        let result = {
+            let mut hub = self.hub.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            match hub.ledger.reserve(&client_id, &request_id, payload_hash, now) {
+                ReserveResult::Replay(DedupOutcome::Producer(outcome)) => {
+                    ProducerProcessResult::Outcome(outcome)
+                }
+                ReserveResult::Replay(_) | ReserveResult::Conflict => {
+                    ProducerProcessResult::Conflict
+                }
+                // Only reachable during a zombie RESERVATION_TIMEOUT window under the synchronous
+                // critical section. Per design C3-03 this must not be treated as a payload
+                // conflict — it is retryable, not a genuine same-key-different-payload collision.
+                ReserveResult::InFlight => ProducerProcessResult::Retry,
+                ReserveResult::Reserved { generation } => {
+                    let outcome = match evaluate_ingest_gate(&cfg, IngestSource::Plugin) {
+                        IngestGateResult::Suppressed(reason) => {
+                            ProducerOutcome::Suppressed { reason }
+                        }
+                        IngestGateResult::Accepted => {
+                            if let Some(ref pane_id) = pane_id {
+                                if !(pane_is_live.take().expect("liveness closure used once"))(
+                                    pane_id,
+                                ) {
+                                    ProducerOutcome::NotFound
+                                } else {
+                                    let (event_seq, delta) =
+                                        hub.ledger.record_pane_event(pane_id, now, severity, now);
+                                    let revision = delta.revision;
+                                    broadcast_data(
+                                        &mut hub,
+                                        ServerEnvelope::StateDelta { delta },
+                                        Some(ServerEnvelope::Notify {
+                                            v: MIN_PROTOCOL_VERSION,
+                                            pane_id: pane_id.clone(),
+                                            title: req.title.clone(),
+                                            body: req.body.clone(),
+                                            notification_type: req.notification_type.clone(),
+                                            event_seq: event_seq.to_string(),
+                                            occurred_at: now,
+                                            severity,
+                                            notif_id: None,
+                                        }),
+                                    );
+                                    accepted_hook = Some((
+                                        req.notification_type.clone(),
+                                        pane_id.clone(),
+                                        req.title.clone(),
+                                        req.body.clone(),
+                                    ));
+                                    ProducerOutcome::AcceptedPane {
+                                        pane_id: pane_id.clone(),
+                                        event_seq,
+                                        revision,
+                                    }
+                                }
+                            } else {
+                                let notif_id = Uuid::new_v4().to_string();
+                                let (event_seq, delta) =
+                                    hub.ledger.record_notif_event(&notif_id, now, severity, now);
+                                let revision = delta.revision;
+                                broadcast_data(
+                                    &mut hub,
+                                    ServerEnvelope::StateDelta { delta },
+                                    Some(ServerEnvelope::Notify {
+                                        v: MIN_PROTOCOL_VERSION,
+                                        pane_id: String::new(),
+                                        title: req.title.clone(),
+                                        body: req.body.clone(),
+                                        notification_type: req.notification_type.clone(),
+                                        event_seq: event_seq.to_string(),
+                                        occurred_at: now,
+                                        severity,
+                                        notif_id: Some(notif_id.clone()),
+                                    }),
+                                );
+                                accepted_hook = Some((
+                                    req.notification_type.clone(),
+                                    String::new(),
+                                    req.title.clone(),
+                                    req.body.clone(),
+                                ));
+                                ProducerOutcome::AcceptedNotif { notif_id, event_seq, revision }
+                            }
+                        }
+                    };
+                    let installed = hub.ledger.complete(
+                        &key,
+                        generation,
+                        DedupOutcome::Producer(outcome.clone()),
+                        now,
+                    );
+                    debug_assert!(installed);
+                    ProducerProcessResult::Outcome(outcome)
+                }
+            }
+        };
+        if let Some((notification_type, pane_id, title, body)) = accepted_hook {
+            self.run_hooks(&notification_type, &pane_id, title.as_deref(), &body);
+        }
+        result
+    }
+
     fn run_hooks(&self, notification_type: &str, pane_id: &str, title: Option<&str>, body: &str) {
+        self.hook_invocations.fetch_add(1, Ordering::Relaxed);
         let hooks = {
             let guard = self.settings.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
             let Some(state) = guard.as_ref() else { return };
@@ -122,9 +557,7 @@ impl NotificationBroadcast {
                     .env("DINOTTY_TITLE", &env_title)
                     .env("DINOTTY_BODY", &env_body);
 
-                let result =
-                    tokio::time::timeout(std::time::Duration::from_secs(30), command.output())
-                        .await;
+                let result = tokio::time::timeout(Duration::from_secs(30), command.output()).await;
                 match result {
                     Ok(Ok(output)) => {
                         if !output.status.success() {
@@ -141,14 +574,293 @@ impl NotificationBroadcast {
             });
         }
     }
+
+    #[cfg(test)]
+    pub(crate) fn snapshot(&self) -> Snapshot {
+        self.hub.lock().unwrap_or_else(std::sync::PoisonError::into_inner).ledger.snapshot()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn broadcast_test_delta(&self, pane_id: &str, now: u64) -> StateDelta {
+        let mut hub = self.hub.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let (_, delta) = hub.ledger.record_pane_event(pane_id, now, Severity::Info, now);
+        broadcast_data(&mut hub, ServerEnvelope::StateDelta { delta: delta.clone() }, None);
+        delta
+    }
+
+    #[cfg(test)]
+    pub(crate) fn fill_control_for_test(&self, conn_id: ConnId) {
+        let mut hub = self.hub.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        for _ in 0..=CONTROL_QUEUE_MSGS {
+            enqueue_control(&mut hub, conn_id, ServerEnvelope::ResyncRequired { v: 1 });
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn client_disconnect_requested(&self, conn_id: ConnId) -> bool {
+        self.hub
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clients
+            .get(&conn_id)
+            .is_none_or(|client| client.disconnect_requested)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn hook_invocation_count(&self) -> u64 {
+        self.hook_invocations.load(Ordering::Relaxed)
+    }
 }
 
-#[derive(Deserialize)]
+fn broadcast_data(hub: &mut LedgerHub, first: ServerEnvelope, second: Option<ServerEnvelope>) {
+    let ids: Vec<_> = hub.clients.keys().copied().collect();
+    for conn_id in ids {
+        enqueue_data(hub, conn_id, first.clone());
+        if let Some(second) = &second {
+            enqueue_data(hub, conn_id, second.clone());
+        }
+    }
+}
+
+fn enqueue_data(hub: &mut LedgerHub, conn_id: ConnId, envelope: ServerEnvelope) {
+    let Some(client) = hub.clients.get_mut(&conn_id) else { return };
+    if client.disconnect_requested {
+        return;
+    }
+    if client.needs_snapshot && envelope.is_state_delta() {
+        return;
+    }
+    let bytes = serialized_len(&envelope);
+    if client.data.len() >= DATA_QUEUE_MSGS
+        || client.data_bytes.saturating_add(bytes) > DATA_QUEUE_BYTES
+    {
+        drop_queued_deltas(client);
+        client.needs_snapshot = true;
+        if !client.resync_enqueued {
+            client.resync_enqueued = true;
+            // Deviation from design §5 control-lane membership, ordering-driven: resync_required
+            // travels the DATA lane (not control) so the single FIFO guarantees it arrives
+            // strictly before the recovery snapshot enqueued just below. If resync instead rode
+            // the control lane, the writer's data-drain loop could deliver the snapshot first,
+            // and the client would adopt authoritative state before ever entering
+            // awaiting_snapshot — silently discarding every future delta. drop_queued_deltas just
+            // freed capacity, so this always fits; only StateDelta envelopes are ever dropped.
+            enqueue_data_direct(client, ServerEnvelope::ResyncRequired { v: MIN_PROTOCOL_VERSION });
+        }
+        schedule_recovery_snapshot(hub, conn_id);
+        if envelope.is_state_delta() {
+            return;
+        }
+    }
+    let Some(client) = hub.clients.get_mut(&conn_id) else { return };
+    if client.data.len() < DATA_QUEUE_MSGS
+        && client.data_bytes.saturating_add(bytes) <= DATA_QUEUE_BYTES
+    {
+        enqueue_data_direct(client, envelope);
+    }
+}
+
+fn enqueue_data_direct(client: &mut ClientHandle, envelope: ServerEnvelope) {
+    let bytes = serialized_len(&envelope);
+    if bytes > DATA_QUEUE_BYTES {
+        // Cannot ever fit, even against an empty queue.
+        request_disconnect(client);
+        return;
+    }
+    // A `Full` wake token means a wake is already pending for the writer to drain the queue —
+    // that is coalescing working as intended, not backpressure. Only a closed channel (the
+    // writer/reader half dropped) means the peer is actually gone.
+    match client.data_wake.try_send(()) {
+        Ok(()) | Err(mpsc::error::TrySendError::Full(())) => {}
+        Err(mpsc::error::TrySendError::Closed(())) => {
+            request_disconnect(client);
+            return;
+        }
+    }
+    // The aggregate bound (DATA_QUEUE_MSGS / DATA_QUEUE_BYTES) is a hard invariant for EVERY
+    // insert path here, not just the ordinary delta fast-path — a queue full of non-droppable
+    // envelopes (raised Bell/Notify cues, a stale Snapshot) must not let resync_required/the
+    // recovery snapshot push it over the limit. Evict the OLDEST entries until there's room:
+    // raised cues are expendable presentation (design §13 accepts card-body gaps) and a queued
+    // stale Snapshot is superseded by whichever snapshot follows. ResyncRequired is EXEMPT from
+    // eviction: frames are small, and each overflow cycle adds at most one before its recovery
+    // snapshot clears resync_enqueued (so multiple resync frames CAN coexist across separate
+    // overflow cycles, but their aggregate stays negligible) — losing one would leave the client
+    // with no signal that a resync happened before it eventually adopts a snapshot. Evicting the
+    // oldest non-resync entry instead also preserves the resync-before-snapshot relative order
+    // (the snapshot itself is appended strictly after, in a later call), and a non-resync entry is
+    // always available to evict since resync frames alone cannot fill the whole bound.
+    while client.data.len() >= DATA_QUEUE_MSGS
+        || client.data_bytes.saturating_add(bytes) > DATA_QUEUE_BYTES
+    {
+        let evict_at = client
+            .data
+            .iter()
+            .position(|queued| !matches!(queued.envelope, ServerEnvelope::ResyncRequired { .. }));
+        let Some(idx) = evict_at else { break };
+        let evicted = client.data.remove(idx).expect("index from position() is valid");
+        client.data_bytes = client.data_bytes.saturating_sub(evicted.bytes);
+    }
+    client.data.push_back(QueuedData { envelope, bytes });
+    client.data_bytes += bytes;
+    debug_assert!(client.data.len() <= DATA_QUEUE_MSGS, "data queue exceeded message bound");
+    debug_assert!(client.data_bytes <= DATA_QUEUE_BYTES, "data queue exceeded byte bound");
+}
+
+fn drop_queued_deltas(client: &mut ClientHandle) {
+    client.data.retain(|queued| {
+        if queued.envelope.is_state_delta() {
+            client.data_bytes = client.data_bytes.saturating_sub(queued.bytes);
+            false
+        } else {
+            true
+        }
+    });
+}
+
+fn schedule_recovery_snapshot(hub: &mut LedgerHub, conn_id: ConnId) {
+    let snapshot = hub.ledger.snapshot();
+    let envelope = ServerEnvelope::Snapshot { snapshot };
+    let bytes = serialized_len(&envelope);
+    let Some(client) = hub.clients.get_mut(&conn_id) else { return };
+    if !client.needs_snapshot || client.disconnect_requested {
+        return;
+    }
+    if client.data.len() < DATA_QUEUE_MSGS
+        && client.data_bytes.saturating_add(bytes) <= DATA_QUEUE_BYTES
+    {
+        enqueue_data_direct(client, envelope);
+        client.needs_snapshot = false;
+        client.resync_enqueued = false;
+    }
+}
+
+fn enqueue_control(hub: &mut LedgerHub, conn_id: ConnId, envelope: ServerEnvelope) {
+    let Some(client) = hub.clients.get_mut(&conn_id) else { return };
+    if client.disconnect_requested {
+        return;
+    }
+    if client.control.try_send(envelope).is_err() {
+        request_disconnect(client);
+    }
+}
+
+fn request_disconnect(client: &mut ClientHandle) {
+    client.disconnect_requested = true;
+    let _ = client.disconnect.send(true);
+}
+
+fn serialized_len(envelope: &ServerEnvelope) -> usize {
+    serde_json::to_vec(envelope).map_or(DATA_QUEUE_BYTES + 1, |json| json.len())
+}
+
+fn conflict_mark_read(request: &MarkReadRequest, epoch: &str) -> MarkReadResult {
+    let results = request
+        .panes
+        .iter()
+        .map(|pane| TargetResult {
+            target: crate::attention::AttentionTarget::Pane { pane_id: pane.pane_id.clone() },
+            status: TargetStatus::Conflict,
+        })
+        .chain(request.notifs.iter().map(|notif| TargetResult {
+            target: crate::attention::AttentionTarget::Notif { notif_id: notif.notif_id.clone() },
+            status: TargetStatus::Conflict,
+        }))
+        .collect();
+    MarkReadResult {
+        request_id: request.request_id.clone(),
+        epoch: epoch.to_string(),
+        applied_at_revision: None,
+        results,
+    }
+}
+
+fn payload_hash<T: Serialize>(payload: &T) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    serde_json::to_vec(payload).unwrap_or_default().hash(&mut hasher);
+    hasher.finish()
+}
+
+pub fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX)
+}
+
+fn severity_from_type(value: &str) -> Option<Severity> {
+    match value {
+        "info" | "bell" => Some(Severity::Info),
+        "success" => Some(Severity::Success),
+        "warning" => Some(Severity::Warning),
+        "error" => Some(Severity::Error),
+        "urgent" => Some(Severity::Urgent),
+        _ => None,
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Hash, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MarkReadRequest {
+    pub v: u64,
+    pub epoch: String,
+    pub client_id: String,
+    pub request_id: String,
+    pub reason: MarkReadReason,
+    #[serde(default)]
+    pub panes: Vec<MarkReadPane>,
+    #[serde(default)]
+    pub notifs: Vec<MarkReadNotif>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Hash, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MarkReadReason {
+    Focus,
+    TerminalInput,
+    TabActivate,
+    TabClose,
+    PaneClose,
+    Goto,
+    ActiveObserved,
+    Dismiss,
+    ClearAll,
+}
+
+#[derive(Clone, Debug, Deserialize, Hash, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MarkReadPane {
+    pub pane_id: String,
+    pub through_event_seq: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Hash, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MarkReadNotif {
+    pub notif_id: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Hash, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct NotifyRequest {
+    #[serde(default)]
+    pub client_id: Option<String>,
+    #[serde(default)]
+    pub request_id: Option<String>,
+    #[serde(default)]
+    pub source: Option<String>,
+    // camelCase's own name for this field is "paneId"; documented legacy callers
+    // (docs/notifications.en.md, scripts/notify-done.sh, users' Claude Code hooks) send the
+    // original snake_case "pane_id" — accept both.
+    #[serde(default, alias = "pane_id")]
     pub pane_id: Option<String>,
+    #[serde(default)]
     pub title: Option<String>,
     pub body: String,
-    #[serde(default = "default_notify_type")]
+    // Legacy callers send snake_case "notification_type"; some send the shorter "type".
+    #[serde(default = "default_notify_type", alias = "type", alias = "notification_type")]
     pub notification_type: String,
 }
 
@@ -156,12 +868,676 @@ fn default_notify_type() -> String {
     "info".to_string()
 }
 
-#[allow(clippy::unused_async)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum ProducerProcessResult {
+    Outcome(ProducerOutcome),
+    Conflict,
+    /// Reservation is in-flight under a zombie window; the caller should retry, not treat this
+    /// as a payload conflict.
+    Retry,
+    Malformed(String),
+}
+
 pub async fn post_notify(
-    State(notifier): State<Arc<NotificationBroadcast>>,
-    Json(req): Json<NotifyRequest>,
-) -> impl IntoResponse {
-    let pane_id = req.pane_id.unwrap_or_default();
-    notifier.send_notify(&pane_id, req.title.as_deref(), &req.body, &req.notification_type);
-    Json(serde_json::json!({ "ok": true }))
+    State((notifier, manager)): State<(Arc<NotificationBroadcast>, Arc<SessionManager>)>,
+    payload: Result<Json<NotifyRequest>, JsonRejection>,
+) -> Response {
+    let Ok(Json(req)) = payload else {
+        return (StatusCode::BAD_REQUEST, Json(serde_json::json!({ "error": "malformed" })))
+            .into_response();
+    };
+    match notifier.process_notify(req, |pane_id| {
+        manager.is_pane_in_any_tab(pane_id) && manager.sessions.contains_key(pane_id)
+    }) {
+        ProducerProcessResult::Outcome(outcome) => producer_response(outcome),
+        ProducerProcessResult::Conflict => {
+            (StatusCode::CONFLICT, Json(serde_json::json!({ "status": "conflict" })))
+                .into_response()
+        }
+        ProducerProcessResult::Retry => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({ "status": "retry" })),
+        )
+            .into_response(),
+        ProducerProcessResult::Malformed(error) => {
+            (StatusCode::BAD_REQUEST, Json(serde_json::json!({ "error": error }))).into_response()
+        }
+    }
+}
+
+fn producer_response(outcome: ProducerOutcome) -> Response {
+    match outcome {
+        ProducerOutcome::AcceptedPane { pane_id, event_seq, revision } => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "paneId": pane_id,
+                "eventSeq": event_seq.to_string(),
+                "revision": revision.to_string()
+            })),
+        )
+            .into_response(),
+        ProducerOutcome::AcceptedNotif { notif_id, event_seq, revision } => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "notifId": notif_id,
+                "eventSeq": event_seq.to_string(),
+                "revision": revision.to_string()
+            })),
+        )
+            .into_response(),
+        ProducerOutcome::Suppressed { reason } => {
+            (StatusCode::OK, Json(serde_json::json!({ "status": "suppressed", "reason": reason })))
+                .into_response()
+        }
+        ProducerOutcome::NotFound => {
+            (StatusCode::NOT_FOUND, Json(serde_json::json!({ "status": "not_found" })))
+                .into_response()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::to_bytes;
+    use std::cell::Cell;
+    use tokio::sync::mpsc::error::TryRecvError;
+
+    fn notify_request(
+        client_id: Option<&str>,
+        request_id: Option<&str>,
+        pane_id: Option<&str>,
+    ) -> NotifyRequest {
+        NotifyRequest {
+            client_id: client_id.map(str::to_string),
+            request_id: request_id.map(str::to_string),
+            source: Some("plugin".into()),
+            pane_id: pane_id.map(str::to_string),
+            title: Some("Test".into()),
+            body: "Body".into(),
+            notification_type: "info".into(),
+        }
+    }
+
+    fn pane_seq(snapshot: &Snapshot, pane_id: &str) -> u64 {
+        snapshot
+            .panes
+            .iter()
+            .find(|pane| pane.pane_id == pane_id)
+            .and_then(|pane| pane.latest_event_seq)
+            .expect("pane must have a latest event")
+    }
+
+    fn mark_read_request(
+        snapshot: &Snapshot,
+        request_id: &str,
+        panes: &[&str],
+        notifs: &[&str],
+    ) -> MarkReadRequest {
+        MarkReadRequest {
+            v: MIN_PROTOCOL_VERSION,
+            epoch: snapshot.epoch.clone(),
+            client_id: "reader-client".into(),
+            request_id: request_id.into(),
+            reason: MarkReadReason::Dismiss,
+            panes: panes
+                .iter()
+                .map(|pane_id| MarkReadPane {
+                    pane_id: (*pane_id).into(),
+                    through_event_seq: pane_seq(snapshot, pane_id).to_string(),
+                })
+                .collect(),
+            notifs: notifs
+                .iter()
+                .map(|notif_id| MarkReadNotif { notif_id: (*notif_id).into() })
+                .collect(),
+        }
+    }
+
+    fn accepted_notif_id(result: ProducerProcessResult) -> String {
+        match result {
+            ProducerProcessResult::Outcome(ProducerOutcome::AcceptedNotif { notif_id, .. }) => {
+                notif_id
+            }
+            other => panic!("expected accepted pane-less notification, got {other:?}"),
+        }
+    }
+
+    async fn response_json(response: Response) -> serde_json::Value {
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    #[test]
+    fn data_overflow_emits_resync_before_recovery_snapshot_on_data_lane() {
+        let notifier = NotificationBroadcast::new();
+        let mut registration = notifier.register_client();
+        registration.data_wake.try_recv().unwrap();
+        assert!(matches!(
+            notifier.take_data(registration.conn_id),
+            Some(ServerEnvelope::Snapshot { .. })
+        ));
+
+        // Moderate-size deltas (small enough that the recovery snapshot itself still fits under
+        // the byte cap) accumulate in the queue until the byte cap trips. Stop broadcasting the
+        // instant it does: the recovery snapshot is enqueued (and flags cleared) in the SAME
+        // call that trips it, so a later iteration would just queue normally again and this test
+        // would observe a second overflow cycle instead of the first one.
+        let pane_id = "p".repeat(32 * 1024);
+        let queue_len = |notifier: &NotificationBroadcast| {
+            notifier
+                .hub
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clients
+                .get(&registration.conn_id)
+                .map_or(0, |client| client.data.len())
+        };
+        let mut previous_len = 0usize;
+        for i in 0..DATA_QUEUE_MSGS {
+            notifier.broadcast_test_delta(&pane_id, i as u64);
+            let current_len = queue_len(&notifier);
+            // Normal accumulation grows the queue by exactly one message per call. A
+            // drop-then-requeue cycle (overflow) instead resets it down to two (resync +
+            // recovery snapshot) — detect that transition and stop right there.
+            if current_len <= previous_len {
+                break;
+            }
+            previous_len = current_len;
+        }
+
+        assert!(!notifier.client_disconnect_requested(registration.conn_id));
+        // resync_required now travels the DATA lane exclusively; control carries only
+        // mark_read_result.
+        assert!(matches!(registration.control.try_recv(), Err(TryRecvError::Empty)));
+
+        // FIFO ordering: resync_required MUST precede the recovery snapshot on the single data
+        // queue, so a client never adopts authoritative state before it knows a resync happened.
+        // (The queued snapshot was captured at overflow time; the ledger's live revision has
+        // since kept advancing from further broadcasts the client never saw, so only the
+        // envelope ORDER is asserted here, not equality with the current live snapshot.)
+        match notifier.take_data(registration.conn_id) {
+            Some(ServerEnvelope::ResyncRequired { v: MIN_PROTOCOL_VERSION }) => {}
+            other => panic!("expected resync_required first, got {other:?}"),
+        }
+        match notifier.take_data(registration.conn_id) {
+            Some(ServerEnvelope::Snapshot { .. }) => {}
+            other => panic!("expected recovery snapshot after resync, got {other:?}"),
+        }
+        assert!(notifier.take_data(registration.conn_id).is_none());
+    }
+
+    #[test]
+    fn overflow_with_non_droppable_heavy_queue_still_respects_the_bound() {
+        // A queue full of NON-droppable envelopes (here: raised Notify cues) must never let
+        // resync_required + the recovery snapshot push it past the aggregate bound —
+        // drop_queued_deltas alone cannot reclaim anything here, since there are no StateDelta
+        // entries to drop.
+        let notifier = NotificationBroadcast::new();
+        let registration = notifier.register_client();
+        notifier.take_data(registration.conn_id).unwrap(); // snapshot
+
+        {
+            let mut hub = notifier.hub.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            let client = hub.clients.get_mut(&registration.conn_id).unwrap();
+            for i in 0..DATA_QUEUE_MSGS {
+                let envelope = ServerEnvelope::Notify {
+                    v: MIN_PROTOCOL_VERSION,
+                    pane_id: format!("p{i}"),
+                    title: None,
+                    body: "b".into(),
+                    notification_type: "info".into(),
+                    event_seq: "1".into(),
+                    occurred_at: 1,
+                    severity: Severity::Info,
+                    notif_id: None,
+                };
+                let bytes = serialized_len(&envelope);
+                client.data.push_back(QueuedData { envelope, bytes });
+                client.data_bytes += bytes;
+            }
+        }
+
+        // Trip overflow: drop_queued_deltas finds nothing droppable, yet resync_required + the
+        // recovery snapshot must still land within DATA_QUEUE_MSGS / DATA_QUEUE_BYTES.
+        notifier.broadcast_test_delta("trigger", 1);
+
+        let (len, bytes) = {
+            let hub = notifier.hub.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            let client = hub.clients.get(&registration.conn_id).unwrap();
+            (client.data.len(), client.data_bytes)
+        };
+        assert!(len <= DATA_QUEUE_MSGS, "queue exceeded message bound: {len}");
+        assert!(bytes <= DATA_QUEUE_BYTES, "queue exceeded byte bound: {bytes}");
+
+        // Whatever survives eviction, FIFO ordering must still hold: a resync_required (if
+        // present) must precede any snapshot.
+        let mut saw_resync = false;
+        while let Some(envelope) = notifier.take_data(registration.conn_id) {
+            match envelope {
+                ServerEnvelope::ResyncRequired { .. } => saw_resync = true,
+                ServerEnvelope::Snapshot { .. } => {
+                    assert!(saw_resync, "snapshot must not precede resync_required");
+                }
+                _ => {}
+            }
+        }
+        assert!(saw_resync, "expected resync_required to have survived eviction");
+    }
+
+    #[test]
+    fn full_control_lane_requests_disconnect_without_blocking_ledger() {
+        let notifier = NotificationBroadcast::new();
+        let registration = notifier.register_client();
+
+        notifier.fill_control_for_test(registration.conn_id);
+        assert!(notifier.client_disconnect_requested(registration.conn_id));
+
+        // A subsequent ledger mutation and snapshot prove the hub mutex was released rather than
+        // waiting for control-lane capacity.
+        let before = notifier.snapshot().revision;
+        let delta = notifier.broadcast_test_delta("still-responsive", 10);
+        assert_eq!(delta.revision, before + 1);
+        assert_eq!(notifier.snapshot().revision, delta.revision);
+    }
+
+    #[test]
+    fn multi_target_mark_read_broadcasts_one_single_revision_delta() {
+        let notifier = NotificationBroadcast::new();
+        let now = now_ms();
+        notifier.broadcast_test_delta("pane-a", now);
+        notifier.broadcast_test_delta("pane-b", now + 1);
+        let notif_id = accepted_notif_id(
+            notifier
+                .process_notify(notify_request(Some("producer"), Some("multi"), None), |_| true),
+        );
+        let snapshot = notifier.snapshot();
+        let mut registration = notifier.register_client();
+        assert!(matches!(
+            notifier.take_data(registration.conn_id),
+            Some(ServerEnvelope::Snapshot { .. })
+        ));
+
+        let request =
+            mark_read_request(&snapshot, "multi-read", &["pane-a", "pane-b"], &[&notif_id]);
+        notifier.apply_mark_read(registration.conn_id, &request);
+
+        let result = match registration.control.try_recv().unwrap() {
+            ServerEnvelope::MarkReadResult { result } => result,
+            other => panic!("expected mark_read_result, got {other:?}"),
+        };
+        let delta = match notifier.take_data(registration.conn_id) {
+            Some(ServerEnvelope::StateDelta { delta }) => delta,
+            other => panic!("expected one state_delta, got {other:?}"),
+        };
+        assert_eq!(result.applied_at_revision, Some(delta.revision));
+        assert_eq!(delta.panes.len(), 2);
+        assert_eq!(delta.notifs.len(), 1);
+        assert_eq!(result.results.len(), 3);
+        assert!(result.results.iter().all(|target| target.status == TargetStatus::Applied));
+        assert!(notifier.take_data(registration.conn_id).is_none());
+    }
+
+    #[test]
+    fn mark_read_happy_path_returns_per_target_results_and_delta() {
+        let notifier = NotificationBroadcast::new();
+        notifier.broadcast_test_delta("pane", now_ms());
+        let notif_id = accepted_notif_id(
+            notifier
+                .process_notify(notify_request(Some("producer"), Some("happy"), None), |_| true),
+        );
+        let snapshot = notifier.snapshot();
+        let mut registration = notifier.register_client();
+        notifier.take_data(registration.conn_id).unwrap();
+
+        let request = mark_read_request(&snapshot, "happy-read", &["pane"], &[&notif_id]);
+        notifier.apply_mark_read(registration.conn_id, &request);
+
+        let result = match registration.control.try_recv().unwrap() {
+            ServerEnvelope::MarkReadResult { result } => result,
+            other => panic!("expected mark_read_result, got {other:?}"),
+        };
+        let delta = match notifier.take_data(registration.conn_id) {
+            Some(ServerEnvelope::StateDelta { delta }) => delta,
+            other => panic!("expected state_delta, got {other:?}"),
+        };
+        assert_eq!(result.request_id, "happy-read");
+        assert_eq!(result.applied_at_revision, Some(delta.revision));
+        assert_eq!(result.results.len(), 2);
+        assert!(result.results.iter().all(|target| target.status == TargetStatus::Applied));
+        assert_eq!(delta.panes.len(), 1);
+        assert_eq!(delta.notifs.len(), 1);
+    }
+
+    #[test]
+    fn already_read_target_acks_current_revision_without_delta() {
+        let notifier = NotificationBroadcast::new();
+        notifier.broadcast_test_delta("pane", now_ms());
+        let snapshot = notifier.snapshot();
+        let mut registration = notifier.register_client();
+        notifier.take_data(registration.conn_id).unwrap();
+
+        let first = mark_read_request(&snapshot, "first-read", &["pane"], &[]);
+        notifier.apply_mark_read(registration.conn_id, &first);
+        registration.control.try_recv().unwrap();
+        notifier.take_data(registration.conn_id).unwrap();
+        let current_revision = notifier.snapshot().revision;
+
+        let replay_as_new_request = mark_read_request(&snapshot, "already-read", &["pane"], &[]);
+        notifier.apply_mark_read(registration.conn_id, &replay_as_new_request);
+        let result = match registration.control.try_recv().unwrap() {
+            ServerEnvelope::MarkReadResult { result } => result,
+            other => panic!("expected mark_read_result, got {other:?}"),
+        };
+
+        assert_eq!(result.applied_at_revision, Some(current_revision));
+        assert_eq!(result.results[0].status, TargetStatus::Applied);
+        assert_eq!(notifier.snapshot().revision, current_revision);
+        assert!(notifier.take_data(registration.conn_id).is_none());
+    }
+
+    #[test]
+    fn producer_replay_returns_cached_outcome_without_second_notif_id() {
+        let notifier = NotificationBroadcast::new();
+        let request = notify_request(Some("producer-client"), Some("request-1"), None);
+
+        let first = notifier.process_notify(request.clone(), |_| true);
+        let second = notifier.process_notify(request, |_| true);
+
+        assert_eq!(second, first);
+        let snapshot = notifier.snapshot();
+        assert_eq!(snapshot.revision, 1);
+        assert_eq!(snapshot.notifs.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn legacy_post_notify_without_dedup_ids_works_end_to_end() {
+        let notifier = Arc::new(NotificationBroadcast::new());
+        let manager = Arc::new(SessionManager::new());
+        let request = notify_request(None, None, None);
+
+        let response = post_notify(
+            State((Arc::clone(&notifier), manager)),
+            Ok::<_, JsonRejection>(Json(request)),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert!(body.get("notifId").and_then(serde_json::Value::as_str).is_some());
+        assert_eq!(notifier.snapshot().notifs.len(), 1);
+    }
+
+    #[test]
+    fn unknown_pane_outcome_is_cached_without_creating_ghost_identity() {
+        let notifier = NotificationBroadcast::new();
+        let pane_id = Uuid::new_v4().to_string();
+        let request = notify_request(Some("producer-client"), Some("missing-pane"), Some(&pane_id));
+        let liveness_checks = Cell::new(0);
+
+        let first = notifier.process_notify(request.clone(), |_| {
+            liveness_checks.set(liveness_checks.get() + 1);
+            false
+        });
+        let second = notifier.process_notify(request, |_| {
+            liveness_checks.set(liveness_checks.get() + 1);
+            false
+        });
+
+        assert_eq!(first, ProducerProcessResult::Outcome(ProducerOutcome::NotFound));
+        assert_eq!(second, first);
+        assert_eq!(liveness_checks.get(), 1, "replay should use the cached not_found outcome");
+        assert_eq!(producer_response(ProducerOutcome::NotFound).status(), StatusCode::NOT_FOUND);
+        let snapshot = notifier.snapshot();
+        assert_eq!(snapshot.revision, 0);
+        assert!(snapshot.panes.is_empty());
+        assert!(snapshot.notifs.is_empty());
+    }
+
+    #[test]
+    fn registered_client_receives_snapshot_then_newer_delta_fifo() {
+        let notifier = NotificationBroadcast::new();
+        let registration = notifier.register_client();
+        let delta = notifier.broadcast_test_delta("pane", 10);
+
+        let snapshot = match notifier.take_data(registration.conn_id) {
+            Some(ServerEnvelope::Snapshot { snapshot }) => snapshot,
+            other => panic!("snapshot must be first, got {other:?}"),
+        };
+        let queued_delta = match notifier.take_data(registration.conn_id) {
+            Some(ServerEnvelope::StateDelta { delta }) => delta,
+            other => panic!("delta must follow snapshot, got {other:?}"),
+        };
+
+        assert_eq!(queued_delta, delta);
+        assert!(queued_delta.revision > snapshot.revision);
+        assert!(notifier.take_data(registration.conn_id).is_none());
+    }
+
+    #[test]
+    fn wake_coalescing_survives_many_enqueues_without_disconnect() {
+        let notifier = NotificationBroadcast::new();
+        let mut registration = notifier.register_client();
+        registration.data_wake.try_recv().unwrap();
+        notifier.take_data(registration.conn_id).unwrap(); // snapshot
+
+        // Enqueue far more state deltas than the wake channel's capacity-1 token could carry one
+        // per message. Coalescing (Full => success) must never trip disconnect.
+        for i in 0..64u64 {
+            notifier.broadcast_test_delta("pane", i);
+        }
+        assert!(!notifier.client_disconnect_requested(registration.conn_id));
+
+        // A single wake token can drain the whole queue.
+        registration.data_wake.try_recv().unwrap();
+        let mut drained = 0;
+        while notifier.take_data(registration.conn_id).is_some() {
+            drained += 1;
+        }
+        assert_eq!(drained, 64);
+        assert!(!notifier.client_disconnect_requested(registration.conn_id));
+    }
+
+    #[test]
+    fn legacy_snake_case_notify_body_deserializes_pane_and_severity() {
+        // Exact body from docs/notifications.en.md's Claude Code hook example (line 72).
+        let body = r#"{"body":"Claude needs your input","title":"Claude Code","notification_type":"warning","pane_id":"11111111-1111-1111-1111-111111111111"}"#;
+        let req: NotifyRequest = serde_json::from_str(body).unwrap();
+        assert_eq!(
+            req.pane_id.as_deref(),
+            Some("11111111-1111-1111-1111-111111111111"),
+            "legacy snake_case pane_id must deserialize"
+        );
+        assert_eq!(severity_from_type(&req.notification_type), Some(Severity::Warning));
+    }
+
+    #[test]
+    fn pane_closed_broadcasts_removal_delta() {
+        let notifier = NotificationBroadcast::new();
+        notifier.broadcast_test_delta("pane", now_ms());
+        let registration = notifier.register_client();
+        notifier.take_data(registration.conn_id).unwrap(); // snapshot
+
+        notifier.pane_closed("pane");
+
+        let delta = match notifier.take_data(registration.conn_id) {
+            Some(ServerEnvelope::StateDelta { delta }) => delta,
+            other => panic!("expected removal delta, got {other:?}"),
+        };
+        assert!(delta.panes.iter().any(|p| p.pane_id == "pane" && p.removed == Some(true)));
+    }
+
+    #[test]
+    fn pane_closed_on_untracked_pane_is_a_harmless_noop() {
+        let notifier = NotificationBroadcast::new();
+        // Must not panic and must not fabricate ledger state for a pane that never had an event.
+        notifier.pane_closed("never-tracked");
+        assert!(notifier.snapshot().panes.is_empty());
+    }
+
+    #[test]
+    fn dedup_in_flight_during_mark_read_produces_no_control_message() {
+        let notifier = NotificationBroadcast::new();
+        notifier.broadcast_test_delta("pane", now_ms());
+        let snapshot = notifier.snapshot();
+        let mut registration = notifier.register_client();
+        notifier.take_data(registration.conn_id).unwrap(); // snapshot
+
+        let request = mark_read_request(&snapshot, "in-flight-read", &["pane"], &[]);
+        {
+            // Manually reserve the dedup key WITHOUT completing, simulating the zombie
+            // in-flight window that is otherwise unreachable under the synchronous critical
+            // section.
+            let mut hub = notifier.hub.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            let key = (request.client_id.clone(), request.request_id.clone());
+            let hash = payload_hash(&("notification.mark_read", &request));
+            let reserved = hub.ledger.reserve(&key.0, &key.1, hash, now_ms());
+            assert!(matches!(reserved, ReserveResult::Reserved { .. }));
+        }
+
+        notifier.apply_mark_read(registration.conn_id, &request);
+
+        assert!(matches!(registration.control.try_recv(), Err(TryRecvError::Empty)));
+    }
+
+    #[tokio::test]
+    async fn producer_in_flight_reservation_returns_503_retry() {
+        let notifier = Arc::new(NotificationBroadcast::new());
+        let manager = Arc::new(SessionManager::new());
+        let request = notify_request(Some("producer"), Some("in-flight"), None);
+        {
+            let mut hub = notifier.hub.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            let hash = payload_hash(&("producer.notify", &request));
+            let reserved = hub.ledger.reserve("producer", "in-flight", hash, now_ms());
+            assert!(matches!(reserved, ReserveResult::Reserved { .. }));
+        }
+
+        let response = post_notify(
+            State((Arc::clone(&notifier), manager)),
+            Ok::<_, JsonRejection>(Json(request)),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = response_json(response).await;
+        assert_eq!(body.get("status").and_then(serde_json::Value::as_str), Some("retry"));
+    }
+
+    #[test]
+    fn legacy_snake_case_body_through_process_notify_targets_live_pane() {
+        // Exact body shape from docs/notifications.en.md's Claude Code hook example (line 72),
+        // driven through the real dispatch (process_notify, which post_notify calls) with a LIVE
+        // pane (liveness closure true) — unlike the pure-deserialization test above, this
+        // exercises the full accepted path: gate, liveness check, record, response shape.
+        let notifier = NotificationBroadcast::new();
+        let pane_id = Uuid::new_v4().to_string();
+        let body = format!(
+            r#"{{"body":"Claude needs your input","title":"Claude Code","notification_type":"warning","pane_id":"{pane_id}"}}"#
+        );
+        let req: NotifyRequest = serde_json::from_str(&body).unwrap();
+
+        let result = notifier.process_notify(req, |_| true);
+        match result {
+            ProducerProcessResult::Outcome(ProducerOutcome::AcceptedPane {
+                pane_id: accepted_pane,
+                ..
+            }) => assert_eq!(accepted_pane, pane_id),
+            other => panic!("expected accepted pane-targeted notification, got {other:?}"),
+        }
+
+        let snapshot = notifier.snapshot();
+        let pane = snapshot.panes.iter().find(|p| p.pane_id == pane_id).expect("pane recorded");
+        assert_eq!(pane.severity, Some(Severity::Warning));
+    }
+
+    #[test]
+    fn accepted_producer_event_invokes_hooks_exactly_once() {
+        let notifier = NotificationBroadcast::new();
+        let request = notify_request(Some("hook-client"), Some("hook-accept"), None);
+        let result = notifier.process_notify(request, |_| true);
+        assert!(matches!(
+            result,
+            ProducerProcessResult::Outcome(ProducerOutcome::AcceptedNotif { .. })
+        ));
+        assert_eq!(notifier.hook_invocation_count(), 1);
+    }
+
+    #[test]
+    fn replayed_and_suppressed_producer_events_never_invoke_hooks() {
+        let notifier = NotificationBroadcast::new();
+        let request = notify_request(Some("hook-client"), Some("hook-replay"), None);
+
+        // First call accepts (and invokes hooks once); the second is a pure dedup replay.
+        let first = notifier.process_notify(request.clone(), |_| true);
+        assert!(matches!(
+            first,
+            ProducerProcessResult::Outcome(ProducerOutcome::AcceptedNotif { .. })
+        ));
+        assert_eq!(notifier.hook_invocation_count(), 1);
+
+        let second = notifier.process_notify(request, |_| true);
+        assert_eq!(second, first, "replay must return the cached outcome verbatim");
+        assert_eq!(
+            notifier.hook_invocation_count(),
+            1,
+            "replay must never invoke hooks a second time"
+        );
+
+        // Now exercise a GENUINELY suppressed outcome (the above never actually produced one):
+        // disable notification ingest, then issue a brand-new requestId.
+        let settings_state: SettingsState =
+            Arc::new(tokio::sync::RwLock::new(crate::settings::Settings::default()));
+        notifier.set_settings(settings_state.clone());
+        settings_state.try_write().unwrap().notification.enabled = false;
+
+        let suppressed_request = notify_request(Some("hook-client"), Some("hook-suppressed"), None);
+        let suppressed = notifier.process_notify(suppressed_request.clone(), |_| true);
+        assert!(
+            matches!(suppressed, ProducerProcessResult::Outcome(ProducerOutcome::Suppressed { .. })),
+            "expected a suppressed outcome, got {suppressed:?}"
+        );
+        assert_eq!(notifier.hook_invocation_count(), 1, "suppressed events must never invoke hooks");
+
+        // Re-enable, then replay the SAME suppressed key — must return the cached suppressed
+        // outcome (not re-evaluate the gate), and must still never invoke hooks.
+        settings_state.try_write().unwrap().notification.enabled = true;
+        let replayed_suppressed = notifier.process_notify(suppressed_request, |_| true);
+        assert_eq!(
+            replayed_suppressed, suppressed,
+            "replay must return the cached suppressed outcome verbatim"
+        );
+        assert_eq!(notifier.hook_invocation_count(), 1);
+    }
+
+    #[test]
+    fn pane_closed_notify_is_a_noop_before_a_notifier_is_registered() {
+        // A bare SessionManager (as constructed in unit tests elsewhere in this crate) must not
+        // panic when a removal site calls pane_closed_notify before start_cleanup_task has ever
+        // registered a notifier.
+        let manager = SessionManager::new();
+        manager.pane_closed_notify("never-registered");
+    }
+
+    #[test]
+    fn register_notifier_wiring_broadcasts_removal_delta() {
+        // Covers the register_notifier/pane_closed_notify wiring itself (independent of
+        // start_cleanup_task, per the H4 signature split: registration must never depend on the
+        // reaper task actually starting). The full natural-exit path via kill_and_remove — with a
+        // real session entry — is covered in
+        // session::kill_and_remove_notifier_tests::kill_and_remove_notifies_attention_ledger_with_a_single_removal_delta.
+        // Live PTY/SSH exit remains a QA-stage exercise.
+        let notifier = Arc::new(NotificationBroadcast::new());
+        let manager = SessionManager::new();
+        manager.register_notifier(Arc::clone(&notifier));
+
+        notifier.broadcast_test_delta("pane", now_ms());
+        let registration = notifier.register_client();
+        notifier.take_data(registration.conn_id).unwrap(); // snapshot
+
+        manager.pane_closed_notify("pane");
+
+        let delta = match notifier.take_data(registration.conn_id) {
+            Some(ServerEnvelope::StateDelta { delta }) => delta,
+            other => panic!("expected removal delta, got {other:?}"),
+        };
+        assert!(delta.panes.iter().any(|p| p.pane_id == "pane" && p.removed == Some(true)));
+    }
 }

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -155,6 +155,7 @@ fn cleanup_exited_pty_session(
     let _ = session.output_tx.send(Vec::new());
 
     if manager.sessions.remove(pane_id).is_some() {
+        manager.pane_closed_notify(pane_id);
         manager
             .event_bus
             .publish(BusEvent::SessionClosed { pane_id: pane_id.to_string(), exit_code });

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -10,7 +10,7 @@ use std::{
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicBool, AtomicU16, AtomicU64, AtomicUsize, Ordering},
-        Arc, Mutex,
+        Arc, Mutex, OnceLock,
     },
     time::Instant,
 };
@@ -995,6 +995,10 @@ pub struct SessionManager {
     pub tab_order: Mutex<Vec<String>>,
     pub event_bus: EventBus,
     notify_port: AtomicU16,
+    /// Set once (via `register_notifier`) so any authoritative pane-removal site — including
+    /// natural PTY/SSH exit, which never goes through `kill_and_remove` — can notify the
+    /// attention ledger without threading a notifier handle through every call site.
+    notifier: OnceLock<Arc<crate::notification::NotificationBroadcast>>,
 }
 
 #[derive(Serialize)]
@@ -1094,6 +1098,16 @@ impl SessionManager {
             pending_ssh_auth: DashMap::new(),
             event_bus: EventBus::new(),
             notify_port: AtomicU16::new(0),
+            notifier: OnceLock::new(),
+        }
+    }
+
+    /// Notifies the attention ledger that `pane_id` was authoritatively removed, if a notifier
+    /// has been registered (via `register_notifier`). No-op otherwise (e.g. in unit tests that
+    /// construct a bare `SessionManager`).
+    pub(crate) fn pane_closed_notify(&self, pane_id: &str) {
+        if let Some(notifier) = self.notifier.get() {
+            notifier.pane_closed(pane_id);
         }
     }
 
@@ -1191,6 +1205,7 @@ impl SessionManager {
             // Drop the input channel sender so the writer task's recv() returns
             // None and the task exits, releasing its Arc<Session>.
             session.input_tx.lock().unwrap_or_else(std::sync::PoisonError::into_inner).take();
+            self.pane_closed_notify(pane_id);
             true
         } else {
             false
@@ -1363,6 +1378,15 @@ impl SessionManager {
         }
     }
 
+    /// Registers the notifier once, so `kill_and_remove` and natural PTY/SSH exit paths can
+    /// notify the attention ledger directly via `pane_closed_notify` without threading a
+    /// notifier handle through every call site. Safe to call before `start_cleanup_task` (the
+    /// two are independent — a bind failure or startup ordering issue must never suppress the
+    /// detached-session reaper).
+    pub fn register_notifier(&self, notifier: Arc<crate::notification::NotificationBroadcast>) {
+        let _ = self.notifier.set(notifier);
+    }
+
     pub fn start_cleanup_task(self: &Arc<Self>) {
         let manager = Arc::clone(self);
         tokio::spawn(async move {
@@ -1400,6 +1424,7 @@ impl SessionManager {
 
                     if should_kill {
                         info!("Cleanup: removing detached session: pane={}", pane_id);
+                        // kill_and_remove now notifies the attention ledger internally.
                         manager.kill_and_remove(&pane_id);
                     }
                 }
@@ -1410,3 +1435,68 @@ impl SessionManager {
 
 #[cfg(test)]
 mod tests;
+
+/// Covers `kill_and_remove`'s attention-ledger wiring specifically (session/tests.rs is out of
+/// scope for this change and only covers layout helpers). A stub `Session` with
+/// `SessionBackend::Exited` avoids spawning a real PTY/child process.
+#[cfg(test)]
+mod kill_and_remove_notifier_tests {
+    use super::*;
+    use crate::notification::NotificationBroadcast;
+    use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize};
+
+    fn stub_session() -> Arc<Session> {
+        let (resize_tx, _resize_rx) = watch::channel(None);
+        let (output_tx, output_rx) = mpsc::unbounded_channel();
+        Arc::new(Session {
+            backend: tokio::sync::Mutex::new(SessionBackend::Exited),
+            ssh_params: None,
+            screen: Mutex::new(VirtualScreen::new(80, 24)),
+            clients: Mutex::new(Vec::new()),
+            next_client_id: AtomicU64::new(1),
+            tauri_client_id: Mutex::new(None),
+            input_tx: Mutex::new(None),
+            status: Mutex::new(SessionStatus::Connected),
+            size: Mutex::new((80, 24)),
+            exited: Mutex::new(false),
+            shell_type: "test".to_string(),
+            tauri_on_exit: Mutex::new(None),
+            cwd_state: Mutex::new(CwdState { cwd: PathBuf::from("/"), sniff_buf: Vec::new() }),
+            sync_active: AtomicBool::new(false),
+            sync_buffer: Mutex::new(Vec::new()),
+            sync_buffer_bytes: AtomicUsize::new(0),
+            resize_tx,
+            ssh_cmd_tx: Mutex::new(None),
+            ssh_handle: tokio::sync::Mutex::new(None),
+            sftp_session: Mutex::new(None),
+            remote_home: Mutex::new(None),
+            remote_user: Mutex::new(None),
+            output_tx,
+            output_rx: Mutex::new(Some(output_rx)),
+            pending_results: Mutex::new(Vec::new()),
+        })
+    }
+
+    #[tokio::test]
+    async fn kill_and_remove_notifies_attention_ledger_with_a_single_removal_delta() {
+        let notifier = Arc::new(NotificationBroadcast::new());
+        let manager = Arc::new(SessionManager::new());
+        manager.register_notifier(Arc::clone(&notifier));
+
+        let pane_id = "stub-pane";
+        manager.sessions.insert(pane_id.to_string(), stub_session());
+        notifier.broadcast_test_delta(pane_id, crate::notification::now_ms());
+        let registration = notifier.register_client();
+        notifier.take_data(registration.conn_id).unwrap(); // snapshot
+
+        assert!(manager.kill_and_remove(pane_id));
+
+        let delta = match notifier.take_data(registration.conn_id) {
+            Some(crate::notification::ServerEnvelope::StateDelta { delta }) => delta,
+            other => panic!("expected exactly one removal delta, got {other:?}"),
+        };
+        assert!(delta.panes.iter().any(|p| p.pane_id == pane_id && p.removed == Some(true)));
+        // Single hub notification: nothing further queued.
+        assert!(notifier.take_data(registration.conn_id).is_none());
+    }
+}

--- a/src/ssh/mod.rs
+++ b/src/ssh/mod.rs
@@ -718,6 +718,7 @@ async fn ssh_reader_task(
 
     if session.notify_exit_and_mark_exited(&pane_id) {
         manager.sessions.remove(&pane_id);
+        manager.pane_closed_notify(&pane_id);
         manager
             .event_bus
             .publish(BusEvent::SessionClosed { pane_id: pane_id.clone(), exit_code: None });

--- a/src/tabs.rs
+++ b/src/tabs.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::items_after_test_module)]
+
 use axum::{
     extract::{Path, State},
     http::StatusCode,

--- a/src/tabs.rs
+++ b/src/tabs.rs
@@ -224,7 +224,8 @@ pub async fn close_tab(
         .map(|layout| session::collect_leaf_pane_ids(&layout))
         .unwrap_or_default();
 
-    // Kill and remove all PTY sessions
+    // Kill and remove all PTY sessions (kill_and_remove notifies the attention ledger
+    // internally).
     for leaf_id in &leaf_ids {
         manager.kill_and_remove(leaf_id);
     }
@@ -420,7 +421,7 @@ pub async fn close_pane(
             .into_response();
     }
 
-    // Kill and remove PTY session
+    // Kill and remove PTY session (kill_and_remove notifies the attention ledger internally).
     manager.kill_and_remove(&pane_id);
 
     // Update layout

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -1,4 +1,11 @@
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::too_many_lines)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::too_many_lines,
+    clippy::doc_markdown,
+    clippy::items_after_statements,
+    clippy::needless_pass_by_value
+)]
 use axum::{
     extract::{
         ws::{close_code, CloseFrame, Message, WebSocket},
@@ -16,7 +23,7 @@ use std::sync::{
     Arc,
 };
 
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::history::HistoryState;
 use crate::notification::{

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -16,10 +16,13 @@ use std::sync::{
     Arc,
 };
 
-use tracing::{error, info, warn};
+use tracing::{error, info};
 
 use crate::history::HistoryState;
-use crate::notification::NotificationBroadcast;
+use crate::notification::{
+    MarkReadRequest, NotificationBroadcast, ServerEnvelope, CLOSE_UPGRADE_REQUIRED, DRAIN_STALL_MS,
+    MIN_PROTOCOL_VERSION,
+};
 use crate::session::{SessionClientEvent, SessionManager, SessionStatus, SyncMsg};
 use crate::settings::SettingsState;
 use crate::workspace_mgmt::WorkspacesState;
@@ -29,6 +32,11 @@ pub struct WsQuery {
     #[serde(rename = "paneId")]
     pane_id: Option<String>,
     argv: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct NotificationWsQuery {
+    v: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -395,6 +403,7 @@ async fn handle_sync_socket(
                                 .map(|layout| crate::session::collect_leaf_pane_ids(&layout))
                                 .unwrap_or_default();
                             // Kill and remove PTY sessions for all leaves in this tab
+                            // (kill_and_remove notifies the attention ledger internally).
                             for leaf_id in &leaf_ids {
                                 manager.kill_and_remove(leaf_id);
                             }
@@ -405,6 +414,7 @@ async fn handle_sync_socket(
                                 .broadcast_sync_others(&SyncMsg::TabClosed { pane_id }, &client_id);
                         }
                         SyncClientMsg::ClosePane { pane_id } => {
+                            // kill_and_remove notifies the attention ledger internally.
                             manager.kill_and_remove(&pane_id);
                             // Collect affected layouts before purging
                             let before_layouts: Vec<(String, serde_json::Value)> = manager
@@ -869,6 +879,7 @@ async fn handle_socket(
 #[allow(clippy::unused_async)]
 pub async fn notification_ws_handler(
     ws: WebSocketUpgrade,
+    Query(q): Query<NotificationWsQuery>,
     State(notifier): State<Arc<NotificationBroadcast>>,
     State(settings): State<SettingsState>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
@@ -882,102 +893,160 @@ pub async fn notification_ws_handler(
     if !crate::auth::check_ws_origin(&headers, &allowed_origins, real_ip, &trusted_proxies) {
         return StatusCode::FORBIDDEN.into_response();
     }
-    ws.on_upgrade(move |socket| handle_notification_socket(socket, notifier)).into_response()
+    let version = notification_protocol_version(q.v.as_deref());
+    ws.on_upgrade(move |socket| handle_notification_socket(socket, notifier, version))
+        .into_response()
 }
 
-async fn handle_notification_socket(socket: WebSocket, notifier: Arc<NotificationBroadcast>) {
+pub(crate) fn notification_protocol_version(value: Option<&str>) -> u64 {
+    value.and_then(|value| value.parse::<u64>().ok()).unwrap_or(0)
+}
+
+async fn handle_notification_socket(
+    mut socket: WebSocket,
+    notifier: Arc<NotificationBroadcast>,
+    version: u64,
+) {
+    if version < MIN_PROTOCOL_VERSION {
+        let _ = socket
+            .send(Message::Close(Some(CloseFrame {
+                code: CLOSE_UPGRADE_REQUIRED,
+                reason: "protocol_upgrade_required".into(),
+            })))
+            .await;
+        return;
+    }
+
+    let registration = notifier.register_client();
+    let conn_id = registration.conn_id;
     let (ws_tx, mut ws_rx) = socket.split();
-    let mut rx = notifier.subscribe();
-
-    // Channel for all outbound WS messages
-    let (ws_out_tx, mut ws_out_rx) = tokio::sync::mpsc::unbounded_channel::<Message>();
-
-    // Writer task
-    let writer_task = tokio::spawn(async move {
+    let (pong_tx, mut pong_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
+    let writer_notifier = Arc::clone(&notifier);
+    let mut data_wake = registration.data_wake;
+    let mut control = registration.control;
+    let mut disconnect = registration.disconnect;
+    let mut writer_task = tokio::spawn(async move {
         let mut ws_tx = ws_tx;
-        while let Some(msg) = ws_out_rx.recv().await {
-            if ws_tx.send(msg).await.is_err() {
-                break;
+        // Send `message` with the drain-stall timeout. Returns `false` if the writer must stop
+        // (send error/timeout, or the message itself was a Close frame).
+        async fn send_one(
+            ws_tx: &mut futures_util::stream::SplitSink<WebSocket, Message>,
+            message: Message,
+        ) -> bool {
+            let closing = matches!(message, Message::Close(_));
+            match tokio::time::timeout(
+                std::time::Duration::from_millis(DRAIN_STALL_MS),
+                ws_tx.send(message),
+            )
+            .await
+            {
+                Ok(Ok(())) => !closing,
+                Ok(Err(_)) | Err(_) => false,
             }
         }
-    });
 
-    // Ping sender task
-    let ping_tx = ws_out_tx.clone();
-    let ping_task = tokio::spawn(async move {
-        let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
-        interval.tick().await;
-        loop {
-            interval.tick().await;
-            if ping_tx.send(Message::Ping(vec![])).is_err() {
-                break;
-            }
-        }
-    });
+        let mut ping_interval = tokio::time::interval(std::time::Duration::from_secs(30));
+        ping_interval.tick().await; // skip the immediate first tick
 
-    let (lag_close_tx, mut lag_close_rx) = tokio::sync::oneshot::channel::<()>();
-    let fwd_ws_out_tx = ws_out_tx.clone();
-    let fwd = tokio::spawn(async move {
-        loop {
-            match rx.recv().await {
-                Ok(event) => {
-                    let json = serde_json::to_string(&event).expect("serialization is infallible");
-                    if fwd_ws_out_tx.send(Message::Text(json)).is_err() {
-                        break;
+        'outer: loop {
+            tokio::select! {
+                biased;
+                changed = disconnect.changed() => {
+                    if changed.is_err() || *disconnect.borrow() {
+                        let message = Message::Close(Some(CloseFrame {
+                            code: close_code::RESTART,
+                            reason: "notification client stalled; reconnect".into(),
+                        }));
+                        send_one(&mut ws_tx, message).await;
+                        break 'outer;
                     }
                 }
-                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
-                    warn!(
-                        "Notification stream lagged by {} events; closing notification WebSocket",
-                        skipped
-                    );
-                    let _ = fwd_ws_out_tx.send(Message::Close(Some(CloseFrame {
-                        code: close_code::RESTART,
-                        reason: "notification stream lagged; reconnect".into(),
-                    })));
-                    let _ = lag_close_tx.send(());
-                    break;
+                envelope = control.recv() => {
+                    let Some(envelope) = envelope else { break 'outer };
+                    if !send_one(&mut ws_tx, envelope_message(envelope)).await {
+                        break 'outer;
+                    }
                 }
-                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                pong = pong_rx.recv() => {
+                    let Some(data) = pong else { break 'outer };
+                    if !send_one(&mut ws_tx, Message::Pong(data)).await {
+                        break 'outer;
+                    }
+                }
+                wake = data_wake.recv() => {
+                    match wake {
+                        Some(()) => {
+                            // Drain the whole queue on one wake token — `take_data` returning
+                            // `None` just means the queue is currently empty (NORMAL), never a
+                            // reason to stop the writer.
+                            while let Some(envelope) = writer_notifier.take_data(conn_id) {
+                                if !send_one(&mut ws_tx, envelope_message(envelope)).await {
+                                    break 'outer;
+                                }
+                            }
+                        }
+                        None => break 'outer, // wake channel closed: client unregistered
+                    }
+                }
+                _ = ping_interval.tick() => {
+                    if !send_one(&mut ws_tx, Message::Ping(vec![])).await {
+                        break 'outer;
+                    }
+                }
             }
         }
     });
 
-    // Keep connection alive until client disconnects or a lagged stream starts closing.
-    let lag_closing = loop {
+    loop {
         tokio::select! {
             msg = ws_rx.next() => {
                 match msg {
                     Some(Ok(Message::Ping(data))) => {
-                        let _ = ws_out_tx.send(Message::Pong(data));
+                        if pong_tx.try_send(data).is_err() {
+                            break;
+                        }
                     }
-                    Some(Ok(Message::Close(_)) | Err(_)) | None => break false,
-                    Some(Ok(_)) => {}
-                }
-            }
-            res = &mut lag_close_rx => break res.is_ok(),
-        }
-    };
-
-    if lag_closing {
-        let close_handshake = async {
-            loop {
-                match ws_rx.next().await {
-                    Some(Ok(Message::Ping(data))) => {
-                        let _ = ws_out_tx.send(Message::Pong(data));
+                    Some(Ok(Message::Text(text))) => {
+                        if let Some(request) = parse_mark_read(&text) {
+                            notifier.apply_mark_read(conn_id, &request);
+                        } else {
+                            tracing::debug!("ignoring malformed notification WebSocket message");
+                        }
                     }
                     Some(Ok(Message::Close(_)) | Err(_)) | None => break,
                     Some(Ok(_)) => {}
                 }
             }
-        };
-        if tokio::time::timeout(std::time::Duration::from_secs(5), close_handshake).await.is_err() {
-            warn!("client did not complete close handshake after lag; dropping connection");
+            _ = &mut writer_task => break,
         }
     }
-    fwd.abort();
     writer_task.abort();
-    ping_task.abort();
+    notifier.unregister_client(conn_id);
+}
+
+fn envelope_message(envelope: ServerEnvelope) -> Message {
+    Message::Text(serde_json::to_string(&envelope).expect("serialization is infallible"))
+}
+
+fn parse_mark_read(text: &str) -> Option<MarkReadRequest> {
+    let value: serde_json::Value = serde_json::from_str(text).ok()?;
+    if value.get("type")?.as_str()? != "notification.mark_read" {
+        return None;
+    }
+    let request: MarkReadRequest = serde_json::from_value(value).ok()?;
+    if request.v < MIN_PROTOCOL_VERSION
+        || request.epoch.is_empty()
+        || request.client_id.is_empty()
+        || request.request_id.is_empty()
+        || request
+            .panes
+            .iter()
+            .any(|pane| pane.pane_id.is_empty() || pane.through_event_seq.parse::<u64>().is_err())
+        || request.notifs.iter().any(|notif| notif.notif_id.is_empty())
+    {
+        return None;
+    }
+    Some(request)
 }
 
 #[derive(Deserialize)]

--- a/src/ws/tests.rs
+++ b/src/ws/tests.rs
@@ -97,3 +97,20 @@ fn server_msg_shell_info_serializes() {
     assert!(json.contains(r#""type":"shell_info""#));
     assert!(json.contains(r#""shell_type":"zsh""#));
 }
+
+#[test]
+fn notification_protocol_version_is_fail_closed() {
+    assert_eq!(notification_protocol_version(None), 0);
+    assert_eq!(notification_protocol_version(Some("malformed-1.0")), 0);
+    assert_eq!(notification_protocol_version(Some("0")), 0);
+    assert_eq!(notification_protocol_version(Some("1")), MIN_PROTOCOL_VERSION);
+    assert_eq!(notification_protocol_version(Some("garbage")), 0);
+
+    assert!(notification_protocol_version(None) < MIN_PROTOCOL_VERSION);
+    assert!(notification_protocol_version(Some("0")) < MIN_PROTOCOL_VERSION);
+    assert_eq!(CLOSE_UPGRADE_REQUIRED, 4001);
+
+    // The parser verdict reaches the Close(4001, "protocol_upgrade_required") branch in
+    // handle_notification_socket. A real upgrade, Ping/Pong, Close handshake, and DRAIN_STALL
+    // exercise require a live socket and are intentionally deferred to the QA-stage E2E suite.
+}


### PR DESCRIPTION
## What

The **notification attention core** — a bidirectional, revision-based attention protocol so every surface (desktop, web, each browser tab) shows a consistent unread/attention state and can mark-read authoritatively.

**Backend**
- `src/attention.rs` (new) — `AttentionLedger`: epoch/seq/revision state, exact `firstUnreadAt`, generation-guarded reserve→complete dedup, `UNREAD_CAP=100` / `IDENTITY_CAP=512` eviction (fully-read-first, then oldest-unread), TTL-swept request dedup.
- `src/notification.rs` — `NotificationBroadcast` wraps the ledger + client registry in one `Mutex<LedgerHub>`, held across the whole reserve→mutate→complete→broadcast span (no `.await` inside) so the two-phase dedup can't race. Bounded outbound queue (message + byte caps) with a drop-`StateDelta`-then-resync eviction protocol.
- `src/ws/mod.rs` — `/ws/notify` protocol: connect-time version gate (closes `4001` below min), `mark_read` with generation-guarded dedup, pane-close GC via `kill_and_remove`, 60s sweep wired at the real startup entry point.

**Frontend**
- `attentionReconcile.ts` (new) — attention store with a `BigInt` revision gate (rejects stale/replayed deltas), epoch-mismatch → `awaitingSnapshot`, requestId overlay masking, bounded ack-timeout resend.
- `useAppForeground.ts` (new) + `useNotification.ts` rewrite — `/ws/notify?v=1` dispatcher, `4001` handling (cancel pending, stop reconnect, one-reload-per-60s guard), read triggers (`active_observed` / focus / terminal-input) gated on app foreground, `PENDING_CAP=64` FIFO pool.

Revision/seq are wire-encoded as decimal strings and parsed with `BigInt` to avoid JS `Number` precision loss above 2^53.

## Stacked PR

This PR is stacked on **#161** (P1 ws-lag close), **#162** (P2 bell-debounce), and **#163** (P6 notification reveal-goto) — those three appear in this diff as prerequisites. **Merge #161, #162, #163 first**; GitHub then recomputes `dev...head` and this PR auto-shrinks to just the attention-core delta.

## Tests

`src/attention.rs` embeds ~24 inline unit tests (reclaim, replay, conflict, identity-cap tie-breaking, stale-owner-after-reclaim); `src/ws/tests.rs`; frontend `attentionReconcile.spec.ts`, `useNotificationProtocol.spec.ts`, `useNotificationTriggers.spec.ts`, `useAppForeground.spec.ts`, plus a rewritten `AppPaneClose.test.ts`. Frontend suite: 488/488 pass locally (vue-tsc 0, build OK).

## Hardening notes for review (non-blocking)

Dual review (independent) surfaced hardening opportunities. None is a current-functionality defect (the protocol is authenticated single-user; these matter under hostile/malformed input), and they're listed transparently for your call:

1. **Protocol version gate is min-only** (`ws/mod.rs`): `version < MIN_PROTOCOL_VERSION` rejects below-min but admits a future `?v=2`/`?v=999` and processes it as v1. Once v2 changes the wire shape you'd likely want an exact-match or `[min,max]` range.
2. **`mark_read` batch is unbounded** (`ws/mod.rs`/`notification.rs`): no cap on pane/notif count or id length in one frame; `apply_mark_read` holds the hub lock across the batch and `push_unique` is linear, so a very large authenticated frame can stall producers/sweep briefly. A pre-lock target-count/size limit would bound it.
3. **Request-dedup map is TTL-bounded but not count-bounded** (`attention.rs`): sustained unique `(clientId, requestId)` keys are retained until the 10-min/30-s sweep; a capacity cap would bound peak memory under sustained traffic.
4. **Malformed `mark_read` is silently dropped** (`ws/mod.rs` `debug!("ignoring…")`): no terminal error is returned, so the client's ack-timeout retries it up to 4×. A protocol-error reply (or close) would avoid retry amplification on a permanent schema/version mismatch.
5. **Frontend decode errors are swallowed** (`useNotification.ts` `try { … } catch {}` around `JSON.parse`/`BigInt`): a malformed delta is dropped without logging or requesting a resync, which could leave state stale until the next snapshot. Logging + a resync request on decode failure would be more robust.

Also worth confirming before merge: `docs/notifications*.md` reflect the new `/ws/notify` mark_read schema, `4001` close code, and epoch/revision semantics.

## CI note

Upstream `dev`'s `Backend (clippy + fmt + test)` job is currently red on pre-existing rustfmt drift + clippy pedantic under an unpinned stable toolchain, in files unrelated to this change. This PR adds no new fmt/clippy findings in its own files and its tests pass.
