### PR TITLE
fix(session): keep sync-buffer flush chunks on UTF-8 boundaries

### DIFF
--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -604,7 +604,8 @@ impl Session {
     }
 
     /// Flush buffered output accumulated during synchronized output mode.
-    /// Breaks large payloads into chunks to avoid freezing the frontend UI thread.
+    /// Breaks large payloads into chunks at UTF-8 character boundaries to avoid
+    /// freezing the frontend UI thread.
     pub fn flush_sync_buffer(&self) {
         let data: Vec<String> = {
             let mut buf =
@@ -618,13 +619,14 @@ impl Session {
         }
         let combined = data.join("");
         let mut clients = self.clients.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-        if combined.len() <= FLUSH_CHUNK_SIZE {
-            Self::send_chunk_to_clients(&mut clients, &combined);
-        } else {
-            for chunk in combined.as_bytes().chunks(FLUSH_CHUNK_SIZE) {
-                let s = String::from_utf8_lossy(chunk).into_owned();
-                Self::send_chunk_to_clients(&mut clients, &s);
+        let mut start = 0;
+        while start < combined.len() {
+            let mut end = (start + FLUSH_CHUNK_SIZE).min(combined.len());
+            while end > start && !combined.is_char_boundary(end) {
+                end -= 1;
             }
+            Self::send_chunk_to_clients(&mut clients, &combined[start..end]);
+            start = end;
         }
     }
 
@@ -1678,6 +1680,31 @@ mod kill_and_remove_notifier_tests {
             output_rx: Mutex::new(Some(output_rx)),
             pending_results: Mutex::new(Vec::new()),
         })
+    }
+
+    #[test]
+    fn flush_sync_buffer_preserves_multibyte_across_chunk_boundary() {
+        let session = stub_session();
+        let (_, mut rx) = session.add_client();
+        session.clients.lock().unwrap()[0].snapshot_pending.store(false, Ordering::Relaxed);
+
+        let input = format!("{}界tail", "a".repeat(FLUSH_CHUNK_SIZE - 1));
+        session.sync_buffer.lock().unwrap().push(input.clone());
+        session.sync_buffer_bytes.store(input.len(), Ordering::Relaxed);
+
+        session.flush_sync_buffer();
+
+        let received: String = std::iter::from_fn(|| rx.try_recv().ok())
+            .filter_map(|event| match event {
+                SessionClientEvent::Output(data) => Some(data),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            !received.contains('\u{FFFD}'),
+            "flushed output contains U+FFFD replacement character"
+        );
+        assert_eq!(received, input);
     }
 
     #[tokio::test]


### PR DESCRIPTION
`flush_sync_buffer()` splits large payloads with a fixed 65536-byte stride:

```rust
for chunk in combined.as_bytes().chunks(FLUSH_CHUNK_SIZE) {
    let s = String::from_utf8_lossy(chunk).into_owned();
    Self::send_chunk_to_clients(&mut clients, &s);
}
```

`chunks()` knows nothing about UTF-8. When a multibyte character straddles a 64KB boundary its bytes land in two different chunks, and `from_utf8_lossy` then replaces the trailing partial sequence of chunk N *and* the leading continuation bytes of chunk N+1 with U+FFFD. The character is destroyed on the wire — the client never receives the bytes needed to reassemble it.

This hits any non-ASCII content — CJK, emoji, box-drawing — in a synchronized-output flush larger than 64KB. Probability per flush is roughly (character width − 1) / 65536 per boundary crossed, so it is rare per event but unbounded over a long session, and each hit is a permanently wrong glyph rather than something that repaints.

## Fix

Walk the string with `is_char_boundary`, backing off to the nearest boundary at or below the stride:

```rust
let mut start = 0;
while start < combined.len() {
    let mut end = (start + FLUSH_CHUNK_SIZE).min(combined.len());
    while end > start && !combined.is_char_boundary(end) {
        end -= 1;
    }
    Self::send_chunk_to_clients(&mut clients, &combined[start..end]);
    start = end;
}
```

Notes on the shape:

- Chunks become "at most `FLUSH_CHUNK_SIZE`" instead of exactly. The shortfall is at most 3 bytes, and the constant exists to bound per-write work on the frontend UI thread, so an under-shoot is harmless.
- The `combined.len() <= FLUSH_CHUNK_SIZE` fast path is subsumed rather than kept: under the limit the loop runs exactly once with `end == combined.len()` and sends the whole string, which is what the old branch did.
- The `end > start` guard cannot actually fire — a UTF-8 character is at most 4 bytes and the stride is 65536 — but it means the loop is structurally incapable of spinning.
- `send_chunk_to_clients` already takes `&str`, so slicing borrows directly and the per-chunk `from_utf8_lossy(...).into_owned()` allocation goes away.

## Verification

`cargo fmt --check` clean, `cargo test --lib` 362 → 363 passed / 0 failed.

The added test is **proven discriminating**: it builds an input where a 3-byte character straddles offset 65536, and against the old code it fails on the U+FFFD assertion. It checks both that the received stream equals the input exactly and that it contains no replacement character — the equality proves no corruption, the U+FFFD check names the failure mode so a future regression is self-describing.

I could not run `cargo clippy --all-targets` to completion on a bare checkout: `main.rs` needs the embedded `frontend/dist`, which is absent until the frontend is built. Nothing in this diff introduces a lint-visible construct.

## Relationship to #194

Independent — different defect, different mechanism, and this one is a pure data bug with no concurrency aspect. I kept the three-field `sync_active` / `sync_buffer` / `sync_buffer_bytes` structure untouched here rather than anticipating #194's restructure, so the two can be reviewed and merged in either order.

They do touch adjacent lines, so whichever lands second will want a trivial rebase: #194 moves this loop into `flush_sync_buffer_locked` but preserves it verbatim, so the rebase is the same six lines at a new location. Happy to do that rebase whenever you decide the order.
