### PR TITLE
fix(output): close two concurrency bugs in the terminal output path

### DIFF
--- a/src/pty.rs
+++ b/src/pty.rs
@@ -378,58 +378,58 @@ pub fn create_session(
                     // CWD sniffing (before lock, uses its own cwd_state lock)
                     reader_session.on_pty_output(data);
 
-                    // Feed to virtual screen + extract command results + handle sync events
-                    {
+                    // Feed to virtual screen + extract command results + collect sync events
+                    let feed_result = {
                         let mut screen = reader_session
                             .screen
                             .lock()
                             .unwrap_or_else(std::sync::PoisonError::into_inner);
-                        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                             screen.feed(data);
                             let results = screen.drain_command_results();
                             let outputs: Vec<String> =
                                 (0..results.len()).map(|_| screen.take_command_output()).collect();
                             let sync = screen.drain_sync_events();
                             (results.into_iter().zip(outputs).collect::<Vec<_>>(), sync)
-                        }));
-                        match result {
-                            Ok((command_results, sync_events)) => {
-                                // Handle sync events immediately (while still holding lock
-                                // prevents race between sync start and broadcast task wakeup)
-                                for event in sync_events {
-                                    match event {
-                                        crate::vt_screen::SyncEvent::Start => {
-                                            reader_session.set_sync_mode(true);
-                                        }
-                                        crate::vt_screen::SyncEvent::Stop => {
-                                            reader_session.set_sync_mode(false);
-                                        }
+                        }))
+                    };
+                    match feed_result {
+                        Ok((command_results, sync_events)) => {
+                            // Apply sync transitions before publishing this read to output_tx.
+                            // The broadcast task cannot observe these bytes until send() below.
+                            for event in sync_events {
+                                match event {
+                                    crate::vt_screen::SyncEvent::Start => {
+                                        reader_session.set_sync_mode(true);
                                     }
-                                }
-                                // Queue command results for broadcast task
-                                if !command_results.is_empty() {
-                                    let mut pending = reader_session
-                                        .pending_results
-                                        .lock()
-                                        .unwrap_or_else(std::sync::PoisonError::into_inner);
-                                    for (result, stdout) in command_results {
-                                        pending.push(crate::session::PendingCommandResult {
-                                            exit_code: result.exit_code,
-                                            duration_ms: result.duration_ms,
-                                            stdout,
-                                            method: result.method,
-                                        });
+                                    crate::vt_screen::SyncEvent::Stop => {
+                                        reader_session.set_sync_mode(false);
                                     }
                                 }
                             }
-                            Err(e) => {
-                                let msg = e
-                                    .downcast_ref::<String>()
-                                    .map(String::as_str)
-                                    .or_else(|| e.downcast_ref::<&str>().copied())
-                                    .unwrap_or("unknown");
-                                error!("feed() PANICKED: {}, {}B, pane={}", msg, n, reader_pane);
+                            // Queue command results for broadcast task
+                            if !command_results.is_empty() {
+                                let mut pending = reader_session
+                                    .pending_results
+                                    .lock()
+                                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                                for (result, stdout) in command_results {
+                                    pending.push(crate::session::PendingCommandResult {
+                                        exit_code: result.exit_code,
+                                        duration_ms: result.duration_ms,
+                                        stdout,
+                                        method: result.method,
+                                    });
+                                }
                             }
+                        }
+                        Err(e) => {
+                            let msg = e
+                                .downcast_ref::<String>()
+                                .map(String::as_str)
+                                .or_else(|| e.downcast_ref::<&str>().copied())
+                                .unwrap_or("unknown");
+                            error!("feed() PANICKED: {}, {}B, pane={}", msg, n, reader_pane);
                         }
                     }
 

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::too_many_lines)]
 use crate::event_bus::BusEvent;
 use crate::platform::shell;
-use crate::session::{Session, SessionBackend, SessionManager, SessionStatus, SyncMsg};
+use crate::session::{Session, SessionBackend, SessionManager, SessionStatus, SyncMsg, SyncState};
 use crate::vt_screen::VirtualScreen;
 use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
 use std::io::{Read, Write};
