### PR TITLE
fix(tabs): follow the successor tab across workspaces on close

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1219,7 +1219,7 @@ async function closeTab(tabId: string) {
   }
 
   if (activePaneId.value === tabId) {
-    const successor = pickSuccessorTab(
+    let successor = pickSuccessorTab(
       tabs.value,
       closedWorkspaceId,
       workspaceIdxBefore,
@@ -1228,8 +1228,26 @@ async function closeTab(tabId: string) {
     )
     // Close-induced reselection is the newest navigation: supersede any in-flight
     // deferred/supervised hop so a late older-generation commit cannot clobber it.
-    nextRevealNavGen()
-    activePaneId.value = successor?.paneId ?? null
+    const gen = nextRevealNavGen()
+    const successorWorkspaceId = successor ? workspaceIdOfTab(successor) : null
+    if (successor && successorWorkspaceId !== activeWorkspaceId.value) {
+      let workspaceCommitted = false
+      try {
+        workspaceCommitted = await activateWorkspace(successorWorkspaceId)
+      } catch {
+        // Keep the current workspace and select one of its remaining tabs below.
+      }
+      if (!workspaceCommitted || gen !== currentRevealNavGen()) {
+        successor = tabs.value.find(
+          (candidate) => workspaceIdOfTab(candidate) === activeWorkspaceId.value
+        )
+      }
+    } else {
+      cancelPendingWorkspaceActivation()
+    }
+    if (gen === currentRevealNavGen()) {
+      activePaneId.value = successor?.paneId ?? null
+    }
   }
 
   if (tab.type !== 'plugin') persist()

--- a/frontend/src/composables/useSyncWebSocket.ts
+++ b/frontend/src/composables/useSyncWebSocket.ts
@@ -22,6 +22,7 @@ import { useWorkspaces } from './useWorkspaces'
 import { apiCreatePluginTab } from './useTabApi'
 import { clearFileWorkspaceState } from './useFileWorkspaceState'
 import { pickSuccessorTab } from '../utils/tabSuccessor'
+import { currentRevealNavGen, nextRevealNavGen } from '../utils/navGen'
 import type TerminalPane from '../components/terminal/TerminalPane.vue'
 
 export function useSyncWebSocket(opts: {
@@ -35,7 +36,13 @@ export function useSyncWebSocket(opts: {
   const { tabs, activePaneId } = storeToRefs(session)
   const ui = useUiStore()
   const { syncConnected } = storeToRefs(ui)
-  const { workspaces, activeWorkspaceId, matchWorkspace } = useWorkspaces()
+  const {
+    workspaces,
+    activeWorkspaceId,
+    activateWorkspace,
+    cancelPendingWorkspaceActivation,
+    matchWorkspace,
+  } = useWorkspaces()
 
   function workspaceIdOfTab(tab: Tab): string | null {
     if (tab.type === 'plugin') return tab.workspaceId ?? null
@@ -124,7 +131,7 @@ export function useSyncWebSocket(opts: {
       syncReconnectDelay = 1000
     }
 
-    function handleMsg(e: { data: string }) {
+    async function handleMsg(e: { data: string }) {
       let msg: SyncServerMsg
       try {
         msg = JSON.parse(e.data)
@@ -339,14 +346,33 @@ export function useSyncWebSocket(opts: {
           if (tabs.value.length === 0) {
             newTab()
           } else if (activePaneId.value === tab.paneId) {
-            const successor = pickSuccessorTab(
+            let successor = pickSuccessorTab(
               tabs.value,
               closedWorkspaceId,
               workspaceIdxBefore,
               tabIdx,
               workspaceIdOfTab
             )
-            activePaneId.value = successor?.paneId ?? null
+            const gen = nextRevealNavGen()
+            const successorWorkspaceId = successor ? workspaceIdOfTab(successor) : null
+            if (successor && successorWorkspaceId !== activeWorkspaceId.value) {
+              let workspaceCommitted = false
+              try {
+                workspaceCommitted = await activateWorkspace(successorWorkspaceId)
+              } catch {
+                // Keep the current workspace and select one of its remaining tabs below.
+              }
+              if (!workspaceCommitted || gen !== currentRevealNavGen()) {
+                successor = tabs.value.find(
+                  (candidate) => workspaceIdOfTab(candidate) === activeWorkspaceId.value
+                )
+              }
+            } else {
+              cancelPendingWorkspaceActivation()
+            }
+            if (gen === currentRevealNavGen()) {
+              activePaneId.value = successor?.paneId ?? null
+            }
             persist()
             nextTick(() => focusActive())
           }
@@ -478,7 +504,9 @@ export function useSyncWebSocket(opts: {
       }
     }
 
-    syncWs.onmessage = (e) => handleMsg(e)
+    syncWs.onmessage = (e) => {
+      void handleMsg(e)
+    }
 
     syncWs.onclose = (e) => {
       console.warn('[sync] disconnected', e.code, e.reason)

--- a/frontend/src/test/AppPaneClose.test.ts
+++ b/frontend/src/test/AppPaneClose.test.ts
@@ -754,6 +754,50 @@ describe('App.vue - onClosePane routes through confirmation gate', () => {
 
     expect(session.activePaneId).toBe('workspace-a-successor')
   })
+
+  it('moves to the successor workspace when closing its active workspace last tab', async () => {
+    const wrapper = await mountWithTabs()
+    const session = useSessionStore()
+    const workspaceState = useWorkspaces()
+    workspaceState.workspaces.value = [
+      { id: 'workspace-a', name: 'Workspace A', path: '/workspace/a', order: 0 },
+      { id: 'workspace-b', name: 'Workspace B', path: '/workspace/b', order: 1 },
+    ]
+    workspaceState.activeWorkspaceId.value = 'workspace-a'
+    const terminalTab = (paneId: string, cwd: string): Tab => ({
+      type: 'terminal',
+      paneId,
+      layout: {
+        type: 'leaf',
+        paneId: `${paneId}-leaf`,
+        title: paneId,
+        ratio: 1,
+        zoomed: false,
+      },
+      activePaneId: `${paneId}-leaf`,
+      paneMru: [`${paneId}-leaf`],
+      broadcastMode: false,
+      broadcastActivity: 0,
+      previewVisible: false,
+      previewAddress: '',
+      previewUrl: '',
+      previewKind: 'web',
+      cwd,
+    })
+    session.setTabs([
+      terminalTab('workspace-a-only-tab', '/workspace/a'),
+      terminalTab('workspace-b-successor', '/workspace/b'),
+    ])
+    session.setActivePane('workspace-a-only-tab')
+
+    const app = wrapper.vm as unknown as { closeTab: (tabId: string) => Promise<void> }
+    await app.closeTab('workspace-a-only-tab')
+    await nextTick()
+
+    expect(mocks.apiActivateWorkspace).toHaveBeenCalledWith('workspace-b')
+    expect(workspaceState.activeWorkspaceId.value).toBe('workspace-b')
+    expect(session.activePaneId).toBe('workspace-b-successor')
+  })
 })
 
 describe('App.vue - notification badge visibility', () => {

--- a/frontend/src/test/useSyncWebSocketMru.test.ts
+++ b/frontend/src/test/useSyncWebSocketMru.test.ts
@@ -2,6 +2,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
 import type { PaneLayout, TerminalTab } from '../types/pane'
 
+const mocks = vi.hoisted(() => ({
+  apiActivateWorkspace: vi.fn(async () => {}),
+}))
+
 let socket: MockWebSocket
 class MockWebSocket {
   static OPEN = 1
@@ -25,8 +29,18 @@ vi.mock('../composables/apiBase', () => ({
 }))
 vi.mock('../composables/useTransport', () => ({ isTauri: () => false }))
 vi.mock('../composables/usePluginLoader', () => ({ handlePluginChanged: vi.fn() }))
+vi.mock('../composables/useWorkspaceApi', () => ({
+  apiListWorkspaces: vi.fn(async () => []),
+  apiCreateWorkspace: vi.fn(),
+  apiUpdateWorkspace: vi.fn(),
+  apiDeleteWorkspace: vi.fn(),
+  apiActivateWorkspace: mocks.apiActivateWorkspace,
+  apiDeactivateWorkspace: vi.fn(async () => {}),
+  apiReorderWorkspaces: vi.fn(),
+}))
 
 import { useSyncWebSocket } from '../composables/useSyncWebSocket'
+import { useWorkspaces } from '../composables/useWorkspaces'
 import { useSessionStore } from '../stores/sessionStore'
 
 function leaf(paneId: string): PaneLayout {
@@ -87,7 +101,12 @@ async function setup() {
 }
 
 describe('useSyncWebSocket pane MRU', () => {
-  beforeEach(() => vi.clearAllMocks())
+  beforeEach(() => {
+    vi.clearAllMocks()
+    const workspaceState = useWorkspaces()
+    workspaceState.workspaces.value = []
+    workspaceState.activeWorkspaceId.value = null
+  })
 
   it('uses and focuses the MRU fallback when a focused pane exits', async () => {
     const { tab, emitLayout, focusActive } = await setup()
@@ -127,5 +146,52 @@ describe('useSyncWebSocket pane MRU', () => {
     tab.paneMru = ['b', 'b', 'a', 'c']
     emitLayout(layout('a', 'b', 'c'), 'b')
     expect(tab.paneMru).toEqual(['b', 'a', 'c'])
+  })
+
+  it('moves to the successor workspace when sync closes its last active tab', async () => {
+    setActivePinia(createPinia())
+    const session = useSessionStore()
+    const workspaceState = useWorkspaces()
+    workspaceState.workspaces.value = [
+      { id: 'workspace-a', name: 'Workspace A', path: '/workspace/a', order: 0 },
+      { id: 'workspace-b', name: 'Workspace B', path: '/workspace/b', order: 1 },
+    ]
+    workspaceState.activeWorkspaceId.value = 'workspace-a'
+    const workspaceTab = (paneId: string, cwd: string): TerminalTab => ({
+      type: 'terminal',
+      paneId,
+      layout: leaf(`${paneId}-leaf`),
+      activePaneId: `${paneId}-leaf`,
+      paneMru: [`${paneId}-leaf`],
+      broadcastMode: false,
+      broadcastActivity: 0,
+      previewVisible: false,
+      previewAddress: '',
+      previewUrl: '',
+      previewKind: 'web',
+      cwd,
+    })
+    session.tabs = [
+      workspaceTab('workspace-a-only-tab', '/workspace/a'),
+      workspaceTab('workspace-b-successor', '/workspace/b'),
+    ]
+    session.activePaneId = 'workspace-a-only-tab'
+    const subject = useSyncWebSocket({
+      termRefs: {},
+      persist: vi.fn(),
+      focusActive: vi.fn(),
+      newTab: vi.fn(),
+    })
+    await subject.connectSyncWS()
+
+    socket.onmessage?.({
+      data: JSON.stringify({ type: 'tab_closed', pane_id: 'workspace-a-only-tab' }),
+    })
+    await vi.waitFor(() => {
+      expect(workspaceState.activeWorkspaceId.value).toBe('workspace-b')
+    })
+
+    expect(mocks.apiActivateWorkspace).toHaveBeenCalledWith('workspace-b')
+    expect(session.activePaneId).toBe('workspace-b-successor')
   })
 })


### PR DESCRIPTION
## Problem

`pickSuccessorTab` prefers a tab in the closed tab's own workspace, but once that workspace has no tabs left it falls back to the flat-array neighbour — which may belong to a different workspace.

Neither close path moves the workspace filter afterwards. `App.vue`'s `closeTab` and `useSyncWebSocket.ts`'s `tab_closed` both just commit `activePaneId.value = successor?.paneId ?? null`.

But `visibleTabList` filters the tab bar by `activeWorkspaceId`. So after closing the last tab of workspace A, the terminal area renders a tab belonging to workspace B while the tab bar still lists only workspace A — the active tab is not present in the bar at all.

Repro: two workspaces, one tab each, workspace A active. Close A's only tab. B's tab becomes active, but the tab bar still filters to A.

## Fix

Activate the successor's workspace before committing `activePaneId`, in both close paths.

The existing reveal-nav generation guard is honoured: if an explicit navigation raced the close, it wins and the close-induced selection is dropped. If the activation does not commit, selection falls back to a tab in the current workspace.

No new helper needed — `activateWorkspace` already reports whether it committed, and `nextRevealNavGen`/`currentRevealNavGen` already exist.

## Trade-off worth flagging

`handleMsg` in `useSyncWebSocket.ts` becomes `async`, because the sync path now awaits the workspace activation. It only suspends when the successor is in a different workspace — the exact case this fixes; every other message path stays synchronous, and `onmessage` voids the promise. Happy to restructure if you would rather the sync path not await at all.

## Tests

One regression test per close path:

- `AppPaneClose.test.ts` — "moves to the successor workspace when closing its active workspace last tab"
- `useSyncWebSocketMru.test.ts` — "moves to the successor workspace when sync closes its last active tab"

Both are discriminating, verified rather than assumed: reverting the two source files to `dev` and re-running the suite fails exactly these two (738/740) with no other test affected; with the fix, 740/740 pass.

`vue-tsc --noEmit`, `cargo check`, and `cargo clippy --all-targets -- -D warnings` are all clean.
