### PR TITLE
fix(scroll): stop wheel events becoming arrow keys on the alt screen

### DIFF
--- a/frontend/src/composables/useTerminal.ts
+++ b/frontend/src/composables/useTerminal.ts
@@ -1834,6 +1834,18 @@ export class TerminalInstance {
       if (this._wheelBypass) return true
       if (!this.xterm) return true
 
+      // xterm.js 5.5.0 hardcodes alt-screen wheel-to-arrow conversion with no
+      // option (upstream issue #5194); keep this after _wheelBypass so touchScroll's
+      // synthetic full-screen scrolling can still use that native conversion.
+      if (
+        this.xterm.buffer.active.type === 'alternate' &&
+        this._isWheelReportedByApp() === false
+      ) {
+        e.preventDefault()
+        e.stopPropagation()
+        return false
+      }
+
       // Track user scroll intent to maintain the cross-batch viewport pin.
       // macOS trackpad inertia produces sub-pixel deltaY<0 events that set
       // xterm's isUserScrolling=true; without this filter, a single inertia
@@ -1922,6 +1934,22 @@ export class TerminalInstance {
       )
     }
     return 0
+  }
+
+  private _isWheelReportedByApp(): boolean | undefined {
+    try {
+      const core = (this.xterm as any)?._core
+      const svc =
+        core?.coreMouseService ??
+        core?.mouseService ??
+        core?.services?.coreMouseService
+      const activeProtocol = svc?.activeProtocol ?? svc?._activeProtocol
+      if (typeof activeProtocol !== 'string') return undefined
+      const events = svc?._protocols?.[activeProtocol]?.events
+      return typeof events === 'number' ? (events & 16) !== 0 : undefined
+    } catch {
+      return undefined
+    }
   }
 
   isMouseModeEnabled(): boolean {


### PR DESCRIPTION
Stops wheel events from being turned into arrow-key presses while the alternate screen buffer is active.

## The problem

xterm.js converts wheel scrolling into arrow-key input when the alt screen is active. That behaviour is hardcoded in xterm.js 5.5.0 and cannot be switched off through its public API (xterm.js #5194, still open).

The result is that ordinary scrolling silently types into full-screen TUI programs. Scroll over a pager, an editor, a menu-driven tool — each wheel notch arrives as an arrow key, moving the cursor, changing the selection, or scrolling the app's own viewport by an amount the user never asked for. On a trackpad, where a single gesture emits many wheel events, this can fire dozens of keypresses from one flick. In an editor that is real, hard-to-undo input.

## The fix

A wheel event is swallowed only when both conditions hold:

1. the alternate screen buffer is active, and
2. xterm's `coreMouseService` reports the application has **not** enabled mouse/wheel reporting.

Condition 2 is what keeps this narrow. Programs that ask for mouse reporting — anything that genuinely wants wheel events — are untouched and keep receiving them as before. Only the case where xterm.js would have synthesised arrow keys nobody requested gets blocked.

Touch scrolling is unaffected: the touch-drag path sets the existing wheel-bypass flag and returns before this check.

## Behaviour change to be aware of

For a full-screen program that does *not* enable mouse reporting, the wheel now does nothing instead of sending arrow keys. That is the intended outcome — the previous behaviour was synthetic input the application never asked for and the user never intended — but it is a visible change, so it is worth calling out rather than burying. Keyboard scrolling within such programs is unchanged, and scrollback in the normal buffer is unchanged.

## Verification

- `vue-tsc --noEmit` clean.
- Vitest: only the 2 `addCursorsInFiles` failures that also fail on a clean checkout of `dev` — pre-existing and unrelated.
- No user-visible strings, so no i18n changes.

The change has been carried in a fork build for a while, but I do not have a record of a structured manual test matrix for it, so I would not want to claim one. If you want the mouse-reporting-enabled and mouse-reporting-disabled cases explicitly walked through before merge, say so and I will run them and report back.
