### PR TITLE
ci: sign and notarize macOS release artifacts

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -184,8 +184,75 @@ jobs:
           Remove-Item -LiteralPath target/debian -Recurse -Force -ErrorAction SilentlyContinue
           Remove-Item -LiteralPath src-tauri/target/release/bundle -Recurse -Force -ErrorAction SilentlyContinue
 
+      - name: Configure Apple signing and notarization
+        if: matrix.platform == 'macos'
+        shell: bash
+        env:
+          APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+        run: |
+          set -euo pipefail
+
+          for name in \
+            APPLE_API_KEY_CONTENT \
+            APPLE_API_KEY \
+            APPLE_API_ISSUER \
+            APPLE_CERTIFICATE; do
+            if [[ -z "${!name:-}" ]]; then
+              echo "::error::Required repository secret ${name} is not configured."
+              exit 1
+            fi
+          done
+
+          api_key_path="${RUNNER_TEMP}/AuthKey_${APPLE_API_KEY}.p8"
+          printf '%s' "${APPLE_API_KEY_CONTENT}" > "${api_key_path}"
+          chmod 600 "${api_key_path}"
+          echo "APPLE_API_KEY_PATH=${api_key_path}" >> "${GITHUB_ENV}"
+
       - name: Build desktop packages
+        env:
+          APPLE_API_KEY: ${{ matrix.platform == 'macos' && secrets.APPLE_API_KEY || '' }}
+          APPLE_API_ISSUER: ${{ matrix.platform == 'macos' && secrets.APPLE_API_ISSUER || '' }}
+          APPLE_CERTIFICATE: ${{ matrix.platform == 'macos' && secrets.APPLE_CERTIFICATE || '' }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ matrix.platform == 'macos' && secrets.APPLE_CERTIFICATE_PASSWORD || '' }}
+          APPLE_SIGNING_IDENTITY: "${{ matrix.platform == 'macos' && 'Developer ID Application: ConstChar LLC (N95822WA7A)' || '' }}"
         run: pnpm dlx "@tauri-apps/cli@${{ env.TAURI_CLI_VERSION }}" build --bundles ${{ matrix.bundles }} --ci
+
+      - name: Notarize and verify macOS artifacts
+        if: matrix.platform == 'macos'
+        shell: bash
+        env:
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+        run: |
+          set -euo pipefail
+
+          first_dmg="$(find target src-tauri/target -type f -path '*/release/bundle/dmg/*.dmg' -print -quit 2>/dev/null || true)"
+          if [[ -z "${first_dmg}" ]]; then
+            echo "::error::Expected a macOS DMG output."
+            exit 1
+          fi
+
+          # Tauri removes the intermediate .app after creating a DMG-only bundle.
+          while IFS= read -r -d '' app; do
+            codesign --verify --deep --strict --verbose=2 "${app}"
+            xcrun stapler validate "${app}"
+            spctl --assess --type execute --verbose=2 "${app}"
+          done < <(find target src-tauri/target -type d -path '*/release/bundle/macos/*.app' -print0 2>/dev/null || true)
+
+          # Tauri notarizes the app bundle; submit and staple each distributed DMG as well.
+          while IFS= read -r -d '' dmg; do
+            xcrun notarytool submit "${dmg}" \
+              --key "${APPLE_API_KEY_PATH}" \
+              --key-id "${APPLE_API_KEY}" \
+              --issuer "${APPLE_API_ISSUER}" \
+              --wait
+            xcrun stapler staple "${dmg}"
+            xcrun stapler validate "${dmg}"
+            spctl --assess --type open --context context:primary-signature --verbose=2 "${dmg}"
+          done < <(find target src-tauri/target -type f -path '*/release/bundle/dmg/*.dmg' -print0 2>/dev/null || true)
 
       - name: Install cargo-deb
         if: matrix.platform == 'linux'
@@ -245,6 +312,11 @@ jobs:
           $portableDir = 'target/release/bundle/portable'
           New-Item -ItemType Directory -Path $portableDir -Force | Out-Null
           Copy-Item -LiteralPath $exe -Destination (Join-Path $portableDir $portableName) -Force
