### PR TITLE
fix(plugin): kill the child process when plugin_exec times out

### DIFF
--- a/src/plugin/handlers.rs
+++ b/src/plugin/handlers.rs
@@ -154,6 +154,7 @@ pub async fn plugin_exec(
     cmd.args(&body.args);
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
+    cmd.kill_on_drop(true);
     if let Some(ref cwd) = body.cwd {
         cmd.current_dir(cwd);
     }


### PR DESCRIPTION
Every `plugin_exec` call that hits its timeout leaves the plugin's child process running.

## The defect

`plugin_exec` builds its `Command` without `kill_on_drop`:

```rust
let mut cmd = Command::new(&bin_path);
cmd.no_window();
cmd.args(&body.args);
cmd.stdout(Stdio::piped());
cmd.stderr(Stdio::piped());
```

and then runs it under a timeout:

```rust
match tokio::time::timeout(timeout_dur, cmd.output()).await {
    ...
    Err(_) => Json(ExecResult {
        code: -1,
        stdout: String::new(),
        stderr: format!("timeout after {timeout_ms}ms"),
    })
    .into_response(),
}
```

On timeout, `tokio::time::timeout` drops the `cmd.output()` future. Tokio does **not** kill a `Child`
on drop unless `kill_on_drop(true)` was set on the command, so dropping the future only stops us from
*waiting* — the process itself keeps running, detached, with its pipes closed.

The caller gets a clean `timeout after Nms` and has no idea anything is still alive. A plugin that
hangs is therefore not merely slow: each invocation leaks one process, and a plugin the user retries
a few times leaves a pile of them.

The default timeout is 30s, so this is reachable by any plugin that blocks on network or stdin.

## Fix

One line — set `kill_on_drop(true)` when building the command, so the drop that already happens on
timeout also reaps the child.

This mirrors what the long-lived process path in this same file already does: `plugin_process_start`
sets `cmd.kill_on_drop(true)` on its command. `plugin_exec` looks like it was simply missed — the
one-shot path needs it for exactly the same reason, and arguably more, since its lifetime is bounded
by a timeout that is *designed* to fire.

## On testing

I did not add a test. A real one would have to spawn a process that outlives its timeout and then
assert the OS reaped it, which means sleeping past a timeout and polling for process death — timing
dependent and flaky in CI, on a one-line builder change. A test that only asserted "the builder was
called" would assert nothing about the actual behaviour.

Happy to add one if you would rather have it; I would want to agree on how to make it deterministic
first.

## Verification

`cargo fmt --check` clean. `cargo test --lib` 368 passed / 0 failed.

`cargo clippy --all-targets -- -D warnings` could not run in a bare checkout — it needs the embedded
`frontend/dist`, which is absent until the frontend is built. Flagging that rather than implying I
ran it. Nothing in this diff introduces a lint-visible construct.
