### PR TITLE
fix(tabs): validate cached plugin tabs on restore, close resurrect race

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -411,6 +411,17 @@ const clearActiveReadContext = setActiveReadContext({
 })
 const stopForegroundGainSubscription = onAppForegroundGain(evaluateActiveRead)
 const { loadedPlugins, loadAll, getPluginContext, pluginList, allCommands } = usePluginLoader()
+let initialPluginLoad: Promise<void> | null = null
+function loadPluginsInitially() {
+  if (!initialPluginLoad) {
+    const load = loadAll()
+    initialPluginLoad = load
+    void load.catch(() => {
+      if (initialPluginLoad === load) initialPluginLoad = null
+    })
+  }
+  return initialPluginLoad
+}
 const { isMobile } = useIsMobile()
 
 // Workspace filtering
@@ -639,6 +650,8 @@ const syncWs = useSyncWebSocket({
   persist,
   focusActive,
   newTab: async () => { await newTab() },
+  loadedPlugins,
+  initialPluginLoad: loadPluginsInitially,
 })
 
 // Set up SSH keyboard-interactive auth handler
@@ -1122,6 +1135,7 @@ async function closeTab(tabId: string) {
   if (idx === -1) return
 
   tabs.value.splice(idx, 1)
+  if (tab.type === 'plugin') persistNow()
 
   // If this was the last tab, create a new one
   if (tabs.value.length === 0) {
@@ -1137,7 +1151,7 @@ async function closeTab(tabId: string) {
     activePaneId.value = tabs.value[newIdx].paneId
   }
 
-  persist()
+  if (tab.type !== 'plugin') persist()
   nextTick(() => focusActive())
 }
 
@@ -1287,7 +1301,7 @@ async function onLoginSuccess() {
   ui.setAuthenticated(true)
   await getApiBase()
   await settingsStore.load()
-  void loadAll()
+  void loadPluginsInitially()
   void syncWs.connectSyncWS()
   initMonitorHistory()
 }
@@ -2050,7 +2064,7 @@ onMounted(async () => {
     await settingsStore.load()
     void syncWs.connectSyncWS()
     initMonitorHistory()
-    void loadAll()
+    void loadPluginsInitially()
     // Fallback: if sync WS hasn't delivered tabs within 3s, load via REST
     setTimeout(async () => {
       if (tabs.value.length === 0 && !syncWs.isConnected()) {

--- a/frontend/src/composables/useSyncWebSocket.ts
+++ b/frontend/src/composables/useSyncWebSocket.ts
@@ -26,8 +26,10 @@ export function useSyncWebSocket(opts: {
   persist: () => void
   focusActive: () => void
   newTab: () => Promise<void>
+  loadedPlugins: ReadonlyMap<string, { manifest: { name: string } }>
+  initialPluginLoad: () => Promise<void>
 }) {
-  const { termRefs, persist, focusActive, newTab } = opts
+  const { termRefs, persist, focusActive, newTab, loadedPlugins, initialPluginLoad } = opts
   const session = useSessionStore()
   const { tabs, activePaneId } = storeToRefs(session)
   const ui = useUiStore()
@@ -41,6 +43,7 @@ export function useSyncWebSocket(opts: {
   // Grace period: tabs created within the last 5s are protected from tab_list pruning.
   // This prevents a race where tab_list arrives before the REST-driven tab_created.
   const recentlyCreated = new Map<string, number>()
+  const invalidCachedPluginPaneIds = new Set<string>()
   const GRACE_MS = 5000
 
   function markRecentlyCreated(tabId: string) {
@@ -81,10 +84,12 @@ export function useSyncWebSocket(opts: {
       const raw = localStorage.getItem('dinotty_tabs')
       if (!raw) return null
       const { tabs: savedTabs } = JSON.parse(raw)
-      const direct = savedTabs?.find((t: any) => t.paneId === paneId)
+      // Plugin pane IDs must never be treated as saved terminal layout IDs.
+      const terminalTabs = savedTabs?.filter((t: { type?: string }) => t.type !== 'plugin')
+      const direct = terminalTabs?.find((t: any) => t.paneId === paneId)
       if (direct) return direct
       return (
-        savedTabs?.find((t: any) => {
+        terminalTabs?.find((t: any) => {
           if (!t.layout) return false
           const leaves = getAllLeaves(t.layout)
           return leaves.some((l: any) => l.paneId === paneId)
@@ -114,6 +119,69 @@ export function useSyncWebSocket(opts: {
       console.log('[sync] connected')
       syncConnected.value = true
       syncReconnectDelay = 1000
+    }
+
+    function restorePluginTabs() {
+      const restored = new Map<string, string>()
+      try {
+        const raw = localStorage.getItem('dinotty_tabs')
+        if (!raw) return
+        const { tabs: savedTabs } = JSON.parse(raw)
+        for (const saved of savedTabs ?? []) {
+          if (
+            saved.type !== 'plugin' ||
+            invalidCachedPluginPaneIds.has(saved.paneId) ||
+            tabs.value.some((tab) => tab.paneId === saved.paneId)
+          ) {
+            continue
+          }
+          const plugin = loadedPlugins.get(saved.pluginId)
+          tabs.value.push({
+            type: 'plugin',
+            paneId: saved.paneId,
+            title: plugin?.manifest.name ?? saved.title ?? saved.pluginId,
+            pluginId: saved.pluginId,
+            workspaceId: saved.workspaceId,
+          })
+          restored.set(saved.paneId, saved.pluginId)
+        }
+      } catch {
+        return
+      }
+
+      if (restored.size === 0) return
+      void initialPluginLoad()
+        .then(async () => {
+          let changed = false
+          for (const [paneId, pluginId] of restored) {
+            const idx = tabs.value.findIndex(
+              (tab) => tab.type === 'plugin' && tab.paneId === paneId && tab.pluginId === pluginId,
+            )
+            if (idx === -1) continue
+            const plugin = loadedPlugins.get(pluginId)
+            if (!plugin) {
+              invalidCachedPluginPaneIds.add(paneId)
+              tabs.value.splice(idx, 1)
+              changed = true
+              continue
+            }
+            const tab = tabs.value[idx]
+            if (tab.type === 'plugin' && tab.title !== plugin.manifest.name) {
+              tab.title = plugin.manifest.name
+              changed = true
+            }
+          }
+          if (!changed) return
+          if (tabs.value.length === 0) await newTab()
+          if (!activePaneId.value || !tabs.value.some((tab) => tab.paneId === activePaneId.value)) {
+            activePaneId.value = tabs.value[0]?.paneId ?? null
+          }
+          persist()
+          nextTick(() => focusActive())
+        })
+        .catch(() => {
+          // A failed initial load is not authoritative evidence that plugins were uninstalled.
+        })
     }
 
     function handleMsg(e: { data: string }) {
@@ -187,26 +255,7 @@ export function useSyncWebSocket(opts: {
           }
         }
 
-        // Restore plugin tabs from localStorage
-        try {
-          const raw = localStorage.getItem('dinotty_tabs')
-          if (raw) {
-            const { tabs: savedTabs } = JSON.parse(raw)
-            for (const st of savedTabs) {
-              if (st.type === 'plugin' && !tabs.value.some((t) => t.paneId === st.paneId)) {
-                tabs.value.push({
-                  type: 'plugin',
-                  paneId: st.paneId,
-                  title: st.title || st.pluginId,
-                  pluginId: st.pluginId,
-                  workspaceId: st.workspaceId,
-                })
-              }
-            }
-          }
-        } catch {
-          /* noop */
-        }
+        restorePluginTabs()
 
         // Remove terminal tabs whose leaf paneIds are no longer on the server
         const serverTabIds = new Set(msg.tabs.map((t) => t.tab_id))

--- a/frontend/src/test/AppPaneClose.test.ts
+++ b/frontend/src/test/AppPaneClose.test.ts
@@ -5,13 +5,16 @@ import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vites
 // readyState. We set readyState=CONNECTING (0) so the fallback timer
 // fires apiListTabs and populates tabs.
 const originalWebSocket = (global as any).WebSocket
+let latestMockWebSocket: MockWebSocket | null = null
 class MockWebSocket {
   public readyState = 0
   public onopen: any = null
   public onmessage: any = null
   public onclose: any = null
   public onerror: any = null
-  constructor(public url: string) {}
+  constructor(public url: string) {
+    latestMockWebSocket = this
+  }
   close() {}
 }
 ;(global as any).WebSocket = MockWebSocket as any
@@ -83,6 +86,8 @@ const mocks = vi.hoisted(() => {
     resetNotificationRequestIds: () => {
       notificationRequestIdCounter = 0
     },
+    loadedPlugins: new Map<string, any>(),
+    loadAllPlugins: vi.fn(async () => {}),
   }
 })
 
@@ -172,8 +177,8 @@ vi.mock('../composables/useAppForeground', () => ({
 }))
 vi.mock('../composables/usePluginLoader', () => ({
   usePluginLoader: () => ({
-    loadedPlugins: new Map(),
-    loadAll: vi.fn(),
+    loadedPlugins: mocks.loadedPlugins,
+    loadAll: mocks.loadAllPlugins,
     getPluginContext: vi.fn(),
     pluginList: { value: [], __v_isRef: true },
     allCommands: { value: [], __v_isRef: true },
@@ -380,6 +385,9 @@ afterEach(() => {
   mocks.apiDeactivateWorkspace.mockResolvedValue(undefined)
   mocks.mintNotificationRequestId.mockClear()
   mocks.resetNotificationRequestIds()
+  mocks.loadedPlugins.clear()
+  mocks.loadAllPlugins.mockReset()
+  mocks.loadAllPlugins.mockResolvedValue(undefined)
 })
 
 describe('App.vue - activateTab cross-workspace', () => {
@@ -493,6 +501,120 @@ describe('App.vue - activateTab cross-workspace', () => {
     expect(mocks.apiActivateWorkspace).toHaveBeenCalledWith('ws-other')
     expect(workspaceState.activeWorkspaceId.value).toBe('ws-other')
     expect(mocks.scrollTabIntoView).toHaveBeenCalledWith('terminal-other')
+  })
+})
+
+describe('App.vue - tab persistence', () => {
+  it('persists terminal and plugin tabs and indexes the full list', async () => {
+    const wrapper = await mountWithTabs()
+    const session = useSessionStore()
+    const terminal = session.tabs[0]
+    const splitContainer = wrapper.findComponent(SplitContainerStub)
+    if (!terminal || terminal.type !== 'terminal') throw new Error('expected seeded terminal tab')
+    session.setTabs([
+      {
+        type: 'plugin',
+        paneId: 'plugin:memory',
+        title: 'Memory',
+        pluginId: 'memory',
+        workspaceId: 'workspace-1',
+      },
+      terminal,
+    ])
+    session.setActivePane(terminal.paneId)
+
+    splitContainer.vm.$emit('divider-drag-end')
+    window.dispatchEvent(new Event('beforeunload'))
+    session.setTabs([terminal])
+
+    const saved = JSON.parse(localStorageMock.getItem('dinotty_tabs')!)
+    expect(saved.tabs.map((tab: Tab) => tab.type)).toEqual(['plugin', 'terminal'])
+    expect(saved.tabs[0]).toEqual({
+      type: 'plugin',
+      paneId: 'plugin:memory',
+      title: 'Memory',
+      pluginId: 'memory',
+      workspaceId: 'workspace-1',
+    })
+    expect(saved.activeIdx).toBe(1)
+  })
+
+  it('does not resurrect a plugin when tab_list arrives immediately after close', async () => {
+    const wrapper = await mountWithTabs()
+    const session = useSessionStore()
+    const terminal = session.tabs[0]
+    const splitContainer = wrapper.findComponent(SplitContainerStub)
+    if (!terminal || terminal.type !== 'terminal') throw new Error('expected seeded terminal tab')
+    mocks.loadedPlugins.set('memory', {
+      manifest: { id: 'memory', name: 'Memory' },
+    })
+    session.setTabs([
+      terminal,
+      { type: 'plugin', paneId: 'plugin:memory', title: 'Memory', pluginId: 'memory' },
+    ])
+    session.setActivePane('plugin:memory')
+    splitContainer.vm.$emit('divider-drag-end')
+    window.dispatchEvent(new Event('beforeunload'))
+    expect(JSON.parse(localStorageMock.getItem('dinotty_tabs')!).tabs).toHaveLength(2)
+
+    await (wrapper.vm as any).closeTab('plugin:memory')
+
+    expect(JSON.parse(localStorageMock.getItem('dinotty_tabs')!).tabs).toHaveLength(1)
+    latestMockWebSocket?.onmessage?.({
+      data: JSON.stringify({
+        type: 'tab_list',
+        tabs: [
+          {
+            tab_id: terminal.paneId,
+            pane_id: terminal.activePaneId,
+            active_pane_id: terminal.activePaneId,
+            layout: terminal.layout,
+          },
+        ],
+        active_pane_id: terminal.activePaneId,
+      }),
+    })
+    await Promise.resolve()
+
+    expect(session.tabs.some((tab) => tab.paneId === 'plugin:memory')).toBe(false)
+  })
+
+  it('retries a rejected initial plugin load and completes reconciliation on a later tab_list', async () => {
+    mocks.loadAllPlugins.mockRejectedValueOnce(new Error('temporary plugin load failure'))
+    const wrapper = await mountWithTabs()
+    const session = useSessionStore()
+    const terminal = session.tabs[0]
+    if (!terminal || terminal.type !== 'terminal') throw new Error('expected seeded terminal tab')
+    expect(mocks.loadAllPlugins).toHaveBeenCalledOnce()
+
+    localStorage.setItem(
+      'dinotty_tabs',
+      JSON.stringify({
+        tabs: [{ type: 'plugin', paneId: 'plugin:legacy', title: 'Legacy', pluginId: 'legacy' }],
+        activeIdx: 0,
+      }),
+    )
+
+    latestMockWebSocket?.onmessage?.({
+      data: JSON.stringify({
+        type: 'tab_list',
+        tabs: [
+          {
+            tab_id: terminal.paneId,
+            pane_id: terminal.activePaneId,
+            active_pane_id: terminal.activePaneId,
+            layout: terminal.layout,
+          },
+        ],
+        active_pane_id: terminal.activePaneId,
+      }),
+    })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(mocks.loadAllPlugins).toHaveBeenCalledTimes(2)
+    expect(session.tabs.some((tab) => tab.paneId === 'plugin:legacy')).toBe(false)
+    expect(wrapper.exists()).toBe(true)
   })
 })
 

--- a/frontend/src/test/useSyncWebSocketMru.test.ts
+++ b/frontend/src/test/useSyncWebSocketMru.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
 import type { PaneLayout, TerminalTab } from '../types/pane'
+import type { SyncTabList } from '../types/protocol'
 
 let socket: MockWebSocket
 class MockWebSocket {
@@ -28,6 +29,17 @@ vi.mock('../composables/usePluginLoader', () => ({ handlePluginChanged: vi.fn() 
 
 import { useSyncWebSocket } from '../composables/useSyncWebSocket'
 import { useSessionStore } from '../stores/sessionStore'
+
+const localStorageMock = (() => {
+  const store = new Map<string, string>()
+  return {
+    clear: () => store.clear(),
+    getItem: (key: string) => store.get(key) ?? null,
+    removeItem: (key: string) => store.delete(key),
+    setItem: (key: string, value: string) => store.set(key, value),
+  }
+})()
+vi.stubGlobal('localStorage', localStorageMock)
 
 function leaf(paneId: string): PaneLayout {
   return { type: 'leaf', paneId, title: paneId, ratio: 1, zoomed: false }
@@ -59,18 +71,24 @@ function makeTab(): TerminalTab {
   }
 }
 
-async function setup() {
+async function setup(pluginOpts?: {
+  loadedPlugins?: Map<string, any>
+  initialPluginLoad?: () => Promise<void>
+}) {
   setActivePinia(createPinia())
   const session = useSessionStore()
   const tab = makeTab()
   session.tabs = [tab]
   session.activePaneId = tab.paneId
   const focusActive = vi.fn()
+  const newTab = vi.fn().mockResolvedValue(undefined)
   const subject = useSyncWebSocket({
     termRefs: {},
     persist: vi.fn(),
     focusActive,
-    newTab: vi.fn(),
+    newTab,
+    loadedPlugins: pluginOpts?.loadedPlugins ?? new Map(),
+    initialPluginLoad: pluginOpts?.initialPluginLoad ?? (() => Promise.resolve()),
   })
   await subject.connectSyncWS()
   const emitLayout = (nextLayout: PaneLayout, serverActivePaneId: string) => {
@@ -83,11 +101,213 @@ async function setup() {
       }),
     })
   }
-  return { tab, emitLayout, focusActive }
+  const emitTabList = (tabs: SyncTabList['tabs'] = []) => {
+    socket.onmessage?.({
+      data: JSON.stringify({ type: 'tab_list', tabs, active_pane_id: null }),
+    })
+  }
+  return { tab, session, subject, emitLayout, emitTabList, focusActive, newTab }
 }
 
 describe('useSyncWebSocket pane MRU', () => {
-  beforeEach(() => vi.clearAllMocks())
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorageMock.clear()
+  })
+
+  it('drops a cached plugin tab after initial loading confirms it is no longer installed', async () => {
+    let finishLoad!: () => void
+    const initialPluginLoad = () => new Promise<void>((resolve) => { finishLoad = resolve })
+    localStorage.setItem(
+      'dinotty_tabs',
+      JSON.stringify({
+        tabs: [{ type: 'plugin', paneId: 'plugin:legacy', title: 'Legacy', pluginId: 'legacy' }],
+        activeIdx: 0,
+      }),
+    )
+    const { session, emitTabList, newTab } = await setup({ initialPluginLoad })
+
+    emitTabList()
+
+    expect(session.tabs).toContainEqual({
+      type: 'plugin',
+      paneId: 'plugin:legacy',
+      title: 'Legacy',
+      pluginId: 'legacy',
+    })
+    expect(newTab).not.toHaveBeenCalled()
+
+    finishLoad()
+    await Promise.resolve()
+
+    expect(session.tabs.some((tab) => tab.type === 'plugin')).toBe(false)
+    expect(newTab).toHaveBeenCalledOnce()
+  })
+
+  it('does not restore a known-invalid cached plugin on a later tab_list from the same connection', async () => {
+    localStorage.setItem(
+      'dinotty_tabs',
+      JSON.stringify({
+        tabs: [{ type: 'plugin', paneId: 'plugin:legacy', title: 'Legacy', pluginId: 'legacy' }],
+        activeIdx: 0,
+      }),
+    )
+    const { tab, session, emitTabList } = await setup()
+    const serverTabs = [
+      { tab_id: tab.paneId, pane_id: 'a', active_pane_id: tab.activePaneId, layout: tab.layout },
+    ]
+
+    emitTabList(serverTabs)
+    await Promise.resolve()
+
+    expect(session.tabs.some((candidate) => candidate.paneId === 'plugin:legacy')).toBe(false)
+
+    emitTabList(serverTabs)
+
+    expect(session.tabs.some((candidate) => candidate.paneId === 'plugin:legacy')).toBe(false)
+  })
+
+  it('does not restore a known-invalid cached plugin after reconnect', async () => {
+    localStorage.setItem(
+      'dinotty_tabs',
+      JSON.stringify({
+        tabs: [{ type: 'plugin', paneId: 'plugin:legacy', title: 'Legacy', pluginId: 'legacy' }],
+        activeIdx: 0,
+      }),
+    )
+    const { tab, session, subject, emitTabList } = await setup()
+    const serverTabs = [
+      { tab_id: tab.paneId, pane_id: 'a', active_pane_id: tab.activePaneId, layout: tab.layout },
+    ]
+
+    emitTabList(serverTabs)
+    await Promise.resolve()
+
+    expect(session.tabs.some((candidate) => candidate.paneId === 'plugin:legacy')).toBe(false)
+
+    await subject.connectSyncWS()
+    emitTabList(serverTabs)
+
+    expect(session.tabs.some((candidate) => candidate.paneId === 'plugin:legacy')).toBe(false)
+  })
+
+  it('restores an installed plugin tab with its current manifest title', async () => {
+    const loadedPlugins = new Map([
+      ['memory', { manifest: { id: 'memory', name: 'Current Memory' } }],
+    ])
+    localStorage.setItem(
+      'dinotty_tabs',
+      JSON.stringify({
+        tabs: [
+          {
+            type: 'plugin',
+            paneId: 'plugin:memory',
+            title: 'Stale Memory',
+            pluginId: 'memory',
+            workspaceId: 'workspace-1',
+          },
+        ],
+        activeIdx: 0,
+      }),
+    )
+    const { session, emitTabList, newTab } = await setup({ loadedPlugins })
+
+    emitTabList()
+    await Promise.resolve()
+
+    expect(session.tabs).toContainEqual({
+      type: 'plugin',
+      paneId: 'plugin:memory',
+      title: 'Current Memory',
+      pluginId: 'memory',
+      workspaceId: 'workspace-1',
+    })
+    expect(newTab).not.toHaveBeenCalled()
+  })
+
+  it('keeps a cached plugin tab until the initial plugin load completes', async () => {
+    let finishLoad!: () => void
+    const loadedPlugins = new Map<string, any>()
+    const initialPluginLoad = vi.fn(
+      () => new Promise<void>((resolve) => { finishLoad = resolve }),
+    )
+    localStorage.setItem(
+      'dinotty_tabs',
+      JSON.stringify({
+        tabs: [
+          {
+            type: 'plugin',
+            paneId: 'plugin:memory',
+            title: 'Cached Memory',
+            pluginId: 'memory',
+          },
+        ],
+        activeIdx: 0,
+      }),
+    )
+    const { session, emitTabList, newTab } = await setup({ loadedPlugins, initialPluginLoad })
+
+    emitTabList()
+
+    expect(session.tabs).toContainEqual({
+      type: 'plugin',
+      paneId: 'plugin:memory',
+      title: 'Cached Memory',
+      pluginId: 'memory',
+    })
+    expect(newTab).not.toHaveBeenCalled()
+
+    loadedPlugins.set('memory', { manifest: { id: 'memory', name: 'Current Memory' } })
+    finishLoad()
+    await Promise.resolve()
+
+    expect(session.tabs).toContainEqual({
+      type: 'plugin',
+      paneId: 'plugin:memory',
+      title: 'Current Memory',
+      pluginId: 'memory',
+    })
+    expect(newTab).not.toHaveBeenCalled()
+  })
+
+  it('keeps an existing in-memory plugin tab when the server omits it', async () => {
+    const { session, emitTabList, newTab } = await setup()
+    session.tabs = [
+      { type: 'plugin', paneId: 'plugin:memory', title: 'Memory', pluginId: 'memory' },
+    ]
+
+    emitTabList()
+
+    expect(session.tabs).toEqual([
+      { type: 'plugin', paneId: 'plugin:memory', title: 'Memory', pluginId: 'memory' },
+    ])
+    expect(newTab).not.toHaveBeenCalled()
+  })
+
+  it('does not use a legacy plugin record as saved terminal state', async () => {
+    localStorage.setItem(
+      'dinotty_tabs',
+      JSON.stringify({
+        tabs: [
+          {
+            type: 'plugin',
+            paneId: 'server-pane',
+            title: 'Legacy plugin',
+            pluginId: 'legacy',
+            previewVisible: true,
+          },
+        ],
+        activeIdx: 0,
+      }),
+    )
+    const { session, emitTabList } = await setup()
+
+    emitTabList([{ tab_id: 'server-tab', pane_id: 'server-pane' }])
+
+    const restored = session.tabs.find((tab) => tab.paneId === 'server-tab')
+    expect(restored?.type).toBe('terminal')
+    expect(restored?.type === 'terminal' && restored.previewVisible).toBe(false)
+  })
 
   it('uses and focuses the MRU fallback when a focused pane exits', async () => {
     const { tab, emitLayout, focusActive } = await setup()


### PR DESCRIPTION
fix(tabs): validate cached plugin tabs on restore, close resurrect race

Plugin tabs live only in per-client localStorage (the backend TabInfo
protocol has no plugin concept), and were restored unconditionally on
every tab_list message with a title snapshot frozen at open time. An
uninstalled or renamed plugin therefore left a permanent dead tab
showing a stale name — one client could carry ghosts the others never
had.

Restore now reconciles against the loaded plugin set: entries whose
plugin is gone are dropped, survivors take the current manifest name.
Deletion runs only inside the initial-plugin-load continuation, so a
tab_list arriving before plugins finish loading can never drop a valid
tab. The memoized load promise is cleared on rejection so a failed load
does not permanently disable reconciliation.

Also closes a resurrect race: closeTab removed the tab from memory but
scheduled the localStorage write on a 200ms debounce, so a tab_list
landing in that window re-read stale storage and restored the tab that
was just closed. Plugin closes now flush synchronously, and the
invalid-tab set is hoisted above connectSyncWS so it survives
reconnects.


---

Verification: `vue-tsc --noEmit` clean; the change is covered by new behavioural tests (listed in
the commit). The suite has two pre-existing failures in `actionKeyboard.test.ts` /
`keybindings.test.ts` around `addCursorsInFiles` — reproduced on an unmodified `dev` checkout, so
they are unrelated to this change. Not exercised on a real device; verified at the code/test level
only.
