### PR TITLE
feat(plugin-api): pass pane identity and tab-level visibility to dynamic plugin components

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -110,6 +110,7 @@
             :broadcast-activity="tab.broadcastActivity"
             :allow-close="getAllLeaves(tab.layout).length > 1"
             :tab-id="tab.paneId"
+            :is-visible="tab.paneId === activePaneId"
             @register="registerTermRef"
             @title-change="onTitleChange"
             @shell-info="onShellInfo"

--- a/frontend/src/components/plugin/PluginView.vue
+++ b/frontend/src/components/plugin/PluginView.vue
@@ -5,6 +5,10 @@
         v-if="plugin.state === 'active' && plugin.exports?.component && !hasError"
         :is="plugin.exports.component"
         :api="api"
+        :pane-id="paneId"
+        :workspace-id="workspaceId"
+        :is-visible="isVisible"
+        :is-focused="isFocused"
       />
       <div v-else-if="hasError" class="plugin-error">
         <p>Plugin runtime error: {{ errorMsg }}</p>
@@ -26,6 +30,10 @@ import type { LoadedPlugin, PluginContext } from '../../composables/usePluginLoa
 defineProps<{
   plugin: LoadedPlugin
   api: PluginContext
+  paneId: string
+  workspaceId: string | undefined
+  isVisible: boolean
+  isFocused: boolean
 }>()
 
 const hasError = ref(false)

--- a/frontend/src/components/split/PaneContent.vue
+++ b/frontend/src/components/split/PaneContent.vue
@@ -21,6 +21,10 @@
     :data-plugin-pane-id="leaf.paneId"
     :plugin="plugin"
     :api="api"
+    :pane-id="leaf.paneId"
+    :workspace-id="workspaceId"
+    :is-visible="isVisible"
+    :is-focused="isFocused"
   />
   <FileWorkspacePreview
     v-else-if="kind === 'files'"
@@ -53,6 +57,8 @@ import { useI18n } from '../../composables/useI18n'
 
 const props = defineProps<{
   leaf: LeafPane
+  isVisible: boolean
+  isFocused: boolean
 }>()
 
 const emit = defineEmits<{
@@ -83,6 +89,11 @@ const plugin = computed(() =>
 const api = computed(() =>
   props.leaf.pluginId ? getPluginContext(props.leaf.pluginId) : undefined
 )
+const workspaceId = computed(() => {
+  const paneId = props.leaf.paneId
+  if (!paneId.startsWith('plugin:')) return undefined
+  return paneId.split(':').slice(2).join(':') || undefined
+})
 </script>
 
 <style scoped>

--- a/frontend/src/components/split/SplitContainer.vue
+++ b/frontend/src/components/split/SplitContainer.vue
@@ -74,6 +74,8 @@
     </div>
     <PaneContent
       :leaf="leaf"
+      :is-visible="isVisible"
+      :is-focused="leaf.paneId === activePaneId"
       @register="(id: string, el: any) => emit('register', id, el)"
       @title-change="(id: string, title: string) => emit('titleChange', id, title)"
       @shell-info="(id: string, shell: string) => emit('shellInfo', id, shell)"
@@ -105,6 +107,7 @@
         :allow-close="allowClose"
         :parent-direction="split!.direction"
         :tab-id="tabId"
+        :is-visible="isChildVisible(child)"
         :style="getChildStyle(idx)"
         @register="(id: string, el: any) => emit('register', id, el)"
         @title-change="(id: string, title: string) => emit('titleChange', id, title)"
@@ -146,16 +149,22 @@ import SplitDivider from './SplitDivider.vue'
 import PaneHeader from './PaneHeader.vue'
 import { useI18n } from '../../composables/useI18n'
 
-const props = defineProps<{
-  layout: PaneLayout
-  activePaneId: string
-  broadcastMode: boolean
-  broadcastActivity: number
-  showHeader?: boolean
-  allowClose?: boolean
-  parentDirection?: 'horizontal' | 'vertical'
-  tabId: string
-}>()
+const props = withDefaults(
+  defineProps<{
+    layout: PaneLayout
+    activePaneId: string
+    broadcastMode: boolean
+    broadcastActivity: number
+    showHeader?: boolean
+    allowClose?: boolean
+    parentDirection?: 'horizontal' | 'vertical'
+    tabId: string
+    isVisible?: boolean
+  }>(),
+  {
+    isVisible: true,
+  }
+)
 
 const emit = defineEmits<{
   register: [paneId: string, el: any]
@@ -183,6 +192,9 @@ const containerRef = ref<HTMLElement>()
 
 const leaf = computed(() => (props.layout.type === 'leaf' ? (props.layout as LeafPane) : null))
 const split = computed(() => (props.layout.type === 'split' ? props.layout : null))
+const hasDirectZoomedLeaf = computed(
+  () => split.value?.children.some((child) => child.type === 'leaf' && child.zoomed) ?? false
+)
 
 const broadcastActive = computed(() => {
   if (!leaf.value) return false
@@ -196,6 +208,10 @@ const broadcastReceiving = computed(() => {
 
 function onLeafClick(paneId: string) {
   emit('focus', paneId)
+}
+
+function isChildVisible(child: PaneLayout) {
+  return props.isVisible && (!hasDirectZoomedLeaf.value || (child.type === 'leaf' && child.zoomed))
 }
 
 function makeRatioRef(idx: number) {


### PR DESCRIPTION
## Summary

A dynamic plugin component only ever received `api`. Hiding a tab is CSS-only, so no Vue
lifecycle hook fires — a plugin cannot tell that it became hidden or visible, nor which pane
it is mounted in when the same plugin is open in two panes. This passes
`paneId` / `workspaceId` / `isVisible` / `isFocused` down to the dynamic component.

Motivation: the session-browser plugin needs the visibility signal to restore its transcript
scroll position across a tab switch. Hiding a tab drops the pane width to 0, which flips the
plugin into its narrow layout; switching back reflows and changes the transcript height while
`scrollTop` still holds the old pixel value, so the view lands a few turns above where the
user left it. Without a visibility signal a plugin can only infer this from a width transition.

## Changes

- `PluginView.vue` — declares and forwards the four new props to the dynamic component.
- `PaneContent.vue` — accepts `isVisible` / `isFocused`; derives `workspaceId` from the plugin paneId.
- `SplitContainer.vue` — threads visibility recursively. Zoom occludes path-locally, so each
  container passes down `parentVisible && (no direct zoomed leaf || this child is it)`.
- `App.vue` — binds the tab-level fact: `tab.paneId === activePaneId`.

`isVisible` is deliberately the TAB-level fact (the same store-level `activePaneId` comparison
that drives `display:none`), not SplitContainer's leaf-level active flag — every tab has that
set on exactly one leaf, including hidden ones.

Additive and backward compatible: `isVisible` defaults to visible, so an omitted binding
preserves today's behaviour. No existing prop, emit, class or style is changed.

## Test Plan

- [x] Tested locally — exercised through the session-browser plugin consuming the new props:
      same plugin open in two workspaces, repeated tab switching, scroll position preserved.
- [x] Frontend type-check passes (`vue-tsc --noEmit`)
- [x] Frontend build passes (`pnpm run build`)
- [ ] Mobile browser — not applicable (no layout or input-surface change)

## Visual Checklist

Not applicable — no colors, icons, palette or theme changes; this is a props-only plumbing change.
