### PR TITLE
fix(supervise): exclude plugin tabs from supervise rotation

### DIFF
--- a/frontend/src/composables/useSuperviseTabs.ts
+++ b/frontend/src/composables/useSuperviseTabs.ts
@@ -67,10 +67,12 @@ export function useSuperviseTabs() {
       orderedTabIds.add(tab.paneId)
     }
 
-    return orderedTabs.map((tab) => ({
-      id: tab.paneId,
-      reminderAt: reminderAt(tab),
-    }))
+    return orderedTabs
+      .filter((tab) => tab.type !== 'plugin')
+      .map((tab) => ({
+        id: tab.paneId,
+        reminderAt: reminderAt(tab),
+      }))
   }
 
   async function supervise(activate: (id: string) => Promise<boolean>): Promise<void> {

--- a/frontend/src/test/useSuperviseTabs.test.ts
+++ b/frontend/src/test/useSuperviseTabs.test.ts
@@ -53,8 +53,30 @@ function pluginTab(id: string): Tab {
   return { type: 'plugin', paneId: id, title: id, pluginId: id }
 }
 
+function terminalTab(id: string): Tab {
+  return {
+    type: 'terminal',
+    paneId: id,
+    layout: {
+      type: 'leaf',
+      paneId: `${id}-leaf`,
+      title: id,
+      ratio: 1,
+      zoomed: false,
+    },
+    activePaneId: `${id}-leaf`,
+    paneMru: [`${id}-leaf`],
+    broadcastMode: false,
+    broadcastActivity: 0,
+    previewVisible: false,
+    previewAddress: '',
+    previewUrl: '',
+    previewKind: 'web',
+  }
+}
+
 function setup(ids = ['a', 'b', 'c'], activePaneId = 'a') {
-  mocks.session.tabs.splice(0, mocks.session.tabs.length, ...ids.map(pluginTab))
+  mocks.session.tabs.splice(0, mocks.session.tabs.length, ...ids.map(terminalTab))
   mocks.session.activePaneId = activePaneId
   mocks.workspaces.value = []
   mocks.matchWorkspace.mockReset().mockReturnValue(null)
@@ -77,6 +99,17 @@ describe('useSuperviseTabs lifecycle', () => {
     for (const scope of scopes.splice(0)) scope.stop()
     vi.clearAllTimers()
     vi.useRealTimers()
+  })
+
+  it('excludes plugin tabs from supervised candidates', async () => {
+    const { supervise } = setup(['a', 'b'])
+    mocks.session.tabs.splice(1, 0, pluginTab('plugin'))
+    const activate = vi.fn().mockResolvedValue(false)
+
+    await supervise(activate)
+
+    expect(activate).toHaveBeenCalledOnce()
+    expect(activate).toHaveBeenCalledWith('b')
   })
 
   it('settles reversed activations under their own tokens and promotes both successes', async () => {


### PR DESCRIPTION
fix(supervise): exclude plugin tabs from supervise rotation

Supervise iterated the full tab list, so it rotated into plugin tabs
(e.g. a session-browser panel) alongside terminals. Filter them out at
the candidate-building site, matching the existing `type !== 'plugin'`
convention used by the bulk-close paths in TabOverview/TabBar. The pure
picker in utils/superviseTabs.ts stays plugin-agnostic.


---

Verification: `vue-tsc --noEmit` clean; the change is covered by new behavioural tests (listed in
the commit). The suite has two pre-existing failures in `actionKeyboard.test.ts` /
`keybindings.test.ts` around `addCursorsInFiles` — reproduced on an unmodified `dev` checkout, so
they are unrelated to this change. Not exercised on a real device; verified at the code/test level
only.
