### PR TITLE
fix(settings): keep the font dropdown inside the settings panel

### DIFF
--- a/frontend/src/components/SettingsPanel.vue
+++ b/frontend/src/components/SettingsPanel.vue
@@ -517,7 +517,6 @@ const tabs = computed(() => [
   top: calc(100% + 4px);
   left: 0;
   right: 0;
-  max-height: 260px;
   overflow-y: auto;
   overscroll-behavior: contain;
   background: var(--bg-surface);
@@ -526,6 +525,10 @@ const tabs = computed(() => [
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
   z-index: 1000;
   padding: 4px 0;
+}
+.font-dropdown-menu.drop-up {
+  top: auto;
+  bottom: calc(100% + 4px);
 }
 .font-dropdown-item {
   display: flex;

--- a/frontend/src/components/settings/AppearanceTab.vue
+++ b/frontend/src/components/settings/AppearanceTab.vue
@@ -36,6 +36,7 @@
         <label>{{ t('settings.text.fontFamily') }}</label>
         <div class="font-dropdown">
           <div
+            ref="fontTriggerEl"
             class="font-dropdown-trigger shortcut-input"
             :style="{ fontFamily: fontFamily || 'inherit' }"
             @click="toggleFontDropdown"
@@ -43,8 +44,14 @@
             <span>{{ currentFontLabel }}</span>
             <span class="font-dropdown-arrow">▾</span>
           </div>
-          <div v-if="fontDropdownOpen" class="font-dropdown-backdrop" @click="closeFontDropdown"></div>
-          <div v-if="fontDropdownOpen" class="font-dropdown-menu" @wheel="onFontMenuWheel">
+          <div v-if="fontDropdownOpen" class="font-dropdown-backdrop" @click="closeFontDropdown" @wheel.prevent></div>
+          <div
+            v-if="fontDropdownOpen"
+            class="font-dropdown-menu"
+            :class="{ 'drop-up': fontMenuDropUp }"
+            :style="{ maxHeight: fontMenuMaxHeight + 'px' }"
+            @wheel="onFontMenuWheel"
+          >
             <div
               v-for="item in fontList"
               :key="item.kind + ':' + item.family"
@@ -264,6 +271,7 @@ import {
   type AddFontError,
 } from '../../utils/fontList'
 import { isFontAvailable, clearNegativeFontCache } from '../../utils/fontAvailability'
+import { computeDropdownPlacement } from '../../utils/dropdownPlacement'
 import {
   FONT_SIZE_MAX,
   FONT_SIZE_MIN,
@@ -283,7 +291,11 @@ const { t } = useI18n()
 
 // ── Text / Font ──
 
+const PREFERRED_FONT_MENU_HEIGHT = 260
+const fontTriggerEl = ref<HTMLElement | null>(null)
 const fontDropdownOpen = ref(false)
+const fontMenuDropUp = ref(false)
+const fontMenuMaxHeight = ref(PREFERRED_FONT_MENU_HEIGHT)
 
 // ── Font picker (DT17) ──
 const availability = reactive<Record<string, boolean>>({})
@@ -341,6 +353,16 @@ function onFontMenuWheel(e: WheelEvent) {
 
 function toggleFontDropdown() {
   if (fontDropdownOpen.value) { closeFontDropdown(); return }
+  const el = fontTriggerEl.value
+  const placement = el
+    ? computeDropdownPlacement(
+        el.getBoundingClientRect(),
+        el.closest('.settings-body')?.getBoundingClientRect() ?? { top: 0, bottom: window.innerHeight },
+        PREFERRED_FONT_MENU_HEIGHT,
+      )
+    : { dropUp: false, maxHeight: PREFERRED_FONT_MENU_HEIGHT }
+  fontMenuDropUp.value = placement.dropUp
+  fontMenuMaxHeight.value = placement.maxHeight
   fontDropdownOpen.value = true
   addFontError.value = ''
   void runProbes()

--- a/frontend/src/test/dropdownPlacement.test.ts
+++ b/frontend/src/test/dropdownPlacement.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { computeDropdownPlacement } from '../utils/dropdownPlacement'
+
+describe('dropdown placement', () => {
+  it('uses the preferred height when there is ample space below', () => {
+    expect(computeDropdownPlacement(
+      { top: 100, bottom: 130 },
+      { top: 0, bottom: 500 },
+      260,
+    )).toEqual({ dropUp: false, maxHeight: 260 })
+  })
+
+  it('drops up and clamps to the space above when it exceeds the space below', () => {
+    expect(computeDropdownPlacement(
+      { top: 200, bottom: 230 },
+      { top: 0, bottom: 300 },
+      260,
+    )).toEqual({ dropUp: true, maxHeight: 188 })
+  })
+
+  it('drops down and clamps to the space below when it exceeds the space above', () => {
+    expect(computeDropdownPlacement(
+      { top: 50, bottom: 80 },
+      { top: 0, bottom: 200 },
+      260,
+    )).toEqual({ dropUp: false, maxHeight: 108 })
+  })
+
+  it('drops down on a cramped equal-space tie', () => {
+    expect(computeDropdownPlacement(
+      { top: 30, bottom: 50 },
+      { top: 0, bottom: 80 },
+      260,
+    )).toEqual({ dropUp: false, maxHeight: 18 })
+  })
+
+  it('clamps an equal negative-space tie to zero', () => {
+    expect(computeDropdownPlacement(
+      { top: 2, bottom: 18 },
+      { top: 0, bottom: 20 },
+      260,
+    )).toEqual({ dropUp: false, maxHeight: 0 })
+  })
+
+  it('drops up and clamps unequal negative space to zero', () => {
+    expect(computeDropdownPlacement(
+      { top: 10, bottom: 38 },
+      { top: 0, bottom: 20 },
+      260,
+    )).toEqual({ dropUp: true, maxHeight: 0 })
+  })
+
+  it('exact-fit below wins even with more space above', () => {
+    expect(computeDropdownPlacement(
+      { top: 400, bottom: 728 },
+      { top: 0, bottom: 1000 },
+      260,
+    )).toEqual({ dropUp: false, maxHeight: 260 })
+  })
+})

--- a/frontend/src/utils/dropdownPlacement.ts
+++ b/frontend/src/utils/dropdownPlacement.ts
@@ -1,0 +1,30 @@
+export interface RectLike {
+  top: number
+  bottom: number
+}
+
+export interface DropdownPlacement {
+  dropUp: boolean
+  maxHeight: number
+}
+
+export function computeDropdownPlacement(
+  trigger: RectLike,
+  bounds: RectLike,
+  preferredHeight: number,
+  gap = 4,
+  margin = 8,
+): DropdownPlacement {
+  const spaceBelow = bounds.bottom - trigger.bottom - gap - margin
+  const spaceAbove = trigger.top - bounds.top - gap - margin
+
+  if (spaceBelow >= preferredHeight) {
+    return { dropUp: false, maxHeight: preferredHeight }
+  }
+
+  const dropUp = spaceAbove > spaceBelow
+  const availableSpace = dropUp ? spaceAbove : spaceBelow
+
+  // No positive floor: forcing one could make the menu clip outside its bounds.
+  return { dropUp, maxHeight: Math.max(0, Math.min(preferredHeight, availableSpace)) }
+}


### PR DESCRIPTION
## Problem

The font-family dropdown in Settings → Appearance can be rendered outside
the visible settings panel and get clipped.

`.font-dropdown-menu` is `position: absolute` with a hardcoded
`max-height: 260px` and always opens downward (`top: calc(100% + 4px)`).
It lives inside `.settings-body`, which is `overflow-y: auto`. When the
trigger sits low enough in the visible panel, the 260px menu overshoots
the scroll container's bottom edge and the browser clips it — the last
entries are cut off mid-row and cannot be reached.

### Steps to reproduce

1. Open Settings → Appearance.
2. Scroll the panel so the "Font family" row sits near the bottom edge.
3. Open the font dropdown.

The bottom of the list is cut off. It is easiest to hit with the
"Advanced" section collapsed, since that shortens the panel content and
leaves nothing below to scroll into, but the same happens whenever the
trigger ends up near the bottom — including on short viewports.

## Fix

`computeDropdownPlacement()` (new, in `utils/dropdownPlacement.ts`) is a
pure function that measures the space above and below the trigger inside
its scroll container and returns a direction plus a height:

- clamp `max-height` to the space actually available — this is what
  guarantees the menu is never clipped, in either direction
- flip the menu upward when there is more room above — this only picks
  the roomier side, it is not the guarantee
- when there is ample room below, behaviour is unchanged: it opens
  downward at the same 260px

Measurement happens on open, from the trigger's rect and the nearest
`.settings-body` ancestor (falling back to the viewport). `max-height`
moves from the stylesheet to an inline style, and the upward direction is
a new `.font-dropdown-menu.drop-up` rule.

Wheel events on the dropdown backdrop are now prevented, so scrolling the
panel underneath cannot move an open menu away from the placement that
was just measured for it.

## Design notes

The menu deliberately stays `position: absolute` rather than moving to a
teleported/fixed popup. Absolute positioning means it keeps tracking its
trigger while the panel scrolls, with no scroll listener needed — and a
scroll listener would interfere with the existing wheel boundary guard on
the menu, which stops wheel-scroll from chaining out of the menu into the
panel under WKWebView. The two wheel paths stay independent: the backdrop
handles events originating outside the menu, the existing guard handles
events originating inside it.

Known limitation, accepted for the above reason: `max-height` is measured
only when the menu opens. A touch-pan over the backdrop or an on-screen
keyboard resize can still leave it stale; it self-corrects on reopen.
`@touchmove` is intentionally not prevented, to avoid regressing mobile
scrolling.

No new user-facing strings, so no i18n changes are needed.

## Testing

- `pnpm exec vue-tsc --noEmit` — clean
- `pnpm run build` — clean
- `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test --lib`
  — all clean (unchanged by this PR, run for completeness)
- `vitest run` — 641 passing, including 7 new unit tests for the
  placement helper covering the exact-fit boundary, the tie-break, and
  the zero-clamp branches
- Manually verified on macOS: the menu no longer clips with the trigger
  near the bottom edge; wheel-scrolling inside the menu still does not
  scroll the settings panel; behaviour with ample room below is unchanged