+
+      - name: Remove temporary Apple API key
+        if: always() && matrix.platform == 'macos'
+        shell: bash
+        run: rm -f "${APPLE_API_KEY_PATH:-}"
 
       - name: Stage package artifacts
         shell: pwsh

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ src-tauri/gen/schemas/*.json
 ghostty-comparison-optimization.md
 .star-cache
 
+# Local Apple signing credentials; never commit private keys or certificates.
+/apple-signing/
+
 # VitePress build output
 docs/.vitepress/dist/
 docs/.vitepress/cache/

--- a/docs/en/getting-started/releasing.md
+++ b/docs/en/getting-started/releasing.md
@@ -123,14 +123,28 @@ git push origin "v$Version"
 
 Before pushing, verify that the tag is exactly `v{workspace_version}` and that the current `HEAD` is the intended `main` commit. Do not use `git push --force` for an official tag.
 
-## 5. Monitor the Package Workflow
+## 5. Configure macOS Signing and Notarization
+
+A repository administrator must configure the following GitHub Actions secrets. Never commit certificates or private key files to Git:
+
+| Secret | Value |
+|--------|-------|
+| `APPLE_CERTIFICATE` | Single-line Base64 of the Developer ID Application `.p12`, for example `base64 -i certificate.p12 \| tr -d '\n'` |
+| `APPLE_CERTIFICATE_PASSWORD` | Password selected when exporting the `.p12`; use an empty value for a passwordless certificate |
+| `APPLE_API_KEY_CONTENT` | Complete contents of the App Store Connect API `AuthKey_*.p8` file |
+| `APPLE_API_KEY` | App Store Connect API Key ID |
+| `APPLE_API_ISSUER` | App Store Connect API Issuer ID |
+
+The macOS job fails immediately when the certificate or any notarization credential is missing, so it cannot publish an unsigned or unnotarized artifact. Tauri signs and notarizes the application with the Developer ID Application certificate; the workflow then submits, staples, and validates the final `.dmg` separately. Secrets can be set safely from standard input with `gh secret set SECRET_NAME`.
+
+## 6. Monitor the Package Workflow
 
 Pushing the tag triggers `.github/workflows/package.yml`:
 
 1. `prepare` confirms that the tag commit is in `origin/main` history.
 2. `scripts/check-workspace-version.py` validates the single version source, Cargo packages, and lockfile.
 3. The workflow confirms that the tag equals `v{workspace_version}`.
-4. The macOS, Linux, and Windows jobs build and upload platform artifacts.
+4. The macOS job signs and notarizes the application and `.dmg`, while all platform jobs build and upload artifacts.
 5. After every platform job succeeds, `publish-release` creates the GitHub Release, generates release notes, and attaches the artifacts.
 
 Expected artifacts:

--- a/docs/zh/getting-started/releasing.md
+++ b/docs/zh/getting-started/releasing.md
@@ -123,14 +123,28 @@ git push origin "v$Version"
 
 推送前应确认 tag 名称是 `v{workspace_version}`，且当前 `HEAD` 正是要发布的 `main` commit。不要使用 `git push --force` 发布正式 tag。
 
-## 5. 监控 Package workflow
+## 5. 配置 macOS 签名和公证
+
+仓库管理员需要在 GitHub 仓库的 Actions secrets 中配置以下值；证书和私钥文件不得提交到 Git：
+
+| Secret | 内容 |
+|--------|------|
+| `APPLE_CERTIFICATE` | Developer ID Application `.p12` 文件的 Base64 单行文本，例如 `base64 -i certificate.p12 \| tr -d '\n'` |
+| `APPLE_CERTIFICATE_PASSWORD` | 导出 `.p12` 时设置的密码；无密码证书配置为空值 |
+| `APPLE_API_KEY_CONTENT` | App Store Connect API `AuthKey_*.p8` 文件的完整文本 |
+| `APPLE_API_KEY` | App Store Connect API Key ID |
+| `APPLE_API_ISSUER` | App Store Connect API Issuer ID |
+
+macOS job 缺少证书或任一公证凭据时会立即失败，不会生成未签名或未公证的发布产物。Tauri 使用 Developer ID Application 证书签名并公证应用；workflow 随后单独提交、装订并验证最终 `.dmg`。可用 `gh secret set SECRET_NAME` 从标准输入安全配置 secrets。
+
+## 6. 监控 Package workflow
 
 tag push 会触发 `.github/workflows/package.yml`：
 
 1. `prepare` 确认 tag commit 位于 `origin/main` 历史；
 2. `scripts/check-workspace-version.py` 校验唯一版本源、Cargo packages 和 lockfile；
 3. workflow 确认 tag 等于 `v{workspace_version}`；
-4. macOS、Linux 和 Windows jobs 构建并上传平台产物；
+4. macOS job 签名并公证应用和 `.dmg`，全部平台 jobs 构建并上传产物；
 5. 全部平台 jobs 成功后，`publish-release` 创建 GitHub Release、生成 release notes 并附加产物。
 
 预期产物如下：


### PR DESCRIPTION
## What changed

- require Apple signing and notarization credentials for the macOS package job
- sign the Tauri application with a Developer ID Application certificate
- notarize, staple, and validate the final DMG before uploading it
- support password-protected and passwordless PKCS#12 certificates
- document the required GitHub Actions secrets in Chinese and English
- ignore the local `apple-signing/` credential directory

## Required repository secrets

- `APPLE_CERTIFICATE`
- `APPLE_CERTIFICATE_PASSWORD`
- `APPLE_API_KEY_CONTENT`
- `APPLE_API_KEY`
- `APPLE_API_ISSUER`

## Validation

- Package workflow YAML parsed successfully
- `scripts/check-workspace-version.py` passed
- `git diff --check` passed
- the workflow was exercised in the fork with successful Developer ID import, signing, notarization, stapling, and DMG verification
