### PR TITLE
feat(keyboard): keep-on-scroll setting for the mobile keyboard

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1422,7 +1422,7 @@ function onTerminalTouch(e: TouchEvent) {
     // Don't show keyboard when a scroll gesture was just detected
     if (scrollGestureDetected) {
       scrollGestureDetected = false
-      if (kbVisible.value) kbVisible.value = false
+      if (kbVisible.value && !appSettings.keyboard_keep_on_scroll) kbVisible.value = false
       return
     }
     const tab = tabs.value.find((t) => t.paneId === activePaneId.value)
@@ -1430,7 +1430,7 @@ function onTerminalTouch(e: TouchEvent) {
     const term = paneId ? termRefs[paneId]?.getTerminal() : null
     if (term && term.touchMoved) {
       term.touchMoved = false
-      if (kbVisible.value) kbVisible.value = false
+      if (kbVisible.value && !appSettings.keyboard_keep_on_scroll) kbVisible.value = false
       return
     }
     kbVisible.value = true
@@ -1441,6 +1441,9 @@ function onTerminalScroll() {
   scrollGestureDetected = true
   clearTimeout(scrollGestureTimer)
   scrollGestureTimer = window.setTimeout(() => { scrollGestureDetected = false }, 300)
+  // With keep-on-scroll enabled, scrolling back through history must not
+  // dismiss the keyboard the user is typing on.
+  if (appSettings.keyboard_keep_on_scroll) return
   if (kbVisible.value) kbVisible.value = false
 }
 

--- a/frontend/src/components/settings/KeyboardTab.vue
+++ b/frontend/src/components/settings/KeyboardTab.vue
@@ -500,6 +500,18 @@
           <span class="toggle-track"><span class="toggle-thumb"></span></span>
         </label>
       </div>
+      <div class="settings-row">
+        <label>{{ t('settings.keyboard.keepOnScroll') }}</label>
+        <label class="toggle">
+          <input
+            type="checkbox"
+            v-model="settings.keyboard_keep_on_scroll"
+            @change="saveSettings()"
+          />
+          <span class="toggle-track"><span class="toggle-thumb"></span></span>
+        </label>
+      </div>
+      <p class="settings-hint">{{ t('settings.keyboard.keepOnScrollHint') }}</p>
     </div>
 
     <CollapsibleSection :title="t('settings.keyboard.openApi')" level="group" default-open>

--- a/frontend/src/composables/useI18n.ts
+++ b/frontend/src/composables/useI18n.ts
@@ -339,6 +339,9 @@ const messages: Record<Locale, Record<string, string>> = {
     'settings.tab.monitor': 'Monitor',
     'settings.keyboard.feedback': 'Key Feedback',
     'settings.keyboard.sound': 'Click sound on key press',
+    'settings.keyboard.keepOnScroll': 'Keep keyboard open while scrolling',
+    'settings.keyboard.keepOnScrollHint':
+      'Scroll back through history without dismissing the keyboard',
     'settings.keyboard.openApi': 'Open API',
     'settings.keyboard.openApiHint':
       'Allow external devices to send input to the terminal via HTTP API.',
@@ -1016,6 +1019,8 @@ const messages: Record<Locale, Record<string, string>> = {
     'settings.tab.monitor': '监控',
     'settings.keyboard.feedback': '按键反馈',
     'settings.keyboard.sound': '按键音效',
+    'settings.keyboard.keepOnScroll': '滚动时保持键盘',
+    'settings.keyboard.keepOnScrollHint': '上翻查看历史输出时不再收起键盘',
     'settings.keyboard.openApi': '开放接口',
     'settings.keyboard.openApiHint': '允许外部设备通过 HTTP API 向终端发送输入。',
     'settings.keyboard.openApiEnabled': '启用开放接口',

--- a/frontend/src/composables/useSettings.ts
+++ b/frontend/src/composables/useSettings.ts
@@ -45,6 +45,7 @@ export interface SettingsData {
   upload_cap_count: number
   keyboard_sound: boolean
   show_virtual_keyboard: boolean
+  keyboard_keep_on_scroll: boolean
   workspace_badge_mode: WorkspaceBadgeMode | null
   confirm_before_close_tab: boolean
   space_confirms_dialogs: boolean
@@ -382,6 +383,7 @@ export const settings = reactive<SettingsData>({
   upload_cap_count: 100,
   keyboard_sound: false,
   show_virtual_keyboard: false,
+  keyboard_keep_on_scroll: false,
   workspace_badge_mode: null,
   confirm_before_close_tab: true,
   space_confirms_dialogs: false,


### PR DESCRIPTION
## Summary

Adds a `keyboard_keep_on_scroll` setting (Settings → Keyboard, default **off**) — when enabled, touch-scrolling back through terminal history no longer collapses the mobile keyboard.

**TL;DR（中文）**：新增「滚动时保持键盘」开关（默认关闭）：手机上打字过程中想上翻看看历史输出时，键盘不再被滚动手势收起。

Currently every scroll gesture dismisses the keyboard (`onTerminalScroll` and the two drag-end collapse sites in App.vue). That is the right default, but when typing a long command while referring to earlier output it forces a re-summon of the keyboard after every peek. The new setting guards those three collapse sites; nothing changes unless the user opts in.

Changes: settings field + default, Keyboard tab toggle row (existing toggle style), zh/en i18n strings, three one-line guards in App.vue.

## Test plan

- [x] Frontend suite: 726 passed — the two count-assertion failures in `actionKeyboard.test.ts` / `keybindings.test.ts` reproduce on plain dev (eaf656ab) without this change (app-action registry gained a 20th entry but the count tests expect 18/19)
- [x] Manual on Android + iOS browsers: default behavior unchanged; with the toggle on, drag-scrolling keeps the keyboard open and typing continues seamlessly