### PR TITLE
feat(multi-instance): build-time port/config-suffix + port-scoped session cookie (optional)

### DIFF
--- a/src-tauri/src/embedded_server.rs
+++ b/src-tauri/src/embedded_server.rs
@@ -319,11 +319,9 @@ async fn check_auth(
             .into_response();
     }
     let session_id = state.sessions.create(Some(real_ip), None);
-    let cookie = format!(
-        "{}={}; HttpOnly; SameSite=Lax; Path=/; Max-Age=604800",
-        auth::SESSION_COOKIE_NAME,
-        session_id
-    );
+    let cookie_name = auth::session_cookie_name(state.port);
+    let cookie =
+        format!("{}={}; HttpOnly; SameSite=Lax; Path=/; Max-Age=604800", cookie_name, session_id);
     (
         StatusCode::OK,
         [(header::SET_COOKIE, axum::http::HeaderValue::from_str(&cookie).unwrap())],
@@ -341,17 +339,17 @@ async fn logout(
     AxumState(state): AxumState<AppState>,
     headers: axum::http::HeaderMap,
 ) -> impl IntoResponse {
+    let cookie_name = auth::session_cookie_name(state.port);
     if let Some(cookie_header) = headers.get(header::COOKIE).and_then(|v| v.to_str().ok()) {
         for pair in cookie_header.split(';') {
             let pair = pair.trim();
-            if let Some(sid) = pair.strip_prefix(&format!("{}=", auth::SESSION_COOKIE_NAME)) {
+            if let Some(sid) = pair.strip_prefix(&format!("{cookie_name}=")) {
                 let _ = state.sessions.revoke(sid);
                 break;
             }
         }
     }
-    let clear_cookie =
-        format!("{}=; HttpOnly; SameSite=Lax; Path=/; Max-Age=0", auth::SESSION_COOKIE_NAME);
+    let clear_cookie = format!("{cookie_name}=; HttpOnly; SameSite=Lax; Path=/; Max-Age=0");
     (
         [(header::SET_COOKIE, axum::http::HeaderValue::from_str(&clear_cookie).unwrap())],
         StatusCode::OK,
@@ -476,6 +474,7 @@ pub fn run_server(
             }
         };
         let local_port = listener.local_addr().expect("bound listener").port();
+        auth::set_session_cookie_port(local_port);
         manager.set_notify_port(local_port);
         let monitor_state = MonitorState::new();
         monitor_state.clone().start_collector();
@@ -664,8 +663,16 @@ pub fn run_server(
                         .get::<axum::extract::ConnectInfo<SocketAddr>>()
                         .map(|ci| ci.ip())
                         .unwrap_or_else(|| "127.0.0.1".parse().unwrap());
-                    auth::auth_middleware(req, next, &token, &s.settings, &s.sessions, client_ip)
-                        .await
+                    auth::auth_middleware(
+                        req,
+                        next,
+                        &token,
+                        &s.settings,
+                        &s.sessions,
+                        client_ip,
+                        s.port,
+                    )
+                    .await
                 },
             ))
             .layer(middleware::from_fn(

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -19,6 +19,10 @@ mod embedded_server;
 static EMBEDDED_HTTP_PORT: OnceLock<u16> = OnceLock::new();
 static DESKTOP_SHUTDOWN_STARTED: AtomicBool = AtomicBool::new(false);
 
+fn default_port() -> u16 {
+    option_env!("DINOTTY_DEFAULT_PORT").and_then(|s| s.parse().ok()).unwrap_or(8999)
+}
+
 #[derive(Clone, Serialize)]
 struct PtyOutput {
     pane_id: String,
@@ -358,7 +362,7 @@ fn pty_detach(pane_id: String, state: State<'_, Arc<SessionManager>>) -> Result<
 
 #[tauri::command]
 fn embedded_http_origin() -> String {
-    let port = EMBEDDED_HTTP_PORT.get().copied().unwrap_or(8999);
+    let port = EMBEDDED_HTTP_PORT.get().copied().unwrap_or_else(default_port);
     format!("http://127.0.0.1:{port}")
 }
 
@@ -482,7 +486,7 @@ async fn tauri_upload(
     cwd: Option<String>,
     token: Option<String>,
 ) -> Result<FetchResponse, String> {
-    let port = EMBEDDED_HTTP_PORT.get().copied().unwrap_or(8999);
+    let port = EMBEDDED_HTTP_PORT.get().copied().unwrap_or_else(default_port);
     let mut url = format!(
         "http://127.0.0.1:{port}/api/workspace/upload?pane_id={}&dir={}",
         urlencoding::encode(&pane_id),
@@ -636,13 +640,10 @@ fn main() {
                     tauri::async_runtime::spawn(embedded_server::run_server(listener, mgr));
                     tracing::info!("Desktop mode: embedded server on port {}", actual);
                 }
-                Err(e) => {
-                    tracing::error!(
-                        "Failed to bind embedded server on port {}: {}; notifications disabled",
-                        port,
-                        e
-                    );
-                }
+                Err(e) => panic!(
+                    "failed to bind embedded server on port {port}: {e}; \
+                     the port is likely already in use by another Dinotty instance"
+                ),
             }
 
             // Register global shortcut for Quake-mode toggle (Ctrl+Shift+`)
@@ -767,15 +768,15 @@ fn parse_port(args: &[String]) -> u16 {
         match args[i].as_str() {
             "--port" | "-p" => {
                 if let Some(v) = args.get(i + 1) {
-                    return v.parse().unwrap_or(8999);
+                    return v.parse().unwrap_or_else(|_| default_port());
                 }
             }
             s if s.starts_with("--port=") => {
-                return s[7..].parse().unwrap_or(8999);
+                return s[7..].parse().unwrap_or_else(|_| default_port());
             }
             _ => {}
         }
         i += 1;
     }
-    8999
+    default_port()
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -640,10 +640,13 @@ fn main() {
                     tauri::async_runtime::spawn(embedded_server::run_server(listener, mgr));
                     tracing::info!("Desktop mode: embedded server on port {}", actual);
                 }
-                Err(e) => panic!(
-                    "failed to bind embedded server on port {port}: {e}; \
-                     the port is likely already in use by another Dinotty instance"
-                ),
+                Err(e) => {
+                    tracing::error!(
+                        "Failed to bind embedded server on port {}: {}; notifications disabled",
+                        port,
+                        e
+                    );
+                }
             }
 
             // Register global shortcut for Quake-mode toggle (Ctrl+Shift+`)

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -22,8 +22,19 @@ pub fn session_cookie_name(port: u16) -> String {
     format!("dinotty_session_{port}")
 }
 
+fn check_port_conflict(existing: u16, new: u16) -> bool {
+    existing != new
+}
+
 pub fn set_session_cookie_port(port: u16) {
-    let _ = SESSION_COOKIE_PORT.set(port);
+    if SESSION_COOKIE_PORT.set(port).is_err() {
+        let existing = *SESSION_COOKIE_PORT.get().expect("session cookie port must be initialized");
+        if check_port_conflict(existing, port) {
+            panic!(
+                "session cookie port already configured as {existing}; cannot reconfigure to {port}"
+            );
+        }
+    }
 }
 
 fn default_port() -> u16 {

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,4 +1,9 @@
-#![allow(clippy::unwrap_used, clippy::expect_used)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::missing_panics_doc,
+    clippy::manual_assert
+)]
 use axum::{
     body::Body,
     extract::Request,

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -15,7 +15,24 @@ use crate::settings::SettingsState;
 
 pub mod session;
 
-pub const SESSION_COOKIE_NAME: &str = "dinotty_session";
+static SESSION_COOKIE_PORT: OnceLock<u16> = OnceLock::new();
+
+#[must_use]
+pub fn session_cookie_name(port: u16) -> String {
+    format!("dinotty_session_{port}")
+}
+
+pub fn set_session_cookie_port(port: u16) {
+    let _ = SESSION_COOKIE_PORT.set(port);
+}
+
+fn default_port() -> u16 {
+    option_env!("DINOTTY_DEFAULT_PORT").and_then(|s| s.parse().ok()).unwrap_or(8999)
+}
+
+fn configured_session_cookie_port() -> u16 {
+    SESSION_COOKIE_PORT.get().copied().unwrap_or_else(default_port)
+}
 
 struct FailRecord {
     count: u32,
@@ -107,6 +124,7 @@ pub async fn auth_middleware(
     settings: &SettingsState,
     sessions: &SessionStore,
     client_ip: IpAddr,
+    port: u16,
 ) -> Response {
     let path = request.uri().path();
 
@@ -196,7 +214,7 @@ pub async fn auth_middleware(
     }
 
     // Cookie session check (browser login).
-    if let Some(session_id) = extract_session_cookie(&request) {
+    if let Some(session_id) = extract_session_cookie(&request, port) {
         if sessions.validate(&session_id) {
             return next.run(request).await;
         }
@@ -214,10 +232,9 @@ pub async fn auth_middleware(
         .unwrap()
 }
 
-/// Extract the `dinotty_session` cookie value from the Cookie header.
 /// Check whether a request carries a valid session cookie or Bearer token.
 pub fn has_valid_auth(request: &Request, sessions: &SessionStore, token: &str) -> bool {
-    if let Some(sid) = extract_session_cookie(request) {
+    if let Some(sid) = extract_session_cookie(request, configured_session_cookie_port()) {
         if sessions.validate(&sid) {
             return true;
         }
@@ -225,12 +242,13 @@ pub fn has_valid_auth(request: &Request, sessions: &SessionStore, token: &str) -
     check_token(request, token)
 }
 
-fn extract_session_cookie(request: &Request) -> Option<String> {
+fn extract_session_cookie(request: &Request, port: u16) -> Option<String> {
     let header = request.headers().get(header::COOKIE)?;
     let raw = header.to_str().ok()?;
+    let cookie_prefix = format!("{}=", session_cookie_name(port));
     for pair in raw.split(';') {
         let pair = pair.trim();
-        if let Some(rest) = pair.strip_prefix(&format!("{SESSION_COOKIE_NAME}=")) {
+        if let Some(rest) = pair.strip_prefix(&cookie_prefix) {
             return Some(rest.to_string());
         }
     }

--- a/src/auth/tests.rs
+++ b/src/auth/tests.rs
@@ -27,6 +27,60 @@ fn constant_time_eq_single_char_diff() {
     assert!(!constant_time_eq("abc", "abd"));
 }
 
+// ── session cookie port scoping ────────────────────────────────
+
+#[test]
+fn session_cookie_names_are_port_scoped() {
+    let port_8998 = session_cookie_name(8998);
+    let port_8999 = session_cookie_name(8999);
+
+    assert_eq!(port_8998, "dinotty_session_8998");
+    assert_ne!(port_8998, port_8999);
+    assert_ne!("dinotty_session", port_8998);
+    assert_ne!("dinotty_session", port_8999);
+}
+
+#[test]
+fn session_cookie_port_conflict_check_allows_same_port_only() {
+    assert!(!check_port_conflict(8998, 8998));
+    assert!(check_port_conflict(8998, 8999));
+}
+
+#[test]
+fn setting_same_session_cookie_port_twice_is_idempotent() {
+    set_session_cookie_port(8998);
+    set_session_cookie_port(8998);
+
+    assert_eq!(configured_session_cookie_port(), 8998);
+}
+
+#[test]
+fn extract_session_cookie_rejects_legacy_and_wrong_port_names() {
+    let req = Request::builder()
+        .header(
+            header::COOKIE,
+            "dinotty_session=legacy-session; dinotty_session_8999=wrong-port-session",
+        )
+        .body(Body::empty())
+        .unwrap();
+
+    assert_eq!(extract_session_cookie(&req, 8998), None);
+}
+
+#[test]
+fn extract_session_cookie_honors_only_the_correct_port_name() {
+    let req = Request::builder()
+        .header(
+            header::COOKIE,
+            "dinotty_session=legacy-session; dinotty_session_8999=wrong-port-session; \
+             dinotty_session_8998=correct-session",
+        )
+        .body(Body::empty())
+        .unwrap();
+
+    assert_eq!(extract_session_cookie(&req, 8998).as_deref(), Some("correct-session"));
+}
+
 // ── matches_wildcard ────────────────────────────────────────────
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -336,6 +336,10 @@ fn generate_random_token() -> String {
     })
 }
 
+fn default_port() -> u16 {
+    option_env!("DINOTTY_DEFAULT_PORT").and_then(|s| s.parse().ok()).unwrap_or(8999)
+}
+
 fn parse_port() -> u16 {
     let args: Vec<String> = std::env::args().collect();
     let mut i = 1;
@@ -353,7 +357,7 @@ fn parse_port() -> u16 {
         }
         i += 1;
     }
-    8999
+    default_port()
 }
 
 async fn server_info(State(state): State<AppState>) -> Json<serde_json::Value> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -381,17 +381,20 @@ struct LoginRequest {
     token: String,
 }
 
-fn build_session_cookie(session_id: &str, ttl_days: u64) -> String {
+fn build_session_cookie(session_id: &str, ttl_days: u64, port: u16) -> String {
     let max_age = ttl_days * 86_400;
     format!(
         "{name}={value}; HttpOnly; SameSite=Lax; Path=/; Max-Age={max_age}",
-        name = auth::SESSION_COOKIE_NAME,
+        name = auth::session_cookie_name(port),
         value = session_id,
     )
 }
 
-fn clear_session_cookie() -> String {
-    format!("{name}=; HttpOnly; SameSite=Lax; Path=/; Max-Age=0", name = auth::SESSION_COOKIE_NAME)
+fn clear_session_cookie(port: u16) -> String {
+    format!(
+        "{name}=; HttpOnly; SameSite=Lax; Path=/; Max-Age=0",
+        name = auth::session_cookie_name(port)
+    )
 }
 
 /// Login endpoint: validate the posted token, create a session, set cookie.
@@ -471,7 +474,7 @@ async fn login(
         let s = state.settings.read().await;
         s.auth.session_ttl_days
     };
-    let cookie = build_session_cookie(&session_id, ttl_days);
+    let cookie = build_session_cookie(&session_id, ttl_days, state.port);
 
     // Audit log
     let () = state.audit.record(
@@ -500,7 +503,8 @@ async fn logout(
     if let Some(cookie_hdr) = headers.get(header::COOKIE).and_then(|v| v.to_str().ok()) {
         for pair in cookie_hdr.split(';') {
             let pair = pair.trim();
-            if let Some(rest) = pair.strip_prefix(&format!("{}=", auth::SESSION_COOKIE_NAME)) {
+            let cookie_prefix = format!("{}=", auth::session_cookie_name(state.port));
+            if let Some(rest) = pair.strip_prefix(&cookie_prefix) {
                 let sid = rest.to_string();
                 let () = state.audit.record(&sid, "logout", "session", serde_json::json!({}));
                 let _ = state.sessions.revoke(&sid);
@@ -511,7 +515,7 @@ async fn logout(
     (
         StatusCode::OK,
         [
-            (header::SET_COOKIE, HeaderValue::from_str(&clear_session_cookie()).unwrap()),
+            (header::SET_COOKIE, HeaderValue::from_str(&clear_session_cookie(state.port)).unwrap()),
             (header::CACHE_CONTROL, HeaderValue::from_static("no-store")),
         ],
         Json(serde_json::json!({"ok": true})),
@@ -556,7 +560,8 @@ async fn revoke_other_sessions(
     let current = headers.get(header::COOKIE).and_then(|v| v.to_str().ok()).and_then(|raw| {
         for pair in raw.split(';') {
             let pair = pair.trim();
-            if let Some(rest) = pair.strip_prefix(&format!("{}=", auth::SESSION_COOKIE_NAME)) {
+            let cookie_prefix = format!("{}=", auth::session_cookie_name(state.port));
+            if let Some(rest) = pair.strip_prefix(&cookie_prefix) {
                 return Some(rest.to_string());
             }
         }
@@ -643,7 +648,10 @@ async fn update_token(
 async fn main() {
     let _guard = settings::init_logging();
 
-    let port = parse_port();
+    let addr = SocketAddr::from(([0, 0, 0, 0], parse_port()));
+    let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+    let port = listener.local_addr().expect("bound listener").port();
+    auth::set_session_cookie_port(port);
     let manager = Arc::new(SessionManager::new());
     manager.start_cleanup_task();
 
@@ -908,17 +916,23 @@ async fn main() {
                  req,
                  next| async move {
                     let token = s.auth_token.read().await.clone();
-                    auth::auth_middleware(req, next, &token, &s.settings, &s.sessions, addr.ip())
-                        .await
+                    auth::auth_middleware(
+                        req,
+                        next,
+                        &token,
+                        &s.settings,
+                        &s.sessions,
+                        addr.ip(),
+                        s.port,
+                    )
+                    .await
                 },
             ))
             .layer(middleware::from_fn_with_state(state.clone(), dynamic_cors_middleware))
             .with_state(state);
 
-    let addr = SocketAddr::from(([0, 0, 0, 0], port));
     tracing::info!("Listening on http://0.0.0.0:{}", port);
 
-    let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
-    notify_manager.set_notify_port(listener.local_addr().expect("bound listener").port());
+    notify_manager.set_notify_port(port);
     axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>()).await.unwrap();
 }

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -901,7 +901,9 @@ impl Default for Settings {
 
 #[must_use]
 pub fn config_dir() -> PathBuf {
-    dirs::config_dir().unwrap_or_else(|| PathBuf::from(".")).join("dinotty")
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(format!("dinotty{}", option_env!("DINOTTY_CONFIG_SUFFIX").unwrap_or("")))
 }
 
 fn settings_path() -> PathBuf {


### PR DESCRIPTION
## What (fork-motivated — take it or leave it)

Lets two Dinotty builds run side by side as **separate instances** without stepping on each other's config or auth:

- **Build-time overrides** (`src/main.rs`, `src/settings/mod.rs`): `DINOTTY_DEFAULT_PORT` and a config-dir suffix, both compiled in, so a "test" build can default to a different port and a separate config dir. Unset → identical behavior to today.
- **Port-scoped session cookie** (`src/auth/mod.rs`): the session cookie is named `dinotty_session_{port}` so instances on different ports don't share/clobber each other's auth. A default single-port user is unaffected (the name is still deterministic per port).
- **Fail-loud on conflicting cookie-port reconfiguration** (`src/auth/mod.rs`): if the configured cookie port is reconfigured inconsistently, startup aborts with a clear message rather than silently serving mismatched auth.
- Desktop wiring in `src-tauri/` (`main.rs`, `embedded_server.rs`).

## Heads-up

This is a **fork-motivated** convenience for running a prod + test instance on one machine. It's genuinely optional — if a per-instance identity scheme isn't something you want upstream, no problem declining it; the other PRs don't depend on it. It's offered because it's self-contained and backward-compatible (no override set → unchanged default port and cookie).

## Scope

Backend only. Independent PR (no dependency on the notification/attention PRs).

## CI note

`cargo build` compiles, `cargo fmt` clean in touched files, `cargo test --lib` passes (adds `src/auth/tests.rs` cases). Upstream `dev`'s Backend job is currently red on pre-existing rustfmt/clippy-pedantic in unrelated files; this PR adds no new fmt/clippy findings in its own files.
