### PR TITLE
fix: preserve tab selection after failed workspace hop

### DIFF
--- a/frontend/src/composables/useTabLifecycle.ts
+++ b/frontend/src/composables/useTabLifecycle.ts
@@ -390,7 +390,15 @@ export function useTabLifecycle(opts: TabLifecycleOptions): TabLifecycleState {
         if (!workspaceCommitted || gen !== currentRevealNavGen()) {
           successor = tabs.value.find(
             (candidate) => workspaceIdOfTab(candidate) === activeWorkspaceId.value
-          )
+          ) ?? tabs.value[Math.min(idx, tabs.value.length - 1)]
+          const fallbackWorkspaceId = successor ? workspaceIdOfTab(successor) : null
+          if (successor && fallbackWorkspaceId !== activeWorkspaceId.value) {
+            try {
+              await activateWorkspace(fallbackWorkspaceId)
+            } catch {
+              // Keep the positional fallback selected if its workspace hop also fails.
+            }
+          }
         }
       } else {
         cancelPendingWorkspaceActivation()

--- a/frontend/src/test/AppPaneClose.test.ts
+++ b/frontend/src/test/AppPaneClose.test.ts
@@ -798,6 +798,51 @@ describe('App.vue - onClosePane routes through confirmation gate', () => {
     expect(workspaceState.activeWorkspaceId.value).toBe('workspace-b')
     expect(session.activePaneId).toBe('workspace-b-successor')
   })
+
+  it('uses a positional fallback when the successor workspace hop fails', async () => {
+    const wrapper = await mountWithTabs()
+    const session = useSessionStore()
+    const workspaceState = useWorkspaces()
+    workspaceState.workspaces.value = [
+      { id: 'workspace-a', name: 'Workspace A', path: '/workspace/a', order: 0 },
+      { id: 'workspace-b', name: 'Workspace B', path: '/workspace/b', order: 1 },
+    ]
+    workspaceState.activeWorkspaceId.value = 'workspace-a'
+    const terminalTab = (paneId: string, cwd: string): Tab => ({
+      type: 'terminal',
+      paneId,
+      layout: {
+        type: 'leaf',
+        paneId: `${paneId}-leaf`,
+        title: paneId,
+        ratio: 1,
+        zoomed: false,
+      },
+      activePaneId: `${paneId}-leaf`,
+      paneMru: [`${paneId}-leaf`],
+      broadcastMode: false,
+      broadcastActivity: 0,
+      previewVisible: false,
+      previewAddress: '',
+      previewUrl: '',
+      previewKind: 'web',
+      cwd,
+    })
+    session.setTabs([
+      terminalTab('workspace-a-only-tab', '/workspace/a'),
+      terminalTab('workspace-b-fallback', '/workspace/b'),
+    ])
+    session.setActivePane('workspace-a-only-tab')
+    mocks.apiActivateWorkspace.mockRejectedValueOnce(new Error('activation failed'))
+
+    const app = wrapper.vm as unknown as { closeTab: (tabId: string) => Promise<void> }
+    await app.closeTab('workspace-a-only-tab')
+    await nextTick()
+
+    expect(mocks.apiActivateWorkspace).toHaveBeenNthCalledWith(2, 'workspace-b')
+    expect(workspaceState.activeWorkspaceId.value).toBe('workspace-b')
+    expect(session.activePaneId).toBe('workspace-b-fallback')
+  })
 })
 
 describe('App.vue - notification badge visibility', () => {


### PR DESCRIPTION
When closing the active tab, the failed-hop rescue path re-searches only the current workspace — which is already empty (that is why the initial successor pick fell through to its cross-array positional fallback). `.find()` then returns `undefined` and `activePaneId` becomes `null`, leaving no tab selected.

This falls back by position across the remaining tabs and activates that tab's workspace, so pane and workspace state stay in sync and a tab is always selected after a close. Adds a test covering the null-successor case.