### PR TITLE
test(frontend): await async Tauri drop handling

### DIFF
--- a/frontend/src/test/terminalUploadDetection.test.ts
+++ b/frontend/src/test/terminalUploadDetection.test.ts
@@ -55,7 +55,7 @@ describe('terminal upload detection', () => {
     expect(drop.defaultPrevented).toBe(true)
   })
 
-  it('keeps the existing Tauri path typing branch unchanged', () => {
+  it('keeps the existing Tauri path typing branch unchanged', async () => {
     transportMocks.tauri = true
     const term = new TerminalInstance('p1')
     const sendData = vi.spyOn(term, 'sendData').mockImplementation(() => {})
@@ -76,6 +76,7 @@ describe('terminal upload detection', () => {
       getData: vi.fn(),
     })
     xterm.dispatchEvent(drop)
+    await flushAsync()
 
     expect(upload).not.toHaveBeenCalled()
     expect(sendData).toHaveBeenCalledWith("'/tmp/a b.txt'")


### PR DESCRIPTION
## What changed

- make the Tauri path typing test asynchronous
- wait for the async native drag-pasteboard fallback before asserting `sendData`

## Why

`setupTerminalDrop` now awaits the native macOS drag pasteboard before falling back to `File.path`. `dispatchEvent()` does not await async listeners, so the existing assertion runs before `sendData` and fails consistently in Windows CI.

## Validation

- `pnpm test` (75 files, 865 tests)
- `pnpm exec vue-tsc --noEmit`
- `pnpm exec eslint src/test/terminalUploadDetection.test.ts`
- `pnpm run build`
- `git diff --check`