### PR TITLE
fix(pty): stop a transient lock failure from killing keyboard input

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -163,7 +163,7 @@ fn spawn_tauri_write_task(session: Arc<dinotty_server::session::Session>, pane_i
                 write_session.write_input_async(batch.as_bytes()).await
             } else {
                 let ws = Arc::clone(&write_session);
-                tokio::task::spawn_blocking(move || ws.write_input_sync(batch.as_bytes()))
+                tokio::task::spawn_blocking(move || ws.write_input_blocking(batch.as_bytes()))
                     .await
                     .unwrap_or_else(|e| Err(e.to_string()))
             };

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -266,6 +266,24 @@ impl Session {
         let Ok(mut backend) = self.backend.try_lock() else {
             return Err("backend lock held".into());
         };
+        Self::write_input_locked(&mut backend, data)
+    }
+
+    /// Write input while waiting for the backend lock from a blocking thread.
+    ///
+    /// Callers MUST be inside `tokio::task::spawn_blocking` (or otherwise off-runtime), because
+    /// `blocking_lock` panics when called on a Tokio worker thread. Waiting is intentional: a
+    /// superseded connection's writer may wait and write its already-dequeued batch slightly late
+    /// instead of failing fast.
+    ///
+    /// # Errors
+    /// Returns an error if the backend is not local or the write fails.
+    pub fn write_input_blocking(&self, data: &[u8]) -> Result<(), String> {
+        let mut backend = self.backend.blocking_lock();
+        Self::write_input_locked(&mut backend, data)
+    }
+
+    fn write_input_locked(backend: &mut SessionBackend, data: &[u8]) -> Result<(), String> {
         match &mut *backend {
             SessionBackend::Local { writer, .. } => {
                 writer.write_all(data).map_err(|e| e.to_string())?;

--- a/src/session/tests.rs
+++ b/src/session/tests.rs
@@ -1,4 +1,103 @@
 use super::*;
+use portable_pty::{Child, ChildKiller, ExitStatus, NativePtySystem, PtySize, PtySystem};
+use std::io;
+
+#[derive(Debug)]
+struct TestChild;
+
+impl ChildKiller for TestChild {
+    fn kill(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn clone_killer(&self) -> Box<dyn ChildKiller + Send + Sync> {
+        Box::new(Self)
+    }
+}
+
+impl Child for TestChild {
+    fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
+        Ok(None)
+    }
+
+    fn wait(&mut self) -> io::Result<ExitStatus> {
+        Ok(ExitStatus::with_exit_code(0))
+    }
+
+    fn process_id(&self) -> Option<u32> {
+        None
+    }
+
+    #[cfg(windows)]
+    fn as_raw_handle(&self) -> Option<std::os::windows::io::RawHandle> {
+        None
+    }
+}
+
+fn local_session() -> Arc<Session> {
+    let pair = NativePtySystem::default()
+        .openpty(PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 })
+        .unwrap();
+    drop(pair.slave);
+
+    let (resize_tx, _resize_rx) = watch::channel(None);
+    let (output_tx, output_rx) = mpsc::unbounded_channel();
+    Arc::new(Session {
+        backend: tokio::sync::Mutex::new(SessionBackend::Local {
+            writer: Box::new(io::sink()),
+            master: pair.master,
+            child: Box::new(TestChild),
+        }),
+        ssh_params: None,
+        screen: Mutex::new(VirtualScreen::new(80, 24)),
+        clients: Mutex::new(Vec::new()),
+        next_client_id: AtomicU64::new(1),
+        tauri_client_id: Mutex::new(None),
+        input_tx: Mutex::new(None),
+        status: Mutex::new(SessionStatus::Connected),
+        size: Mutex::new((80, 24)),
+        exited: Mutex::new(false),
+        shell_type: "test".to_string(),
+        tauri_on_exit: Mutex::new(None),
+        cwd_state: Mutex::new(CwdState { cwd: PathBuf::from("/"), sniff_buf: Vec::new() }),
+        sync_active: AtomicBool::new(false),
+        sync_buffer: Mutex::new(Vec::new()),
+        sync_buffer_bytes: AtomicUsize::new(0),
+        resize_tx,
+        ssh_cmd_tx: Mutex::new(None),
+        ssh_handle: tokio::sync::Mutex::new(None),
+        sftp_session: Mutex::new(None),
+        remote_home: Mutex::new(None),
+        remote_user: Mutex::new(None),
+        output_tx,
+        output_rx: Mutex::new(Some(output_rx)),
+        pending_results: Mutex::new(Vec::new()),
+    })
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn write_input_blocking_waits_for_backend_lock() {
+    let session = local_session();
+    let backend = session.backend.lock().await;
+
+    assert_eq!(session.write_input_sync(b"sync"), Err("backend lock held".to_string()));
+
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+    let write_session = Arc::clone(&session);
+    let mut writer = tokio::task::spawn_blocking(move || {
+        let _ = started_tx.send(());
+        write_session.write_input_blocking(b"blocking")
+    });
+    started_rx.await.unwrap();
+
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(50), &mut writer).await.is_err(),
+        "write_input_blocking returned while backend lock was held"
+    );
+
+    drop(backend);
+    assert_eq!(writer.await.unwrap(), Ok(()));
+}
 
 // ── helpers ──────────────────────────────────────────────────────
 

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -639,7 +639,7 @@ async fn handle_socket(
                     write_session.write_input_async(batch.as_bytes()).await
                 } else {
                     let ws = Arc::clone(&write_session);
-                    tokio::task::spawn_blocking(move || ws.write_input_sync(batch.as_bytes()))
+                    tokio::task::spawn_blocking(move || ws.write_input_blocking(batch.as_bytes()))
                         .await
                         .unwrap_or_else(|e| Err(e.to_string()))
                 };
@@ -804,7 +804,7 @@ async fn handle_socket(
                 write_session.write_input_async(batch.as_bytes()).await
             } else {
                 let ws = Arc::clone(&write_session);
-                tokio::task::spawn_blocking(move || ws.write_input_sync(batch.as_bytes()))
+                tokio::task::spawn_blocking(move || ws.write_input_blocking(batch.as_bytes()))
                     .await
                     .unwrap_or_else(|e| Err(e.to_string()))
             };
@@ -1193,7 +1193,7 @@ pub async fn handle_open_api_ws(socket: WebSocket, manager: Arc<SessionManager>,
                 write_session.write_input_async(batch.as_bytes()).await
             } else {
                 let ws = Arc::clone(&write_session);
-                tokio::task::spawn_blocking(move || ws.write_input_sync(batch.as_bytes()))
+                tokio::task::spawn_blocking(move || ws.write_input_blocking(batch.as_bytes()))
                     .await
                     .unwrap_or_else(|e| Err(e.to_string()))
             };


### PR DESCRIPTION
A single lost lock race permanently kills keyboard input for a pane. The pane looks completely dead — but the process is healthy, the WebSocket stays ESTABLISHED, and nothing further is logged, so it reads as a hang rather than a failure.

## The defect

`Session::write_input_sync` takes the PTY backend with `try_lock` and reports contention as an error:

```rust
let Ok(mut backend) = self.backend.try_lock() else {
    return Err("backend lock held".into());
};
```

The four long-lived writer tasks (`src/ws/mod.rs` ×3, `src-tauri/src/main.rs` ×1) treat every `Err` as fatal:

```rust
Err(e) => {
    error!("PTY write error ({}B): {}, pane={}", batch_len, e, write_pane);
    break;
}
```

`break` ends the writer task. Nothing respawns it short of a whole new WebSocket connection, and the read loop's `let _ = tx.send(data)` then discards keystrokes silently. One unlucky moment costs the connection its keyboard for good.

The contention is routine, not exotic. The child watcher in `src/pty.rs` takes `backend.lock().await` **every 200ms per pane** to poll `child.try_wait()`; `resize` and `resize_async` take it as well. Caught in production:

```
14:38:53  ERROR PTY write error (11B): backend lock held, pane=bd990850…
14:38:53  INFO  PTY write task (reconnect) exited, pane=bd990850…
          … nothing for the next 67 minutes …
```

At inspection the process was alive, HTTP answered in 0.5ms, `sample` showed zero threads blocked on a mutex, and `lsof` showed the socket still ESTABLISHED. Input was simply gone.

## Fix

Add `write_input_blocking`, which uses `blocking_lock` so contention becomes a short wait instead of an error, and point the four `spawn_blocking` writers at it.

This deliberately avoids classifying errors as transient vs fatal: with contention no longer producing an `Err` at all, there is nothing to classify, no retry loop, and no retry bound to tune. The existing `break` arms become correct as written — the only errors that can now reach them are genuinely fatal (session exited, SSH-vs-Local misuse, a real write/flush io error).

**`write_input_sync` is kept as-is** rather than changed in place. Five other call sites (`src/openapi.rs`, `src/agent.rs` ×2, `src/mcp/tools.rs` ×2) invoke it directly from `async fn` bodies, where `blocking_lock` would panic on a runtime worker thread. Both methods now share one private `write_input_locked` helper, so the write logic itself is not duplicated.

## Deadlock analysis

`blocking_lock` is only safe if it cannot complete a cycle, so every acquirer of `backend` was enumerated:

| Site | Held across |
|---|---|
| `pty.rs` child watcher | `child.try_wait()`, then an assignment |
| `write_input_sync` / `write_input_blocking` | `write_all` + `flush` |
| `resize` / `resize_async` | one `PtySize` ioctl (guard dropped before `size`/`screen` are taken) |
| `write_input_async` | `write_all` + `flush` |
| `kill_backend_sync` | teardown, and `exited` |

Every hold is short and non-nested. The only lock taken *beneath* `backend` is `exited`, and none of the four `exited` acquirers takes `backend` while holding it — so there is no reverse edge and no cycle. `blocking_lock` also only ever blocks a `spawn_blocking` pool thread, never a Tokio worker.

## Accepted behaviour change

A writer belonging to a superseded connection used to fail fast; it now waits and may write its already-dequeued batch slightly late. This is bounded to one in-flight batch, and `SessionBackend::Exited` still covers a closed session. Noted in the doc comment. I deliberately did not add a generation counter for it — the machinery would cost more than the window.

## Verification

`cargo fmt --check` clean. `cargo test --lib` 362 → 363 passed, 0 failed.

The new test builds a real `SessionBackend::Local` over an actual PTY master, holds the backend lock, and asserts three things: `write_input_sync` returns `Err("backend lock held")` under that lock (pinning the existing contract), `write_input_blocking` has *not* returned after 50ms, and it completes with `Ok(())` once the lock is released. Against the old code the middle assertion fails, so the test is discriminating rather than merely additive.

I could not build the `src-tauri` crate in a bare checkout — it needs the embedded `frontend/dist`, which is absent until the frontend is built. The change there is a one-call-site swap between two methods with identical signatures, so it is type-identical, but flagging that it is unverified by compilation on my side rather than implying otherwise.

## Relationship to the other open PRs

Independent of #194 and #195. This touches the input path; those touch synchronized-output state and the flush chunking. No overlapping hunks — any of the three can land in any order.

Separately, there is a second defect that contributed to the same incident: the reconnect snapshot handshake has no timeout, so a client whose `SnapshotRequest` never arrives stays muted forever with nothing logged. That one needs its own design discussion and I'll send it separately rather than bundling it here.
