### PR TITLE
fix(vt): stop a UTF-8 boundary panic freezing the screen mirror permanently

### DIFF
--- a/src/vt_screen.rs
+++ b/src/vt_screen.rs
@@ -30,7 +30,7 @@ pub struct CommandResult {
 /// Tracks a pending command for collecting output
 struct PendingCommand {
     start_time: Instant,
-    output_buf: String,
+    output_buf: Vec<u8>,
 }
 
 /// DEC mode 2026 synchronized output events
@@ -247,7 +247,10 @@ impl VirtualScreen {
 
     /// Get the collected stdout from the current/last command
     pub fn take_command_output(&mut self) -> String {
-        self.pending_command.as_mut().map(|p| std::mem::take(&mut p.output_buf)).unwrap_or_default()
+        self.pending_command
+            .as_mut()
+            .map(|p| String::from_utf8_lossy(&std::mem::take(&mut p.output_buf)).into_owned())
+            .unwrap_or_default()
     }
 
     /// Check if shell integration (OSC 133) has been detected
@@ -323,13 +326,16 @@ impl VirtualScreen {
     pub fn begin_command_tracking(&mut self) {
         self.command_state = CommandState::CommandStart;
         self.pending_command =
-            Some(PendingCommand { start_time: Instant::now(), output_buf: String::new() });
+            Some(PendingCommand { start_time: Instant::now(), output_buf: Vec::new() });
     }
 
     /// Force-finish command tracking (e.g. on timeout). Returns collected output.
     pub fn finish_command_tracking(&mut self, exit_code: i32) -> (String, CommandResult) {
         let pending = self.pending_command.take();
-        let stdout = pending.as_ref().map(|p| p.output_buf.clone()).unwrap_or_default();
+        let stdout = pending
+            .as_ref()
+            .map(|p| String::from_utf8_lossy(&p.output_buf).into_owned())
+            .unwrap_or_default();
         let duration_ms = pending.map_or(0, |p| p.start_time.elapsed().as_millis() as u64);
 
         let result = CommandResult { exit_code, duration_ms, method: "timeout".to_string() };
@@ -347,7 +353,7 @@ impl VirtualScreen {
                 // Only collect printable ASCII and UTF-8 text, skip ESC sequences
                 for &b in data {
                     if b >= 0x20 && b != 0x7f {
-                        pending.output_buf.push(b as char);
+                        pending.output_buf.push(b);
                     }
                 }
                 // Cap buffer at 1MB
@@ -856,7 +862,7 @@ impl Perform for ScreenPerformer<'_> {
                 }
                 *self.command_state = CommandState::CommandStart;
                 *self.pending_command =
-                    Some(PendingCommand { start_time: Instant::now(), output_buf: String::new() });
+                    Some(PendingCommand { start_time: Instant::now(), output_buf: Vec::new() });
             }
             b"D" => {
                 // Command finished
@@ -877,7 +883,9 @@ impl Perform for ScreenPerformer<'_> {
                 let stdout = self
                     .pending_command
                     .as_mut()
-                    .map(|p| std::mem::take(&mut p.output_buf))
+                    .map(|p| {
+                        String::from_utf8_lossy(&std::mem::take(&mut p.output_buf)).into_owned()
+                    })
                     .unwrap_or_default();
 
                 self.command_results.push(CommandResult {
@@ -1334,6 +1342,40 @@ mod csi_dispatch_tests {
         assert!(!vs.is_using_alternate());
         vs.feed(b"\x1b[?1049h");
         assert!(vs.is_using_alternate());
+    }
+
+    #[test]
+    fn feed_survives_multibyte_output_exceeding_cap() {
+        let mut vs = VirtualScreen::new(80, 24);
+        vs.begin_command_tracking();
+        assert_eq!(vs.command_state, CommandState::CommandStart);
+        assert!(vs.pending_command.is_some());
+
+        // The odd-length ASCII prefix made the old String drain land inside a
+        // multi-byte char, while 1024-byte reads split the Chinese UTF-8 input.
+        let mut bulk = b"PTY".to_vec();
+        while bulk.len() <= 1024 * 1024 {
+            bulk.extend_from_slice("你好世界".as_bytes());
+        }
+
+        let mut chunks = bulk.chunks(1024);
+        let first_chunk = chunks.next().unwrap();
+        assert!(std::str::from_utf8(first_chunk).is_err());
+        vs.feed(first_chunk);
+        assert!(!vs.pending_command.as_ref().unwrap().output_buf.is_empty());
+        for chunk in chunks {
+            vs.feed(chunk);
+        }
+
+        // A separate post-cap feed must still reach the parser rather than
+        // repeatedly panicking in the collection branch.
+        vs.feed(b"\r\nPOST_CAP_MARKER\r\n");
+        assert!(vs.snapshot_plain().contains("POST_CAP_MARKER"));
+
+        let output = vs.take_command_output();
+        assert!(std::str::from_utf8(output.as_bytes()).is_ok());
+        assert!(output.contains("你好"));
+        assert!(output.contains("世界"));
     }
 }
 


### PR DESCRIPTION
A pane's screen mirror can freeze permanently, and stay frozen for the life of the process. The pane
looks alive — the process is healthy, the WebSocket is fine, nothing is logged — but the server-side
screen never updates again, so reconnects and snapshots serve stale content forever.

## The defect

`PendingCommand.output_buf` is a `String`, filled one byte at a time:

```rust
pending.output_buf.push(b as char);
```

`b as char` maps a byte to the codepoint of the same value, so every byte >= 0x80 becomes
U+0080..U+00FF — which UTF-8 re-encodes as **two** bytes. The buffer's byte length therefore grows
faster than the number of bytes pushed, and its contents are no longer the byte stream that came in.

The 1MB cap then drains by byte offset:

```rust
if pending.output_buf.len() > 1024 * 1024 {
    pending.output_buf.drain(..512 * 1024);
}
```

`String::drain` on a byte range panics unless both ends land on a char boundary. After the
`as char` inflation, offset 512*1024 routinely lands *inside* one of those two-byte sequences, and
`drain` panics on `is_char_boundary`.

## Why it latches

This is the part that turns a panic into a permanent freeze.

The collection branch runs **before** the parser loop in `feed()`. So when it panics:

1. the chunk is never parsed — the screen mirror does not advance, and
2. the buffer is never drained — it stays above 1MB.

Every subsequent `feed()` re-enters the same over-cap branch and panics again, before ever reaching
the parser. The mirror is now permanently stuck, and there is no path back: the only code that could
shrink the buffer is the code that panics.

A `catch_unwind` on the PTY reader keeps the process alive, which is why this presents as a silent
freeze rather than a crash. In production I have seen this fire hundreds of thousands of times over a
few days on a single instance, with the affected panes' mirrors dead the entire time.

Reaching it only requires a command whose output exceeds the 1MB cap and contains any non-ASCII byte
— any CJK, emoji, or box-drawing output, which in practice means a build log or a `find` over a tree
with non-ASCII filenames.

## Fix

Make `output_buf` a `Vec<u8>` and push raw bytes. Draining a `Vec<u8>` by byte offset is always
valid, so the panic cannot occur. The three places that hand the buffer out convert at that point
with `String::from_utf8_lossy`.

This also makes the buffer hold what it claims to hold: the actual output bytes, rather than a
per-byte codepoint expansion of them. A multi-byte character that arrives split across two PTY reads
now reassembles correctly, where before each half became its own U+0080..U+00FF codepoint.

The cap and drain sizes are unchanged.

## Verification

`cargo fmt --check` clean. `cargo test --lib` 369 passed / 0 failed.

The added test is **proven discriminating** — against the pre-fix code it fails with the
`is_char_boundary` panic. It is built to pin the latch specifically:

- an odd-length ASCII prefix puts the drain offset inside a multi-byte character;
- the input is fed in 1024-byte chunks, mirroring real PTY reads, and the test asserts the first
  chunk is *not* valid UTF-8 on its own, so it genuinely exercises the split-character path;
- after exceeding the cap it feeds one more line and asserts that line reaches the screen. That last
  assertion is the important one: it fails on the old code not because of the panic itself but
  because the panic prevents the parser from ever running again.

`cargo clippy --all-targets -- -D warnings` could not run in a bare checkout — it needs the embedded
`frontend/dist`, absent until the frontend is built. Flagging that rather than implying I ran it.

## Note on overlap

I have a second branch in flight that also touches `src/vt_screen.rs` (DEC private-mode replay in
`snapshot()`). The two are unrelated and touch different regions, but whichever lands second may want
a trivial rebase. Happy to do that in whichever order you prefer.
