### PR TITLE
fix(multi-instance): suffix-aware known_hosts + normalize ephemeral port 0

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -18,9 +18,12 @@ mod embedded_server;
 
 static EMBEDDED_HTTP_PORT: OnceLock<u16> = OnceLock::new();
 static DESKTOP_SHUTDOWN_STARTED: AtomicBool = AtomicBool::new(false);
+const BUILT_IN_DEFAULT_PORT: u16 = 8999;
 
 fn default_port() -> u16 {
-    option_env!("DINOTTY_DEFAULT_PORT").and_then(|s| s.parse().ok()).unwrap_or(8999)
+    option_env!("DINOTTY_DEFAULT_PORT")
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(BUILT_IN_DEFAULT_PORT)
 }
 
 #[derive(Clone, Serialize)]
@@ -634,7 +637,17 @@ fn main() {
     let _log_guard = dinotty_server::settings::init_logging();
 
     let args: Vec<String> = std::env::args().collect();
-    let port = parse_port(&args);
+    let requested_port = parse_port(&args);
+    let port = if requested_port == 0 {
+        let port = match default_port() {
+            0 => BUILT_IN_DEFAULT_PORT,
+            port => port,
+        };
+        tracing::warn!("Port 0 is not supported; falling back to default port {port}");
+        port
+    } else {
+        requested_port
+    };
     let _ = EMBEDDED_HTTP_PORT.set(port);
 
     let manager = Arc::new(SessionManager::new());

--- a/src/ssh/host_key.rs
+++ b/src/ssh/host_key.rs
@@ -35,7 +35,7 @@ impl Default for HostKeyVerifier {
 impl HostKeyVerifier {
     #[must_use]
     pub fn new() -> Self {
-        let config_dir = dirs::config_dir().unwrap_or_else(|| PathBuf::from(".")).join("dinotty");
+        let config_dir = crate::settings::config_dir();
         std::fs::create_dir_all(&config_dir).ok();
         Self {
             known_hosts_path: config_dir.join("known_hosts"),


### PR DESCRIPTION
## What

Two small follow-ups that complete the instance-isolation feature from #169 (both surfaced by a post-merge adversarial review):

- **Suffix-aware `known_hosts`.** `HostKeyVerifier::new()` derived the SSH `known_hosts` directory from a hardcoded `dirs::config_dir().join("dinotty")`, ignoring the build-time config-dir suffix. So a suffixed test instance shared — and could overwrite / race — production's `known_hosts`. It now uses the same `settings::config_dir()` helper the rest of the config (settings, tokens, logs, workspaces, audit data) already uses, so each instance's host-key DB is isolated exactly like the rest of its config.
- **Normalize an ephemeral port 0.** A requested port of `0` (`DINOTTY_DEFAULT_PORT=0` or `--port 0`) was stored into `EMBEDDED_HTTP_PORT` as-is, but `bind_listener(0)` then binds an OS-chosen ephemeral port. `embedded_http_origin()` / `tauri_upload()` (which read `EMBEDDED_HTTP_PORT`) would target `127.0.0.1:0` and fail. A requested `0` is now normalized to a real connectable port (the build default, else `8999`) with a warning, before `EMBEDDED_HTTP_PORT` is set — so the origin always matches the bound listener. The common explicit-port path (e.g. 8998/8999) is unchanged.

## Scope

Backend only. Independent follow-up on top of merged #169 — no dependency on other open PRs.

## CI note

`cargo fmt --check` clean on touched files, `cargo build` OK, `cargo clippy --all-targets -- -D warnings` clean, `cargo test --lib` passes (303). No new clippy findings introduced.
