### PR TITLE
fix(tabs): keep the tab-close successor in the same workspace

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -318,6 +318,7 @@ import { useSyncWebSocket } from './composables/useSyncWebSocket'
 import { isWebPreviewInput } from './utils/previewRouting'
 import { isWindowsClient } from './utils/clientPlatform'
 import { nextRevealNavGen, currentRevealNavGen } from './utils/navGen'
+import { pickSuccessorTab } from './utils/tabSuccessor'
 import { initMonitorHistory } from './composables/useMonitor'
 import NotificationPanel from './components/notification/NotificationPanel.vue'
 import { useToast } from 'vue-toastification'
@@ -424,6 +425,12 @@ const { isMobile } = useIsMobile()
 
 // Workspace filtering
 const { workspaces, activeWorkspaceId, activeWorkspacePath, activeWorkspaceName, matchWorkspace, activateWorkspace, cancelPendingWorkspaceActivation } = useWorkspaces()
+
+function workspaceIdOfTab(tab: Tab): string | null {
+  if (tab.type === 'plugin') return tab.workspaceId ?? null
+  return matchWorkspace(tab.cwd ?? '', tab.connectionId, tab.workspaceId)?.id ?? null
+}
+
 const activeWorkspace = computed(() => workspaces.value.find((w) => w.id === activeWorkspaceId.value))
 const activeWorkspaceAbbr = computed(() =>
   activeWorkspace.value ? resolveAbbr(activeWorkspace.value) : ''
@@ -1199,6 +1206,11 @@ async function closeTab(tabId: string) {
   const idx = tabs.value.findIndex((t) => t.paneId === tabId)
   if (idx === -1) return
 
+  const closedWorkspaceId = workspaceIdOfTab(tab)
+  const workspaceIdxBefore = tabs.value
+    .slice(0, idx)
+    .filter((candidate) => workspaceIdOfTab(candidate) === closedWorkspaceId).length
+
   tabs.value.splice(idx, 1)
   if (tab.type === 'plugin') persistNow()
 
@@ -1209,11 +1221,17 @@ async function closeTab(tabId: string) {
   }
 
   if (activePaneId.value === tabId) {
-    const newIdx = Math.min(idx, tabs.value.length - 1)
+    const successor = pickSuccessorTab(
+      tabs.value,
+      closedWorkspaceId,
+      workspaceIdxBefore,
+      idx,
+      workspaceIdOfTab
+    )
     // Close-induced reselection is the newest navigation: supersede any in-flight
     // deferred/supervised hop so a late older-generation commit cannot clobber it.
     nextRevealNavGen()
-    activePaneId.value = tabs.value[newIdx].paneId
+    activePaneId.value = successor?.paneId ?? null
   }
 
   if (tab.type !== 'plugin') persist()

--- a/frontend/src/composables/useSyncWebSocket.ts
+++ b/frontend/src/composables/useSyncWebSocket.ts
@@ -1,7 +1,7 @@
 import { nextTick } from 'vue'
 import { storeToRefs } from 'pinia'
 import type { SyncServerMsg, SyncClientMsg } from '../types/protocol'
-import type { TerminalTab } from '../types/pane'
+import type { Tab, TerminalTab } from '../types/pane'
 import { getAllLeaves, findLeaf, migrateTab, migratePreviewToLeaf, ensureSplitRoot } from '../types/pane'
 import {
   initializePaneMru,
@@ -21,6 +21,7 @@ import { handlePluginChanged } from './usePluginLoader'
 import { useWorkspaces } from './useWorkspaces'
 import { apiCreatePluginTab } from './useTabApi'
 import { clearFileWorkspaceState } from './useFileWorkspaceState'
+import { pickSuccessorTab } from '../utils/tabSuccessor'
 import type TerminalPane from '../components/terminal/TerminalPane.vue'
 
 export function useSyncWebSocket(opts: {
@@ -34,7 +35,12 @@ export function useSyncWebSocket(opts: {
   const { tabs, activePaneId } = storeToRefs(session)
   const ui = useUiStore()
   const { syncConnected } = storeToRefs(ui)
-  const { workspaces, activeWorkspaceId } = useWorkspaces()
+  const { workspaces, activeWorkspaceId, matchWorkspace } = useWorkspaces()
+
+  function workspaceIdOfTab(tab: Tab): string | null {
+    if (tab.type === 'plugin') return tab.workspaceId ?? null
+    return matchWorkspace(tab.cwd ?? '', tab.connectionId, tab.workspaceId)?.id ?? null
+  }
 
   let syncWs: WebSocket | null = null
   let suppressSync = false
@@ -321,6 +327,10 @@ export function useSyncWebSocket(opts: {
         )
         if (tabIdx !== -1) {
           const tab = tabs.value[tabIdx] as TerminalTab
+          const closedWorkspaceId = workspaceIdOfTab(tab)
+          const workspaceIdxBefore = tabs.value
+            .slice(0, tabIdx)
+            .filter((candidate) => workspaceIdOfTab(candidate) === closedWorkspaceId).length
           for (const leaf of getAllLeaves(tab.layout)) {
             delete termRefs[leaf.paneId]
             clearFileWorkspaceState(leaf.paneId)
@@ -329,7 +339,14 @@ export function useSyncWebSocket(opts: {
           if (tabs.value.length === 0) {
             newTab()
           } else if (activePaneId.value === tab.paneId) {
-            activePaneId.value = tabs.value[Math.min(tabIdx, tabs.value.length - 1)].paneId
+            const successor = pickSuccessorTab(
+              tabs.value,
+              closedWorkspaceId,
+              workspaceIdxBefore,
+              tabIdx,
+              workspaceIdOfTab
+            )
+            activePaneId.value = successor?.paneId ?? null
             persist()
             nextTick(() => focusActive())
           }

--- a/frontend/src/test/AppPaneClose.test.ts
+++ b/frontend/src/test/AppPaneClose.test.ts
@@ -712,6 +712,48 @@ describe('App.vue - onClosePane routes through confirmation gate', () => {
     expect(currentRevealNavGen()).toBe(navGenBeforeClose + 1)
     expect(session.activePaneId).toBe('tab-survivor')
   })
+
+  it('selects the same-workspace successor instead of the flat-array neighbour', async () => {
+    const wrapper = await mountWithTabs()
+    const session = useSessionStore()
+    const workspaceState = useWorkspaces()
+    workspaceState.workspaces.value = [
+      { id: 'workspace-a', name: 'Workspace A', path: '/workspace/a', order: 0 },
+      { id: 'workspace-b', name: 'Workspace B', path: '/workspace/b', order: 1 },
+    ]
+    const terminalTab = (paneId: string, cwd: string): Tab => ({
+      type: 'terminal',
+      paneId,
+      layout: {
+        type: 'leaf',
+        paneId: `${paneId}-leaf`,
+        title: paneId,
+        ratio: 1,
+        zoomed: false,
+      },
+      activePaneId: `${paneId}-leaf`,
+      paneMru: [`${paneId}-leaf`],
+      broadcastMode: false,
+      broadcastActivity: 0,
+      previewVisible: false,
+      previewAddress: '',
+      previewUrl: '',
+      previewKind: 'web',
+      cwd,
+    })
+    session.setTabs([
+      terminalTab('workspace-a-closed', '/workspace/a'),
+      terminalTab('workspace-b-neighbour', '/workspace/b'),
+      terminalTab('workspace-a-successor', '/workspace/a'),
+    ])
+    session.setActivePane('workspace-a-closed')
+
+    const app = wrapper.vm as unknown as { closeTab: (tabId: string) => Promise<void> }
+    await app.closeTab('workspace-a-closed')
+    await nextTick()
+
+    expect(session.activePaneId).toBe('workspace-a-successor')
+  })
 })
 
 describe('App.vue - notification badge visibility', () => {

--- a/frontend/src/utils/tabSuccessor.ts
+++ b/frontend/src/utils/tabSuccessor.ts
@@ -1,0 +1,26 @@
+/**
+ * Select the tab to activate after a tab is removed.
+ *
+ * The tab at the closed tab's former workspace-relative position is preferred.
+ * If that workspace is now empty, the nearest tab at the removed flat-array
+ * position is returned instead. Both indices must be captured before removal;
+ * `remainingTabs` must no longer contain the closed tab.
+ */
+export function pickSuccessorTab<T>(
+  remainingTabs: T[],
+  closedWorkspaceId: string | null,
+  workspaceIdxBefore: number,
+  removedIdx: number,
+  workspaceIdOf: (tab: T) => string | null
+): T | undefined {
+  if (remainingTabs.length === 0) return undefined
+
+  const workspaceTabs = remainingTabs.filter(
+    (tab) => workspaceIdOf(tab) === closedWorkspaceId
+  )
+  if (workspaceTabs.length > 0) {
+    return workspaceTabs[Math.min(workspaceIdxBefore, workspaceTabs.length - 1)]
+  }
+
+  return remainingTabs[Math.min(removedIdx, remainingTabs.length - 1)]
+}


### PR DESCRIPTION
Closing a tab can drop you into a different workspace.

## Current behaviour

After removing a tab, the successor is picked by clamping the removed index into the flat tab array:

```js
const newIdx = Math.min(idx, tabs.value.length - 1)
activePaneId.value = tabs.value[newIdx].paneId
```

The array holds every tab from every workspace, so the "neighbour" is whatever happens to sit at that
index — frequently a tab belonging to some other workspace. Close a tab in workspace A and you can
land in workspace B while workspace A still has tabs open, which also drags the workspace-scoped UI
along with it.

Concretely, with tabs `[A₁, B₁, A₂]` and `A₁` active: closing `A₁` clamps to index 0 and activates
`B₁`, even though `A₂` is right there.

## Change

Prefer a tab from the same workspace as the closed one, at the same relative position *within* that
workspace. Fall back to the existing flat-array neighbour only when the closed tab's workspace has no
tabs left — so the behaviour is unchanged whenever the preference does not apply.

The selection is a pure helper in `frontend/src/utils/tabSuccessor.ts`, parameterised by a
`workspaceIdOf` accessor so it carries no assumptions about tab shape:

```ts
export function pickSuccessorTab<T>(
  remainingTabs: T[],
  closedWorkspaceId: string | null,
  workspaceIdxBefore: number,
  removedIdx: number,
  workspaceIdOf: (tab: T) => string | null
): T | undefined
```

Both indices are captured before removal, and `remainingTabs` must already exclude the closed tab —
documented on the function.

Tabs close in two places (the app-level close path and the `tab_closed` sync handler), so both are
wired to the same helper rather than leaving the two paths to drift.

## Deliberately not included

Our own build also activates the successor's *workspace* when it differs from the active one. I left
that out: it is a separate behavioural decision, it touches workspace activation, and this PR reads
better as successor selection alone. Happy to follow up with it if you want that half too.

## Verification

`npx vue-tsc --noEmit` clean. `npx vitest run` 737 passed / 58 files. `cargo fmt --check` clean
(backend untouched).

The added test is **discriminating by construction**: it lays out `[A₁, B₁, A₂]` across two
workspaces and closes `A₁`. The current index clamp yields `B₁`; the test asserts `A₂`, so it fails
against the existing behaviour and passes once wired.

`pnpm lint` reports 523 pre-existing findings across untouched files (6 of them errors); none are in
this diff.
