### PR TITLE
fix(tabs): flush plugin tab closures synchronously to avoid resurrect race

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1197,6 +1197,7 @@ async function closeTab(tabId: string) {
   if (idx === -1) return
 
   tabs.value.splice(idx, 1)
+  if (tab.type === 'plugin') persistNow()
 
   // If this was the last tab, create a new one
   if (tabs.value.length === 0) {
@@ -1212,7 +1213,7 @@ async function closeTab(tabId: string) {
     activePaneId.value = tabs.value[newIdx].paneId
   }
 
-  persist()
+  if (tab.type !== 'plugin') persist()
   nextTick(() => focusActive())
 }
 

--- a/frontend/src/test/AppPaneClose.test.ts
+++ b/frontend/src/test/AppPaneClose.test.ts
@@ -504,6 +504,50 @@ afterAll(() => {
   else (global as any).localStorage = originalLocalStorage
 })
 
+describe('App.vue - plugin tab close persistence', () => {
+  const terminalTab = (paneId: string): Tab => ({
+    type: 'terminal',
+    paneId,
+    layout: { type: 'leaf', paneId: `${paneId}-leaf`, title: paneId, ratio: 1, zoomed: false },
+    activePaneId: `${paneId}-leaf`,
+    paneMru: [`${paneId}-leaf`],
+    broadcastMode: false,
+    broadcastActivity: 0,
+    previewVisible: false,
+    previewAddress: '',
+    previewUrl: '',
+    previewKind: 'web',
+  })
+
+  it('flushes plugin tab closures synchronously to avoid resurrect race', async () => {
+    const wrapper = await mountWithTabs()
+    const session = useSessionStore()
+    const terminal = session.tabs[0]
+    if (!terminal || terminal.type !== 'terminal') {
+      throw new Error('expected seeded terminal tab')
+    }
+    session.setTabs([
+      terminal,
+      { type: 'plugin', paneId: 'plugin:memory', title: 'Memory', pluginId: 'memory' },
+    ])
+    session.setActivePane('plugin:memory')
+
+    const splitContainer = wrapper.findComponent(SplitContainerStub)
+    splitContainer.vm.$emit('divider-drag-end')
+    window.dispatchEvent(new Event('beforeunload'))
+    expect(JSON.parse(localStorageMock.getItem('dinotty_tabs')!).tabs).toHaveLength(2)
+
+    await (wrapper.vm as any).closeTab('plugin:memory')
+
+    // Synchronous flush: localStorage must reflect the close immediately,
+    // not after a 200ms debounce. Otherwise a tab_list arriving in the
+    // window would re-read stale storage and resurrect the closed plugin tab.
+    const saved = JSON.parse(localStorageMock.getItem('dinotty_tabs')!)
+    expect(saved.tabs).toHaveLength(1)
+    expect(saved.tabs[0].paneId).toBe(terminal.paneId)
+  })
+})
+
 describe('App.vue - onClosePane routes through confirmation gate', () => {
   beforeEach(() => {
     settings.confirm_before_close_tab = true


### PR DESCRIPTION
## Summary

- `closeTab` scheduled the localStorage write on a 200ms debounce, so a `tab_list` arriving in that window re-read stale storage and resurrected the just-closed plugin tab.
- Flush synchronously for plugin closes. Terminal tabs already call `apiCloseTab` (removes server state), so they keep the debounced path.

## Context

Extracted from #187. The rest of that PR (restorePluginTabs reconciliation, invalidCachedPluginPaneIds set, lookupSavedTab filter) was made obsolete by `015b5c6` which migrated plugin tabs to `TerminalTab-with-plugin-leaf` and registered them with the backend via `POST /api/tabs/plugin`.

## Test plan

- [x] New test `flushes plugin tab closures synchronously to avoid resurrect race` verifies localStorage reflects the close immediately after `closeTab('plugin:...')`.
- [x] Test fails without the fix (expected 1, received 2).
- [x] `vue-tsc --noEmit` clean.