@@ -27,7 +27,7 @@ pub async fn broadcast_task(session: Arc<Session>, pane_id: String, manager: Arc
     // Watchdog timer: force-flush the sync buffer if the PTY goes silent
     // mid-sync-mode. Without this, the timeout check below only fires when
     // output_rx.recv() returns a new message — a silent PTY (e.g. Claude
-    // Code waiting on an API response mid-redraw) leaves sync_active=true
+    // Code waiting on an API response mid-redraw) leaves sync mode active
     // forever, buffering all subsequent output and freezing the client
     // until a manual refresh. Polling every 100ms is cheap and well below
     // the 500ms timeout threshold.
@@ -50,7 +50,7 @@ pub async fn broadcast_task(session: Arc<Session>, pane_id: String, manager: Arc
                     batch.extend_from_slice(&data);
                 }
 
-                if session.sync_active.load(std::sync::atomic::Ordering::Relaxed) {
+                if session.is_sync_active() {
                     if let Some(started) = sync_started_at {
                         if started.elapsed() > sync_timeout {
                             tracing::warn!(
@@ -120,7 +120,7 @@ pub async fn broadcast_task(session: Arc<Session>, pane_id: String, manager: Arc
                 // PTY-silent watchdog: if sync mode is still active past the
                 // timeout with no new output, force-flush so the client
                 // unblocks. This is the path that was missing before.
-                if session.sync_active.load(std::sync::atomic::Ordering::Relaxed) {
+                if session.is_sync_active() {
                     if let Some(started) = sync_started_at {
                         if started.elapsed() > sync_timeout {
                             tracing::warn!(
@@ -297,9 +297,9 @@ pub fn create_session(
             cwd: initial_cwd,
             sniff_buf: Vec::new(),
         }),
-        sync_active: std::sync::atomic::AtomicBool::new(false),
-        sync_buffer: std::sync::Mutex::new(Vec::new()),
-        sync_buffer_bytes: std::sync::atomic::AtomicUsize::new(0),
+        sync: std::sync::Mutex::new(SyncState::default()),
+        #[cfg(test)]
+        sync_disable_hook: std::sync::Mutex::new(None),
         resize_tx,
         ssh_cmd_tx: std::sync::Mutex::new(None),
         ssh_handle: tokio::sync::Mutex::new(None),

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -9,7 +9,7 @@ use std::{
     io::Write,
     path::{Path, PathBuf},
     sync::{
-        atomic::{AtomicBool, AtomicU16, AtomicU64, AtomicUsize, Ordering},
+        atomic::{AtomicU16, AtomicU64, Ordering},
         Arc, Mutex, OnceLock,
     },
     time::Instant,
@@ -56,7 +56,7 @@ pub enum SshCmd {
     Close,
 }
 
-/// Force-flush `sync_buffer` when accumulated data exceeds this limit (256KB).
+/// Force-flush buffered synchronized output at this limit (256KB).
 /// Prevents massive single payloads that freeze the frontend UI thread.
 const SYNC_BUFFER_LIMIT: usize = 256 * 1024;
 /// Maximum size of a single chunk sent to clients during flush.
@@ -74,6 +74,13 @@ pub enum SessionStatus {
 pub struct CwdState {
     pub cwd: PathBuf,
     pub sniff_buf: Vec<u8>,
+}
+
+#[derive(Default)]
+pub struct SyncState {
+    active: bool,
+    buffer: Vec<String>,
+    bytes: usize,
 }
 
 pub struct PendingCommandResult {
@@ -94,11 +101,11 @@ pub enum SessionClientEvent {
         pane_id: String,
     },
     /// DEC mode 2026 transaction boundary. `SyncBegin` is enqueued BEFORE any
-    /// subsequent Output (which goes to the `sync_buffer` while `sync_active` is
-    /// true); `SyncEnd` is enqueued AFTER `flush_sync_buffer` drains the buffer,
-    /// so the on-wire order is [buffered Output chunks] → `SyncEnd` → [post-sync
-    /// live Output]. Frontend uses these to divert Output into a transaction
-    /// buffer and write it to xterm as a single batch, eliminating per-chunk
+    /// subsequent Output (which is buffered while synchronized output is
+    /// active); `SyncEnd` is enqueued AFTER that buffer is drained, so the
+    /// on-wire order is [buffered Output chunks] → `SyncEnd` → [post-sync live
+    /// Output]. Frontend uses these to divert Output into a transaction buffer
+    /// and write it to xterm as a single batch, eliminating per-chunk
     /// intermediate rAF repaints during a synchronized redraw.
     SyncBegin,
     SyncEnd,
@@ -143,12 +150,10 @@ pub struct Session {
     #[allow(clippy::type_complexity)]
     pub tauri_on_exit: Mutex<Option<Arc<dyn Fn(String) + Send + Sync>>>,
     pub cwd_state: Mutex<CwdState>,
-    /// DEC mode 2026: synchronized output active flag
-    pub sync_active: AtomicBool,
-    /// Buffered output while synchronized output mode is active
-    pub sync_buffer: Mutex<Vec<String>>,
-    /// Running byte count of `sync_buffer` to avoid O(n) sum on every broadcast
-    pub sync_buffer_bytes: AtomicUsize,
+    /// DEC mode 2026 state. Always acquire this before `clients` when both are needed.
+    pub sync: Mutex<SyncState>,
+    #[cfg(test)]
+    pub(crate) sync_disable_hook: Mutex<Option<Box<dyn FnOnce() + Send>>>,
     /// Sender for debounced resize requests (None = no pending resize)
     pub(crate) resize_tx: watch::Sender<Option<(u64, u16, u16)>>,
     /// Channel to send commands (input/resize/close) to the SSH reader task.
@@ -369,7 +374,7 @@ impl Session {
         // PTY + size + screen resize (async — uses backend lock). Resize also
         // breaks sync mode if active (apply_and_broadcast_resize / Step 1b),
         // but resize_async does not break sync itself — handle that here.
-        if self.sync_active.load(Ordering::Relaxed) {
+        if self.is_sync_active() {
             self.set_sync_mode(false);
         }
         self.resize_async(cols, rows).await?;
@@ -452,12 +457,12 @@ impl Session {
         // terminal to end sync mode on resize, and doing so prevents the
         // buffer-stuck bug where a PTY that goes silent mid-sync (e.g. Claude
         // Code waiting on an API response during a window resize) leaves
-        // sync_active=true forever and the client sees a frozen screen.
+        // synchronized output active forever and the client sees a frozen screen.
         //
         // We flush BEFORE resizing so clients receive the pre-resize buffered
         // output at the old dimensions, then the resize event, then
         // post-resize output at the new dimensions — coherent ordering.
-        if self.sync_active.load(Ordering::Relaxed) {
+        if self.is_sync_active() {
             tracing::debug!("apply_and_broadcast_resize: breaking sync mode for resize, pane=?");
             self.set_sync_mode(false);
         }
@@ -553,40 +558,52 @@ impl Session {
         if self.is_exited() {
             return;
         }
-        if self.sync_active.load(Ordering::Relaxed) {
-            let mut buf =
-                self.sync_buffer.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut sync = self.sync.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        if sync.active {
             let len = msg.len();
-            buf.push(msg.to_string());
-            let total = self.sync_buffer_bytes.fetch_add(len, Ordering::Relaxed) + len;
-            if total < SYNC_BUFFER_LIMIT {
+            sync.buffer.push(msg.to_string());
+            sync.bytes += len;
+            if sync.bytes < SYNC_BUFFER_LIMIT {
                 return;
             }
-            drop(buf);
-            self.flush_sync_buffer();
+            self.flush_sync_buffer_locked(&mut sync);
             return;
         }
         let mut clients = self.clients.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         Self::send_chunk_to_clients(&mut clients, msg);
     }
 
+    pub fn is_sync_active(&self) -> bool {
+        self.sync.lock().unwrap_or_else(std::sync::PoisonError::into_inner).active
+    }
+
     /// Enable or disable synchronized output mode (DEC mode 2026).
-    /// When enabling: mark `sync_active` first (so subsequent `broadcast()` calls
-    /// divert Output to `sync_buffer` instead of going direct), then enqueue
-    /// `SyncBegin` to clients — it lands in the per-client mpsc channel before
-    /// any buffered Output could be flushed.
-    /// When disabling: flush `sync_buffer` (buffered chunks land in client
-    /// channels), enqueue `SyncEnd`, THEN clear `sync_active` so the broadcast
-    /// task resumes direct sends. The on-wire order per client is therefore
-    /// [buffered Output] → `SyncEnd` → [post-sync live Output].
+    /// When enabling: mark the sync state active, then enqueue `SyncBegin` while
+    /// holding the sync guard, so no subsequent Output can overtake it.
+    /// When disabling: mark inactive, flush buffered Output, and enqueue
+    /// `SyncEnd` while holding the same guard. A concurrent `broadcast()` then
+    /// lands after `SyncEnd` in each client's mpsc channel.
     pub fn set_sync_mode(&self, active: bool) {
+        let mut sync = self.sync.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         if active {
-            self.sync_active.store(true, Ordering::Relaxed);
+            sync.active = true;
             self.enqueue_control(&SessionClientEvent::SyncBegin);
         } else {
-            self.flush_sync_buffer();
+            if !sync.active {
+                return;
+            }
+            sync.active = false;
+            self.flush_sync_buffer_locked(&mut sync);
+            #[cfg(test)]
+            if let Some(hook) = self
+                .sync_disable_hook
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .take()
+            {
+                hook();
+            }
             self.enqueue_control(&SessionClientEvent::SyncEnd);
-            self.sync_active.store(false, Ordering::Relaxed);
         }
     }
 
@@ -606,13 +623,13 @@ impl Session {
     /// Flush buffered output accumulated during synchronized output mode.
     /// Breaks large payloads into chunks to avoid freezing the frontend UI thread.
     pub fn flush_sync_buffer(&self) {
-        let data: Vec<String> = {
-            let mut buf =
-                self.sync_buffer.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-            let d = std::mem::take(&mut *buf);
-            self.sync_buffer_bytes.store(0, Ordering::Relaxed);
-            d
-        };
+        let mut sync = self.sync.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        self.flush_sync_buffer_locked(&mut sync);
+    }
+
+    fn flush_sync_buffer_locked(&self, sync: &mut SyncState) {
+        let data = std::mem::take(&mut sync.buffer);
+        sync.bytes = 0;
         if data.is_empty() {
             return;
         }
@@ -1639,14 +1656,15 @@ impl SessionManager {
 #[cfg(test)]
 mod tests;
 
-/// Covers `kill_and_remove`'s attention-ledger wiring specifically (session/tests.rs is out of
-/// scope for this change and only covers layout helpers). A stub `Session` with
-/// `SessionBackend::Exited` avoids spawning a real PTY/child process.
+/// Session regressions that use a stub with `SessionBackend::Exited` to avoid
+/// spawning a real PTY/child process.
 #[cfg(test)]
-mod kill_and_remove_notifier_tests {
+mod session_stub_tests {
     use super::*;
     use crate::notification::NotificationBroadcast;
-    use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize};
+    use std::sync::atomic::AtomicU64;
+    use std::sync::mpsc as std_mpsc;
+    use std::time::Duration;
 
     fn stub_session() -> Arc<Session> {
         let (resize_tx, _resize_rx) = watch::channel(None);
@@ -1665,9 +1683,8 @@ mod kill_and_remove_notifier_tests {
             shell_type: "test".to_string(),
             tauri_on_exit: Mutex::new(None),
             cwd_state: Mutex::new(CwdState { cwd: PathBuf::from("/"), sniff_buf: Vec::new() }),
-            sync_active: AtomicBool::new(false),
-            sync_buffer: Mutex::new(Vec::new()),
-            sync_buffer_bytes: AtomicUsize::new(0),
+            sync: Mutex::new(SyncState::default()),
+            sync_disable_hook: Mutex::new(None),
             resize_tx,
             ssh_cmd_tx: Mutex::new(None),
             ssh_handle: tokio::sync::Mutex::new(None),
@@ -1678,6 +1695,107 @@ mod kill_and_remove_notifier_tests {
             output_rx: Mutex::new(Some(output_rx)),
             pending_results: Mutex::new(Vec::new()),
         })
+    }
+
+    fn add_ready_client(session: &Session) -> mpsc::Receiver<SessionClientEvent> {
+        let (client_id, rx) = session.add_client();
+        let clients = session.clients.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        clients
+            .iter()
+            .find(|client| client.id == client_id)
+            .expect("newly added client must exist")
+            .snapshot_pending
+            .store(false, Ordering::Relaxed);
+        rx
+    }
+
+    fn assert_output(event: SessionClientEvent, expected: &str) {
+        match event {
+            SessionClientEvent::Output(output) => assert_eq!(output, expected),
+            _ => panic!("expected Output event"),
+        }
+    }
+
+    #[test]
+    fn sync_wire_order_is_begin_buffer_end_live() {
+        let session = stub_session();
+        let mut rx = add_ready_client(&session);
+
+        session.set_sync_mode(true);
+        session.broadcast("BUF");
+        session.set_sync_mode(false);
+        session.broadcast("LIVE");
+
+        assert!(matches!(rx.try_recv(), Ok(SessionClientEvent::SyncBegin)));
+        assert_output(rx.try_recv().expect("buffered output"), "BUF");
+        assert!(matches!(rx.try_recv(), Ok(SessionClientEvent::SyncEnd)));
+        assert_output(rx.try_recv().expect("live output"), "LIVE");
+        assert!(matches!(rx.try_recv(), Err(mpsc::error::TryRecvError::Empty)));
+    }
+
+    #[test]
+    fn sync_teardown_blocks_concurrent_broadcast_until_after_sync_end() {
+        let session = stub_session();
+        let mut rx = add_ready_client(&session);
+        session.set_sync_mode(true);
+        session.broadcast("BUF");
+
+        let weak_session = Arc::downgrade(&session);
+        let (started_tx, started_rx) = std_mpsc::channel();
+        let (finished_tx, finished_rx) = std_mpsc::channel();
+        let thread_handle = Arc::new(Mutex::new(None));
+        let hook_thread_handle = Arc::clone(&thread_handle);
+        *session.sync_disable_hook.lock().unwrap_or_else(std::sync::PoisonError::into_inner) =
+            Some(Box::new(move || {
+                let broadcast_session = weak_session.upgrade().expect("session remains alive");
+                let handle = std::thread::spawn(move || {
+                    started_tx.send(()).expect("teardown hook remains alive");
+                    broadcast_session.broadcast("LIVE");
+                    let _ = finished_tx.send(());
+                });
+                *hook_thread_handle.lock().unwrap_or_else(std::sync::PoisonError::into_inner) =
+                    Some(handle);
+
+                started_rx
+                    .recv_timeout(Duration::from_secs(1))
+                    .expect("concurrent broadcaster must start");
+                assert!(
+                    matches!(
+                        finished_rx.recv_timeout(Duration::from_millis(100)),
+                        Err(std_mpsc::RecvTimeoutError::Timeout)
+                    ),
+                    "concurrent broadcast passed the sync guard before teardown completed"
+                );
+            }));
+
+        session.set_sync_mode(false);
+        thread_handle
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take()
+            .expect("hook spawned broadcaster")
+            .join()
+            .expect("concurrent broadcaster completed");
+
+        assert!(matches!(rx.try_recv(), Ok(SessionClientEvent::SyncBegin)));
+        assert_output(rx.try_recv().expect("buffered output"), "BUF");
+        assert!(matches!(rx.try_recv(), Ok(SessionClientEvent::SyncEnd)));
+        assert_output(rx.try_recv().expect("live output"), "LIVE");
+        assert!(matches!(rx.try_recv(), Err(mpsc::error::TryRecvError::Empty)));
+    }
+
+    #[test]
+    fn double_sync_disable_emits_exactly_one_sync_end() {
+        let session = stub_session();
+        let mut rx = add_ready_client(&session);
+
+        session.set_sync_mode(true);
+        session.set_sync_mode(false);
+        session.set_sync_mode(false);
+
+        assert!(matches!(rx.try_recv(), Ok(SessionClientEvent::SyncBegin)));
+        assert!(matches!(rx.try_recv(), Ok(SessionClientEvent::SyncEnd)));
+        assert!(matches!(rx.try_recv(), Err(mpsc::error::TryRecvError::Empty)));
     }
 
     #[tokio::test]

--- a/src/ssh/mod.rs
+++ b/src/ssh/mod.rs
@@ -519,9 +519,9 @@ pub async fn create_ssh_session(
         shell_type: "ssh".to_string(),
         tauri_on_exit: std::sync::Mutex::new(tauri_on_exit),
         cwd_state: std::sync::Mutex::new(CwdState { cwd: effective_cwd, sniff_buf: Vec::new() }),
-        sync_active: std::sync::atomic::AtomicBool::new(false),
-        sync_buffer: std::sync::Mutex::new(Vec::new()),
-        sync_buffer_bytes: std::sync::atomic::AtomicUsize::new(0),
+        sync: std::sync::Mutex::new(crate::session::SyncState::default()),
+        #[cfg(test)]
+        sync_disable_hook: std::sync::Mutex::new(None),
         resize_tx,
         ssh_cmd_tx: std::sync::Mutex::new(Some(ssh_cmd_tx)),
         ssh_handle: tokio::sync::Mutex::new(None),


### PR DESCRIPTION
Two independent concurrency bugs in the PTY output path. Both reproduce on `dev` as-is; neither is fork-specific.

## 1. DEC 2026 synchronized output: cross-task race reorders the stream

`sync_active` (`AtomicBool`), `sync_buffer` (`Mutex<Vec<String>>`) and `sync_buffer_bytes` (`AtomicUsize`) are three separate pieces of state mutated from different tokio tasks with no shared critical section.

`set_sync_mode(false)` drains the buffer and enqueues `SyncEnd` *before* clearing the active flag:

```rust
self.flush_sync_buffer();
self.enqueue_control(&SessionClientEvent::SyncEnd);
self.sync_active.store(false, Ordering::Relaxed);   // gap above this line
```

`set_sync_mode` runs on the PTY reader task; `broadcast()` runs on the broadcast task. A `broadcast()` landing in that gap reads `sync_active == true` and pushes its payload into the just-emptied buffer, where it strands until the next frame. The following payload reads `false` and goes direct, arriving on time.

**This is reordering, not loss.** An escape sequence split across that boundary is delivered with its halves swapped, so the tail reaches the terminal without its introducer and renders as literal text — visible garbling on screen.

Wire-level evidence (browser-side capture of the raw WebSocket stream):

| bare tail at offset | orphaned head at offset | reassembled |
|---|---|---|
| 979457 `;2;153;153;153m` | 980535 `ESC[38` | `ESC[38;2;153;153;153m` |
| 346111 `;2;1…` | 347518 `ESC[38;2;1` | — |

Exact complements, three independent occurrences, and every orphaned head is immediately followed by the next frame's `ESC[?2026h`.

**Fix:** merge the three fields into a single `Mutex<SyncState { active, buffer, bytes }>` and hold the guard across the entire teardown (mark inactive → drain → send → `SyncEnd`). Releasing mid-sequence lets a direct send overtake the buffered tail, so the guard has to span the whole thing. `broadcast()` holds the same guard across its check-and-act. Adds `is_sync_active()` to funnel the four external read sites, and makes the disable path a no-op when already inactive so the check-then-act watchdogs cannot emit a spurious second `SyncEnd`.

## 2. `screen` → `clients` lock cycle freezes the PTY reader

Two paths acquire the same pair in opposite orders:

```
atomic_resize_and_snapshot_for_client:  clients -> screen
PTY reader (set_sync_mode -> enqueue_control):  screen -> clients
```

The reader dispatches drained sync events while still holding the screen lock, and `enqueue_control` takes `clients`. A snapshot holding `clients` and waiting for `screen`, against a reader holding `screen` and waiting for `clients`, blocks both permanently — the PTY reader stops and the pane goes dead.

**Fix:** collect the sync events under the screen lock, release it, then apply the transitions.

The existing comment claims the screen lock is what prevents a sync-start / broadcast-wakeup race. That is not where the guarantee comes from: `set_sync_mode()` runs earlier in the same sequential task than the `output_tx.send()` below it, and the broadcast task cannot observe those bytes until that send. Lock scope is irrelevant to the ordering, so moving the call out is safe.

Enumerated every `screen` and `clients` acquisition in the tree: after this change no `screen -> clients` edge remains anywhere (the SSH reader, `agent.rs`, `openapi.rs` and the resize paths never nest the two), leaving only the snapshot path's `clients -> screen`. A single direction cannot cycle.

## Verification

- `cargo test`: 365 passed, 0 failed. `cargo fmt --check` and `cargo clippy` clean.
- The sync-race regression test is **proven discriminating**: splicing the old ordering back in fails it at the intended assertion with `concurrent broadcast passed the sync guard before teardown completed`.
- Real-machine: two rebuilds of a live instance, 1.25M then 2.0M chars of wire capture across 4111 synchronized frames — zero truncated CSI, zero bare SGR parameter tails, zero malformed colour sequences. Pre-fix rate was ~4.2 corruption points per million chars, so a clean 2.0M sample would be a ~0.02% coincidence if the race were still live.

**The deadlock fix has no test.** A lock cycle cannot be reproduced deterministically, so the enumeration above is the argument rather than an executable check. Flagging that explicitly rather than implying both halves carry equal evidence.

## Noted but deliberately not touched

`flush_sync_buffer` chunks with `combined.as_bytes().chunks(FLUSH_CHUNK_SIZE)` followed by `from_utf8_lossy`, which splits a multibyte character at every 64KB boundary and replaces both halves with U+FFFD — CJK and emoji corrupt on large flushes. This PR preserves that loop verbatim to stay single-purpose. Happy to send a separate PR for it if you'd like.
