### PR TITLE
fix(frontend): deterministic plugin tab workspace attribution

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -332,6 +332,7 @@ import { isWebPreviewInput } from './utils/previewRouting'
 import { isWindowsClient } from './utils/clientPlatform'
 import { nextRevealNavGen, currentRevealNavGen } from './utils/navGen'
 import { pickSuccessorTab } from './utils/tabSuccessor'
+import { workspaceIdFromPaneId } from './utils/pluginPaneId'
 import { initMonitorHistory } from './composables/useMonitor'
 import NotificationPanel from './components/notification/NotificationPanel.vue'
 import { useToast } from 'vue-toastification'
@@ -446,8 +447,16 @@ const { isMobile } = useIsMobile()
 const { workspaces, activeWorkspaceId, activeWorkspace, activeWorkspacePath, activeWorkspaceName, matchWorkspace, activateWorkspace, cancelPendingWorkspaceActivation } = useWorkspaces()
 
 function workspaceIdOfTab(tab: Tab): string | null {
-  if (tab.type === 'plugin') return tab.workspaceId ?? null
-  return matchWorkspace(tab.cwd ?? '', tab.connectionId, tab.workspaceId)?.id ?? null
+  if (tab.type === 'plugin') {
+    return tab.workspaceId ?? workspaceIdFromPaneId(tab.paneId) ?? null
+  }
+  return (
+    matchWorkspace(
+      tab.cwd ?? '',
+      tab.connectionId,
+      tab.workspaceId ?? workspaceIdFromPaneId(tab.paneId)
+    )?.id ?? null
+  )
 }
 const activeWorkspaceAbbr = computed(() =>
   activeWorkspace.value ? resolveAbbr(activeWorkspace.value) : ''

--- a/frontend/src/composables/usePluginLauncher.ts
+++ b/frontend/src/composables/usePluginLauncher.ts
@@ -62,7 +62,7 @@ export function usePluginLauncher(opts: PluginLauncherOptions): PluginLauncherSt
         (t) => t.type === 'terminal' && t.paneId === result.tab_id,
       ) as TerminalTab | undefined
       if (existingTab) {
-        const wsIdVal = activeWorkspaceId.value ?? undefined
+        const wsIdVal = wsId || undefined
         if (wsIdVal && !existingTab.workspaceId) existingTab.workspaceId = wsIdVal
       } else {
         tabs.value.push({
@@ -77,7 +77,7 @@ export function usePluginLauncher(opts: PluginLauncherOptions): PluginLauncherSt
           previewAddress: '',
           previewUrl: '',
           previewKind: 'web',
-          workspaceId: activeWorkspaceId.value ?? undefined,
+          workspaceId: wsId || undefined,
         })
       }
       commitLocalActivePane(result.tab_id)

--- a/frontend/src/composables/useSyncWebSocket.ts
+++ b/frontend/src/composables/useSyncWebSocket.ts
@@ -23,6 +23,7 @@ import { apiCreatePluginTab } from './useTabApi'
 import { clearFileWorkspaceState } from './useFileWorkspaceState'
 import { pickSuccessorTab } from '../utils/tabSuccessor'
 import { currentRevealNavGen, nextRevealNavGen } from '../utils/navGen'
+import { workspaceIdFromPaneId } from '../utils/pluginPaneId'
 import type TerminalPane from '../components/terminal/TerminalPane.vue'
 
 type SyncEventHandler = (e: SyncEvent) => void
@@ -113,8 +114,16 @@ export function useSyncWebSocket(opts: {
   } = useWorkspaces()
 
   function workspaceIdOfTab(tab: Tab): string | null {
-    if (tab.type === 'plugin') return tab.workspaceId ?? null
-    return matchWorkspace(tab.cwd ?? '', tab.connectionId, tab.workspaceId)?.id ?? null
+    if (tab.type === 'plugin') {
+      return tab.workspaceId ?? workspaceIdFromPaneId(tab.paneId) ?? null
+    }
+    return (
+      matchWorkspace(
+        tab.cwd ?? '',
+        tab.connectionId,
+        tab.workspaceId ?? workspaceIdFromPaneId(tab.paneId)
+      )?.id ?? null
+    )
   }
 
   let syncWs: WebSocket | null = null
@@ -273,7 +282,7 @@ export function useSyncWebSocket(opts: {
               customTitle: migrated?.customTitle,
               cwd: tab.cwd,
               connectionId: tab.connection_id,
-              workspaceId: migrated?.workspaceId,
+              workspaceId: migrated?.workspaceId ?? workspaceIdFromPaneId(tab.tab_id),
             })
           }
         }
@@ -372,6 +381,11 @@ export function useSyncWebSocket(opts: {
           if (msg.connection_id && existing.type === 'terminal' && !existing.connectionId) {
             existing.connectionId = msg.connection_id
           }
+          const decodedWorkspaceId = workspaceIdFromPaneId(msg.tab_id)
+          if (existing.type === 'terminal' && !existing.workspaceId && decodedWorkspaceId) {
+            existing.workspaceId = decodedWorkspaceId
+            persist()
+          }
         }
         if (!existing) {
           const layout = msg.layout
@@ -397,6 +411,7 @@ export function useSyncWebSocket(opts: {
             previewKind: 'web',
             cwd: msg.cwd,
             connectionId: msg.connection_id,
+            workspaceId: workspaceIdFromPaneId(msg.tab_id),
           })
           markRecentlyCreated(msg.tab_id)
           activePaneId.value = msg.tab_id
@@ -445,9 +460,18 @@ export function useSyncWebSocket(opts: {
                 // Keep the current workspace and select one of its remaining tabs below.
               }
               if (!workspaceCommitted || gen !== currentRevealNavGen()) {
-                successor = tabs.value.find(
-                  (candidate) => workspaceIdOfTab(candidate) === activeWorkspaceId.value
-                )
+                successor =
+                  tabs.value.find(
+                    (candidate) => workspaceIdOfTab(candidate) === activeWorkspaceId.value
+                  ) ?? tabs.value[Math.min(tabIdx, tabs.value.length - 1)]
+                const fallbackWorkspaceId = successor ? workspaceIdOfTab(successor) : null
+                if (successor && fallbackWorkspaceId !== activeWorkspaceId.value) {
+                  try {
+                    await activateWorkspace(fallbackWorkspaceId)
+                  } catch {
+                    // Keep the positional fallback selected if its workspace hop also fails.
+                  }
+                }
               }
             } else {
               cancelPendingWorkspaceActivation()

--- a/frontend/src/test/pluginPaneId.test.ts
+++ b/frontend/src/test/pluginPaneId.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { workspaceIdFromPaneId } from '../utils/pluginPaneId'
+
+describe('workspaceIdFromPaneId', () => {
+  it('scenario 1: decodes a new-format plugin pane id', () => {
+    expect(workspaceIdFromPaneId('plugin:session-browser:4ce788c1-x')).toBe('4ce788c1-x')
+  })
+
+  it.each([
+    ['scenario 2: empty workspace segment', 'plugin:json-formatter:'],
+    ['scenario 3: old plugin format', 'plugin:whiteboard'],
+    ['scenario 4: non-plugin pane id', 'a1b2c3d4-uuid'],
+    ['extra segment', 'plugin:session-browser:workspace-a:extra'],
+    ['wrong prefix', 'terminal:session-browser:workspace-a'],
+  ])('returns undefined for %s', (_label, paneId) => {
+    expect(workspaceIdFromPaneId(paneId)).toBeUndefined()
+  })
+})

--- a/frontend/src/test/usePluginLauncherWorkspace.test.ts
+++ b/frontend/src/test/usePluginLauncherWorkspace.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import type { LoadedPlugin } from '../composables/usePluginLoader'
+import type { PaneLayout, Tab, TerminalTab } from '../types/pane'
+
+const mocks = vi.hoisted(() => ({
+  apiCreatePluginTab: vi.fn(),
+}))
+
+vi.mock('../composables/useTabApi', () => ({
+  apiCreatePluginTab: mocks.apiCreatePluginTab,
+}))
+
+import { usePluginLauncher } from '../composables/usePluginLauncher'
+
+function leaf(paneId: string): PaneLayout {
+  return { type: 'leaf', paneId, title: paneId, ratio: 1, zoomed: false }
+}
+
+function plugin(): LoadedPlugin {
+  return {
+    id: 'session-browser',
+    manifest: { id: 'session-browser', name: 'Session Browser', version: '1.0.0' },
+    module: { activate: vi.fn() },
+    exports: null,
+    state: 'active',
+  }
+}
+
+function terminal(paneId: string): TerminalTab {
+  return {
+    type: 'terminal',
+    paneId,
+    layout: leaf(paneId),
+    activePaneId: paneId,
+    paneMru: [paneId],
+    broadcastMode: false,
+    broadcastActivity: 0,
+    previewVisible: false,
+    previewAddress: '',
+    previewUrl: '',
+    previewKind: 'web',
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+function setup(tabsValue: Tab[]) {
+  const tabs = ref<Tab[]>(tabsValue)
+  const activeWorkspaceId = ref<string | null>('workspace-a')
+  const persist = vi.fn()
+  const subject = usePluginLauncher({
+    tabs,
+    activeWorkspaceId,
+    loadedPlugins: new Map([['session-browser', plugin()]]),
+    syncWs: { sendSync: vi.fn() },
+    ensureSplitRoot: (layout) => layout,
+    activateTab: vi.fn(),
+    commitLocalActivePane: vi.fn(),
+    persist,
+    focusActive: vi.fn(),
+  })
+  return { tabs, activeWorkspaceId, persist, subject }
+}
+
+describe('usePluginLauncher workspace snapshot', () => {
+  it('scenario 5: backfills a tab_created winner from the pre-await workspace snapshot', async () => {
+    const pending = deferred<{ tab_id: string; pane_id: string; layout: PaneLayout }>()
+    mocks.apiCreatePluginTab.mockReturnValueOnce(pending.promise)
+    const { tabs, activeWorkspaceId, subject } = setup([])
+    const opening = subject.openPlugin('session-browser')
+
+    const paneId = 'plugin:session-browser:workspace-a'
+    const racedTab = terminal(paneId)
+    tabs.value.push(racedTab)
+    activeWorkspaceId.value = null
+    pending.resolve({ tab_id: paneId, pane_id: paneId, layout: leaf(paneId) })
+    await opening
+
+    expect(racedTab.workspaceId).toBe('workspace-a')
+  })
+
+  it('scenario 5: assigns a newly pushed tab from the pre-await workspace snapshot', async () => {
+    const pending = deferred<{ tab_id: string; pane_id: string; layout: PaneLayout }>()
+    mocks.apiCreatePluginTab.mockReturnValueOnce(pending.promise)
+    const { tabs, activeWorkspaceId, subject } = setup([])
+    const opening = subject.openPlugin('session-browser')
+
+    const paneId = 'plugin:session-browser:workspace-a'
+    activeWorkspaceId.value = null
+    pending.resolve({ tab_id: paneId, pane_id: paneId, layout: leaf(paneId) })
+    await opening
+
+    expect(tabs.value).toHaveLength(1)
+    expect((tabs.value[0] as TerminalTab).workspaceId).toBe('workspace-a')
+  })
+})

--- a/frontend/src/test/useSyncWebSocketPluginWorkspace.test.ts
+++ b/frontend/src/test/useSyncWebSocketPluginWorkspace.test.ts
@@ -1,0 +1,281 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import type { PaneLayout, TerminalTab } from '../types/pane'
+
+const mocks = vi.hoisted(() => ({
+  apiActivateWorkspace: vi.fn(async () => {}),
+  apiDeactivateWorkspace: vi.fn(async () => {}),
+}))
+
+let socket: MockWebSocket
+class MockWebSocket {
+  static OPEN = 1
+  readyState = MockWebSocket.OPEN
+  onopen: (() => void) | null = null
+  onmessage: ((event: { data: string }) => void) | null = null
+  onclose: ((event: { code: number; reason: string }) => void) | null = null
+  onerror: (() => void) | null = null
+  send = vi.fn()
+  close = vi.fn()
+  constructor(public url: string) {
+    socket = this
+  }
+}
+vi.stubGlobal('WebSocket', MockWebSocket)
+
+class MemoryStorage {
+  private values = new Map<string, string>()
+  getItem(key: string) {
+    return this.values.get(key) ?? null
+  }
+  setItem(key: string, value: string) {
+    this.values.set(key, value)
+  }
+  removeItem(key: string) {
+    this.values.delete(key)
+  }
+  clear() {
+    this.values.clear()
+  }
+}
+vi.stubGlobal('localStorage', new MemoryStorage())
+
+vi.mock('../composables/apiBase', () => ({
+  getApiBase: async () => 'http://localhost',
+  wsUrlWithToken: (url: string) => url,
+  hasAuthToken: () => false,
+}))
+vi.mock('../composables/useTransport', () => ({ isTauri: () => false }))
+vi.mock('../composables/usePluginLoader', () => ({ handlePluginChanged: vi.fn() }))
+vi.mock('../composables/useWorkspaceApi', () => ({
+  apiListWorkspaces: vi.fn(async () => []),
+  apiCreateWorkspace: vi.fn(),
+  apiUpdateWorkspace: vi.fn(),
+  apiDeleteWorkspace: vi.fn(),
+  apiActivateWorkspace: mocks.apiActivateWorkspace,
+  apiDeactivateWorkspace: mocks.apiDeactivateWorkspace,
+  apiReorderWorkspaces: vi.fn(),
+}))
+
+import { useSyncWebSocket } from '../composables/useSyncWebSocket'
+import { useWorkspaces } from '../composables/useWorkspaces'
+import { useSessionStore } from '../stores/sessionStore'
+
+function leaf(paneId: string): PaneLayout {
+  return { type: 'leaf', paneId: `${paneId}-leaf`, title: paneId, ratio: 1, zoomed: false }
+}
+
+function terminal(
+  paneId: string,
+  options: { workspaceId?: string | null; cwd?: string } = {}
+): TerminalTab {
+  return {
+    type: 'terminal',
+    paneId,
+    layout: leaf(paneId),
+    activePaneId: `${paneId}-leaf`,
+    paneMru: [`${paneId}-leaf`],
+    broadcastMode: false,
+    broadcastActivity: 0,
+    previewVisible: false,
+    previewAddress: '',
+    previewUrl: '',
+    previewKind: 'web',
+    workspaceId: options.workspaceId as string | undefined,
+    cwd: options.cwd,
+  }
+}
+
+async function setup(
+  initialTabs: TerminalTab[] = [],
+  activePaneId: string | null = initialTabs[0]?.paneId ?? null
+) {
+  setActivePinia(createPinia())
+  const session = useSessionStore()
+  session.tabs = initialTabs
+  session.activePaneId = activePaneId
+  const workspaceState = useWorkspaces()
+  workspaceState.workspaces.value = [
+    { id: 'workspace-a', name: 'Workspace A', path: '/workspace/a', order: 0 },
+    { id: 'workspace-b', name: 'Workspace B', path: '/workspace/b', order: 1 },
+  ]
+  workspaceState.activeWorkspaceId.value = 'workspace-a'
+  const persist = vi.fn()
+  const subject = useSyncWebSocket({
+    termRefs: {},
+    persist,
+    focusActive: vi.fn(),
+    newTab: vi.fn(async () => {}),
+  })
+  await subject.connectSyncWS()
+  const emit = (message: Record<string, unknown>) => {
+    socket.onmessage?.({ data: JSON.stringify(message) })
+  }
+  return { session, workspaceState, persist, emit }
+}
+
+describe('useSyncWebSocket plugin workspace attribution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    mocks.apiActivateWorkspace.mockResolvedValue(undefined)
+    mocks.apiDeactivateWorkspace.mockResolvedValue(undefined)
+  })
+
+  it('scenario 10: repairs workspaceId when tab_created pushes a plugin tab', async () => {
+    const { session, emit } = await setup()
+    emit({
+      type: 'tab_created',
+      tab_id: 'plugin:session-browser:workspace-a',
+      pane_id: 'plugin-pane',
+    })
+
+    expect((session.tabs[0] as TerminalTab).workspaceId).toBe('workspace-a')
+  })
+
+  it('scenario 11: backfills an existing tab and persists the repair', async () => {
+    const existing = terminal('plugin:session-browser:workspace-a', { workspaceId: null })
+    const { persist, emit } = await setup([existing])
+    emit({
+      type: 'tab_created',
+      tab_id: existing.paneId,
+      pane_id: existing.activePaneId,
+    })
+
+    expect(existing.workspaceId).toBe('workspace-a')
+    expect(persist).toHaveBeenCalledOnce()
+  })
+
+  it('scenario 12: rebuilds corrupt saved plugin attribution from tab_id', async () => {
+    const paneId = 'plugin:session-browser:workspace-b'
+    localStorage.setItem(
+      'dinotty_tabs',
+      JSON.stringify({ tabs: [terminal(paneId, { workspaceId: null })] })
+    )
+    const { session, emit } = await setup()
+    emit({
+      type: 'tab_list',
+      tabs: [{ tab_id: paneId, pane_id: `${paneId}-leaf` }],
+      active_pane_id: null,
+    })
+
+    expect((session.tabs[0] as TerminalTab).workspaceId).toBe('workspace-b')
+  })
+
+  it('scenario 6: close-time read fallback attributes a missing field to a live workspace', async () => {
+    const pluginTab = terminal('plugin:session-browser:workspace-b')
+    const successor = terminal('workspace-b-successor', { workspaceId: 'workspace-b' })
+    const other = terminal('workspace-a-other', { workspaceId: 'workspace-a' })
+    const { session, workspaceState, emit } = await setup(
+      [pluginTab, other, successor],
+      pluginTab.paneId
+    )
+    workspaceState.activeWorkspaceId.value = 'workspace-b'
+    emit({ type: 'tab_closed', pane_id: pluginTab.paneId })
+
+    await vi.waitFor(() => expect(session.activePaneId).toBe(successor.paneId))
+    expect(mocks.apiActivateWorkspace).not.toHaveBeenCalled()
+  })
+
+  it('scenario 7: a decoded stale workspace falls through to default without crashing', async () => {
+    const pluginTab = terminal('plugin:session-browser:deleted-workspace')
+    const defaultTab = terminal('default-successor')
+    const { session, workspaceState, emit } = await setup([pluginTab, defaultTab], pluginTab.paneId)
+    workspaceState.activeWorkspaceId.value = null
+    emit({ type: 'tab_closed', pane_id: pluginTab.paneId })
+
+    await vi.waitFor(() => expect(session.activePaneId).toBe(defaultTab.paneId))
+    expect(mocks.apiActivateWorkspace).not.toHaveBeenCalled()
+  })
+
+  it('scenario 8: closing a corrupt-field plugin tab selects its origin-workspace successor', async () => {
+    const pluginTab = terminal('plugin:session-browser:workspace-a', { workspaceId: null })
+    const workspaceB = terminal('workspace-b-other', { workspaceId: 'workspace-b' })
+    const workspaceA = terminal('workspace-a-successor', { workspaceId: 'workspace-a' })
+    const { session, emit } = await setup([pluginTab, workspaceB, workspaceA], pluginTab.paneId)
+    emit({ type: 'tab_closed', pane_id: pluginTab.paneId })
+
+    await vi.waitFor(() => expect(session.activePaneId).toBe(workspaceA.paneId))
+    expect(mocks.apiActivateWorkspace).not.toHaveBeenCalled()
+  })
+
+  it('scenario 9: after a failed hop, re-picks from the active workspace before position', async () => {
+    const pluginTab = terminal('plugin:session-browser:workspace-b')
+    const workspaceB = terminal('workspace-b-successor', { workspaceId: 'workspace-b' })
+    const workspaceA = terminal('workspace-a-fallback', { workspaceId: 'workspace-a' })
+    mocks.apiActivateWorkspace.mockRejectedValueOnce(new Error('hop failed'))
+    const { session, emit } = await setup([pluginTab, workspaceB, workspaceA], pluginTab.paneId)
+    emit({ type: 'tab_closed', pane_id: pluginTab.paneId })
+
+    await vi.waitFor(() => expect(session.activePaneId).toBe(workspaceA.paneId))
+    expect(mocks.apiActivateWorkspace).toHaveBeenCalledTimes(1)
+    expect(mocks.apiActivateWorkspace).toHaveBeenCalledWith('workspace-b')
+  })
+
+  it('scenario 9: uses positional fallback last and attempts its workspace hop again', async () => {
+    const pluginTab = terminal('plugin:session-browser:workspace-a')
+    const workspaceB = terminal('workspace-b-positional', { workspaceId: 'workspace-b' })
+    mocks.apiActivateWorkspace.mockRejectedValueOnce(new Error('first hop failed'))
+    const { session, emit } = await setup([pluginTab, workspaceB], pluginTab.paneId)
+    emit({ type: 'tab_closed', pane_id: pluginTab.paneId })
+
+    await vi.waitFor(() => expect(mocks.apiActivateWorkspace).toHaveBeenCalledTimes(2))
+    expect(mocks.apiActivateWorkspace).toHaveBeenNthCalledWith(1, 'workspace-b')
+    expect(mocks.apiActivateWorkspace).toHaveBeenNthCalledWith(2, 'workspace-b')
+    expect(session.activePaneId).toBe(workspaceB.paneId)
+  })
+
+  it('scenario 13: preserves the successful-hop behavior for a non-plugin tab', async () => {
+    const workspaceA = terminal('normal-a', { workspaceId: 'workspace-a' })
+    const workspaceB = terminal('normal-b', { workspaceId: 'workspace-b' })
+    const { session, workspaceState, emit } = await setup(
+      [workspaceA, workspaceB],
+      workspaceA.paneId
+    )
+    emit({ type: 'tab_closed', pane_id: workspaceA.paneId })
+
+    await vi.waitFor(() => expect(workspaceState.activeWorkspaceId.value).toBe('workspace-b'))
+    expect(mocks.apiActivateWorkspace).toHaveBeenCalledOnce()
+    expect(session.activePaneId).toBe(workspaceB.paneId)
+  })
+
+  it('scenario 14: gives a non-plugin failed hop positional fallback and a second attempt', async () => {
+    const workspaceA = terminal('normal-a', { workspaceId: 'workspace-a' })
+    const workspaceB = terminal('normal-b', { workspaceId: 'workspace-b' })
+    mocks.apiActivateWorkspace.mockRejectedValueOnce(new Error('first hop failed'))
+    const { session, emit } = await setup([workspaceA, workspaceB], workspaceA.paneId)
+    emit({ type: 'tab_closed', pane_id: workspaceA.paneId })
+
+    await vi.waitFor(() => expect(mocks.apiActivateWorkspace).toHaveBeenCalledTimes(2))
+    expect(session.activePaneId).toBe(workspaceB.paneId)
+  })
+
+  it('scenario 15: a live stored field wins over a different decoded workspace', async () => {
+    const pluginTab = terminal('plugin:session-browser:workspace-a', {
+      workspaceId: 'workspace-b',
+    })
+    const workspaceA = terminal('workspace-a-first', { workspaceId: 'workspace-a' })
+    const workspaceB = terminal('workspace-b-successor', { workspaceId: 'workspace-b' })
+    const { session, workspaceState, emit } = await setup(
+      [pluginTab, workspaceA, workspaceB],
+      pluginTab.paneId
+    )
+    workspaceState.activeWorkspaceId.value = 'workspace-b'
+    emit({ type: 'tab_closed', pane_id: pluginTab.paneId })
+
+    await vi.waitFor(() => expect(session.activePaneId).toBe(workspaceB.paneId))
+    expect(mocks.apiActivateWorkspace).not.toHaveBeenCalled()
+  })
+
+  it('scenario 16: a passive close decodes consistently without hopping workspaces', async () => {
+    const active = terminal('workspace-a-active', { workspaceId: 'workspace-a' })
+    const passivePlugin = terminal('plugin:session-browser:workspace-a', { workspaceId: null })
+    const { session, workspaceState, emit } = await setup([active, passivePlugin], active.paneId)
+    emit({ type: 'tab_closed', pane_id: passivePlugin.paneId })
+
+    expect(session.tabs.map((tab) => tab.paneId)).toEqual([active.paneId])
+    expect(session.activePaneId).toBe(active.paneId)
+    expect(workspaceState.activeWorkspaceId.value).toBe('workspace-a')
+    expect(mocks.apiActivateWorkspace).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/utils/pluginPaneId.ts
+++ b/frontend/src/utils/pluginPaneId.ts
@@ -1,0 +1,5 @@
+export function workspaceIdFromPaneId(paneId: string): string | undefined {
+  const parts = paneId.split(':')
+  if (parts.length !== 3 || parts[0] !== 'plugin' || !parts[2]) return undefined
+  return parts[2]
+}


### PR DESCRIPTION
## Problem

Closing a plugin tab deterministically jumps to the default workspace, regardless of which workspace the plugin was opened in.

Root cause: plugin tabs can lose their `workspaceId` at creation time —

1. The `tab_created` WS broadcast wins the race against the REST response and inserts the tab **without** the `workspaceId` field.
2. The post-`await` backfill in `openPlugin` re-reads `activeWorkspaceId`, which can differ from the workspace the plugin was actually opened in (or miss entirely).

A tab with `workspaceId: null` is attributed to the default workspace at close time, so the close-successor logic picks a default-workspace tab and activates the default workspace — the jump.

## Fix

- **`utils/pluginPaneId.ts` (new)**: `workspaceIdFromPaneId` decoder — plugin pane ids embed their workspace (`plugin:<pluginId>:<wsId>`), so the origin workspace is recoverable even when the field is lost.
- **`usePluginLauncher.ts`**: snapshot the workspace id *before* the `await`, and write it on both the existing-tab and push branches (no post-await re-reads).
- **`useSyncWebSocket.ts`**:
  - `tab_created`: decode + backfill `workspaceId` at ingress (and persist the repair);
  - `tab_list`: decode fallback when rebuilding tabs;
  - `workspaceIdOfTab`: fall back to paneId decode (validated via `matchWorkspace`);
  - `tab_closed`: port the close-successor parity from #204 (active-workspace re-pick first, positional fallback last, second `activateWorkspace` when the hop failed) so the WS close path matches the local close path.
- **`App.vue`**: same `workspaceIdOfTab` fallback in the second copy.

## Testing

- 3 new test files: decoder unit tests, launcher workspace attribution, sync-handler ingress/close scenarios (race, backfill+persist, successor ordering, decode precedence).
- Full suite green on this branch: `vitest` 774/774, `vue-tsc --noEmit` clean.
- Manually verified end-to-end: opening a plugin in a named workspace now stores the attribution immediately (previously `null`), and closing it stays in the origin workspace with a same-workspace successor.