### PR TITLE
fix: sync workspace window titles and normalize Windows paths

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -355,6 +355,7 @@ import type { Tab, TerminalTab, PluginTab, PaneLayout, LeafPane, DropPosition } 
 import { getAllLeaves, findLeaf, findFirstLeaf, ensureSplitRoot, paneKind } from './types/pane'
 import { createFrozenSendFn, type SendDataFn } from './utils/frozenSend'
 import { initializePaneMru } from './types/paneMru'
+import { setTauriWindowTitle, updateDocumentTitle } from './utils/windowTitle'
 // useSettings replaced by useSettingsStore
 import {
   getApiBase,
@@ -817,16 +818,13 @@ watch(
   { immediate: true }
 )
 watch(
-  () => {
-    return activeWorkspaceName.value ?? 'dinotty'
-  },
+  () => activeWorkspaceName.value,
   (wsName) => {
-    document.title = wsName
+    const title = updateDocumentTitle(wsName)
     if (isTauri()) {
-      tauriInvoke('set_window_title', { title: wsName }).catch(() => {
-        const tauriWindow = (window as any).__TAURI__?.window?.getCurrentWindow?.()
-        tauriWindow?.setTitle?.(wsName)
-      })
+      void setTauriWindowTitle(title, tauriInvoke, () =>
+        (window as any).__TAURI__?.window?.getCurrentWindow?.()
+      )
     }
   },
   { immediate: true }

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -662,6 +662,7 @@ const onSshConnectRef = shallowRef<
     pane_id: string
     layout: any
     connection_id?: string
+    workspace_id?: string
   }) => Promise<void>
 >(async () => {
   throw new Error('onSshConnect not wired')

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -725,6 +725,7 @@ const {
   termRefs,
   session,
   activateTab,
+  activateWorkspace,
   closeTab,
   requestCloseTab,
   newTab,

--- a/frontend/src/components/overview/WorkspaceOverview.vue
+++ b/frontend/src/components/overview/WorkspaceOverview.vue
@@ -94,7 +94,7 @@ const emit = defineEmits<{
   'close-tab': [paneId: string]
   'close-tabs': [paneIds: string[]]
   'new-tab': [cwd?: string, workspaceId?: string | null]
-  'new-tab-ssh': [connectionId: string, initialCwd?: string]
+  'new-tab-ssh': [connectionId: string, initialCwd?: string, workspaceId?: string]
   'rename-tab': [paneId: string, title: string]
 }>()
 
@@ -267,7 +267,7 @@ function onNewTabForSelected() {
   } else {
     const ws = workspaces.value.find((w) => w.id === sel)
     if (ws?.connection_id) {
-      emit('new-tab-ssh', ws.connection_id, ws.path)
+      emit('new-tab-ssh', ws.connection_id, ws.path, sel)
     } else {
       emit('new-tab', ws?.path, sel)
     }

--- a/frontend/src/components/ssh/SshHostsPanel.vue
+++ b/frontend/src/components/ssh/SshHostsPanel.vue
@@ -312,7 +312,7 @@ async function connectProfile(profile: SshProfile) {
   connecting.value = true
   error.value = ''
   try {
-    const result = await apiCreateSshTab(profile.id, undefined, abortController.signal)
+    const result = await apiCreateSshTab(profile.id, undefined, undefined, abortController.signal)
     emit('connect', result)
     close()
   } catch (e: any) {

--- a/frontend/src/components/ui/CreateWorkspaceDialog.vue
+++ b/frontend/src/components/ui/CreateWorkspaceDialog.vue
@@ -138,7 +138,11 @@
 import { ref, computed, watch, nextTick } from 'vue'
 import { FolderOpen } from 'lucide-vue-next'
 import { useI18n } from '../../composables/useI18n'
-import { DEFAULT_WORKSPACE_ID, useWorkspaces } from '../../composables/useWorkspaces'
+import {
+  DEFAULT_WORKSPACE_ID,
+  useWorkspaces,
+  workspaceBasename,
+} from '../../composables/useWorkspaces'
 import { useSettings } from '../../composables/useSettings'
 import { isTauri, tauriInvoke } from '../../composables/useTransport'
 import type { Workspace } from '../../types/workspace'
@@ -255,8 +259,7 @@ function autoFillName() {
   if (!name.value.trim()) {
     const p = path.value.trim()
     if (p) {
-      const parts = p.split('/').filter(Boolean)
-      name.value = parts[parts.length - 1] || ''
+      name.value = workspaceBasename(p)
     }
   }
 }

--- a/frontend/src/composables/__tests__/useWorkspaces.spec.ts
+++ b/frontend/src/composables/__tests__/useWorkspaces.spec.ts
@@ -189,6 +189,20 @@ describe('useWorkspaces', () => {
       expect(resultWs3).toHaveLength(1)
       expect(resultWs3[0].paneId).toBe('t2')
     })
+
+    it('uses explicit workspace attribution when remote workspaces share a profile', () => {
+      workspaces.value = [
+        { id: 'remote-a', name: 'app-a', path: '/srv/a', order: 0, connection_id: 'shared' },
+        { id: 'remote-b', name: 'app-b', path: '/srv/b', order: 1, connection_id: 'shared' },
+      ]
+      const tabs = [
+        { ...makeTab('ssh-a'), connectionId: 'shared', workspaceId: 'remote-a' },
+        { ...makeTab('ssh-b'), connectionId: 'shared', workspaceId: 'remote-b' },
+      ]
+
+      expect(filterTabs(tabs, 'remote-a').map((tab) => tab.paneId)).toEqual(['ssh-a'])
+      expect(filterTabs(tabs, 'remote-b').map((tab) => tab.paneId)).toEqual(['ssh-b'])
+    })
   })
 
   describe('visibleTabList pattern (TabInfo filtering)', () => {

--- a/frontend/src/composables/__tests__/useWorkspaces.spec.ts
+++ b/frontend/src/composables/__tests__/useWorkspaces.spec.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { DEFAULT_WORKSPACE_ID, useWorkspaces } from '../useWorkspaces'
+import {
+  DEFAULT_WORKSPACE_ID,
+  isPathWithinWorkspace,
+  useWorkspaces,
+  workspaceBasename,
+} from '../useWorkspaces'
 import { settings } from '../useSettings'
 import type { Workspace } from '../../types/workspace'
 import type { TerminalTab } from '../../types/pane'
@@ -22,6 +27,35 @@ function makeTab(paneId: string, cwd?: string): TerminalTab {
     cwd,
   }
 }
+
+describe('workspace path helpers', () => {
+  it.each([
+    [String.raw`C:\repo\dinotty`, 'dinotty'],
+    ['C:/repo/dinotty/', 'dinotty'],
+    ['/home/user/dinotty/', 'dinotty'],
+    ['\\\\server\\share\\project\\', 'project'],
+  ])('gets the basename of %s', (path, expected) => {
+    expect(workspaceBasename(path)).toBe(expected)
+  })
+
+  it('matches Windows drive paths by segment with mixed case and separators', () => {
+    expect(isPathWithinWorkspace(String.raw`c:\REPO\dinotty\src`, 'C:/repo/Dinotty/')).toBe(true)
+    expect(isPathWithinWorkspace(String.raw`C:\repo\dinotty-old`, String.raw`C:\repo\dinotty`)).toBe(
+      false
+    )
+  })
+
+  it('matches UNC paths case-insensitively', () => {
+    expect(
+      isPathWithinWorkspace(String.raw`\\SERVER\Share\Project\src`, '//server/share/project/')
+    ).toBe(true)
+  })
+
+  it('keeps POSIX path matching case-sensitive', () => {
+    expect(isPathWithinWorkspace('/Users/me/Project/src', '/Users/me/Project///')).toBe(true)
+    expect(isPathWithinWorkspace('/Users/me/project/src', '/Users/me/Project')).toBe(false)
+  })
+})
 
 describe('useWorkspaces', () => {
   const { workspaces, activeWorkspaceId, activeWorkspace, matchWorkspace, filterTabs } = useWorkspaces()
@@ -103,6 +137,17 @@ describe('useWorkspaces', () => {
     it('matches workspace with path exactly equal to cwd', () => {
       const result = matchWorkspace('/Users/talentc/projects/my-app')
       expect(result?.id).toBe('ws2')
+    })
+
+    it('uses Windows path semantics while preserving longest-prefix matching', () => {
+      workspaces.value = [
+        { id: 'parent', name: 'repo', path: String.raw`C:\Repo`, order: 0 },
+        { id: 'child', name: 'dinotty', path: 'c:/repo/dinotty/', order: 1 },
+      ]
+
+      const result = matchWorkspace(String.raw`C:\REPO\Dinotty\src`)
+
+      expect(result?.id).toBe('child')
     })
   })
 

--- a/frontend/src/composables/useOverviewCallbacks.ts
+++ b/frontend/src/composables/useOverviewCallbacks.ts
@@ -119,11 +119,15 @@ export function useOverviewCallbacks(opts: OverviewCallbacksOptions): OverviewCa
         && workspaceId !== activeWorkspaceId.value
         && !(await activateWorkspace(workspaceId))
       ) return
-      const result = await apiCreateSshTab(connectionId, initialCwd)
+      const result = await apiCreateSshTab(connectionId, initialCwd, workspaceId)
+      const resolvedWorkspaceId = result.workspace_id ?? workspaceId
       const existing = tabs.value.find(
         (t) => t.type === 'terminal' && t.paneId === result.tab_id,
       )
       if (existing) {
+        if (existing.type === 'terminal' && resolvedWorkspaceId) {
+          existing.workspaceId = resolvedWorkspaceId
+        }
         commitLocalActivePane(result.tab_id)
         persist()
         nextTick(() => focusActive())
@@ -143,6 +147,7 @@ export function useOverviewCallbacks(opts: OverviewCallbacksOptions): OverviewCa
         previewUrl: '',
         previewKind: 'web',
         connectionId,
+        workspaceId: resolvedWorkspaceId,
       } as TerminalTab)
       commitLocalActivePane(result.tab_id)
       persist()

--- a/frontend/src/composables/useOverviewCallbacks.ts
+++ b/frontend/src/composables/useOverviewCallbacks.ts
@@ -15,6 +15,7 @@ export interface OverviewCallbacksOptions {
     renameTab: (tabId: string, title: string) => void
   }
   activateTab: (paneId: string) => Promise<boolean> | boolean
+  activateWorkspace: (workspaceId: string | null) => Promise<boolean>
   closeTab: (paneId: string) => Promise<void>
   requestCloseTab: (paneId: string) => Promise<void> | void
   newTab: (cwd?: string, argv?: string[], title?: string, workspaceId?: string | null) => Promise<string | void>
@@ -32,16 +33,22 @@ export interface OverviewCallbacks {
   onOverviewCloseTab: (tabId: string) => void
   onCloseTabsBulk: (paneIds: string[]) => Promise<void>
   onOverviewNewTab: (cwd?: string, workspaceId?: string | null) => Promise<void>
-  onOverviewNewTabSsh: (connectionId: string, initialCwd?: string) => Promise<void>
+  onOverviewNewTabSsh: (
+    connectionId: string,
+    initialCwd?: string,
+    workspaceId?: string
+  ) => Promise<void>
   onOverviewRenameTab: (paneId: string, title: string) => void
 }
 
 export function useOverviewCallbacks(opts: OverviewCallbacksOptions): OverviewCallbacks {
   const {
     tabs,
+    activeWorkspaceId,
     termRefs,
     session,
     activateTab,
+    activateWorkspace,
     closeTab,
     requestCloseTab,
     newTab,
@@ -89,12 +96,29 @@ export function useOverviewCallbacks(opts: OverviewCallbacksOptions): OverviewCa
 
   async function onOverviewNewTab(cwd?: string, workspaceId?: string | null): Promise<void> {
     closeOverview()
+    if (workspaceId !== undefined && workspaceId !== activeWorkspaceId.value) {
+      try {
+        if (!(await activateWorkspace(workspaceId))) return
+      } catch (e) {
+        console.error('Failed to activate workspace:', e)
+        return
+      }
+    }
     await newTab(cwd, undefined, undefined, workspaceId)
   }
 
-  async function onOverviewNewTabSsh(connectionId: string, initialCwd?: string): Promise<void> {
+  async function onOverviewNewTabSsh(
+    connectionId: string,
+    initialCwd?: string,
+    workspaceId?: string
+  ): Promise<void> {
     closeOverview()
     try {
+      if (
+        workspaceId !== undefined
+        && workspaceId !== activeWorkspaceId.value
+        && !(await activateWorkspace(workspaceId))
+      ) return
       const result = await apiCreateSshTab(connectionId, initialCwd)
       const existing = tabs.value.find(
         (t) => t.type === 'terminal' && t.paneId === result.tab_id,

--- a/frontend/src/composables/useSshConnectFlow.ts
+++ b/frontend/src/composables/useSshConnectFlow.ts
@@ -7,6 +7,7 @@ export interface SshConnectResult {
   pane_id: string
   layout: any
   connection_id?: string
+  workspace_id?: string
 }
 
 export interface SshConnectFlowOptions {
@@ -52,6 +53,7 @@ export function useSshConnectFlow(opts: SshConnectFlowOptions): SshConnectFlowSt
   async function onSshConnect(result: SshConnectResult) {
     const resolvedConnectionId = result.connection_id
       ?? workspaces.value.find((w) => w.id === activeWorkspaceId.value)?.connection_id
+    const resolvedWorkspaceId = result.workspace_id ?? activeWorkspaceId.value ?? undefined
 
     const existing = tabs.value.find((t) => t.paneId === result.tab_id)
     if (existing) {
@@ -59,8 +61,8 @@ export function useSshConnectFlow(opts: SshConnectFlowOptions): SshConnectFlowSt
         if (resolvedConnectionId && !existing.connectionId) {
           existing.connectionId = resolvedConnectionId
         }
-        if (!existing.workspaceId && activeWorkspaceId.value) {
-          existing.workspaceId = activeWorkspaceId.value
+        if (resolvedWorkspaceId) {
+          existing.workspaceId = resolvedWorkspaceId
         }
       }
       commitLocalActivePane(result.tab_id)
@@ -82,7 +84,7 @@ export function useSshConnectFlow(opts: SshConnectFlowOptions): SshConnectFlowSt
       previewUrl: '',
       previewKind: 'web',
       connectionId: resolvedConnectionId,
-      workspaceId: activeWorkspaceId.value ?? undefined,
+      workspaceId: resolvedWorkspaceId,
     })
     commitLocalActivePane(result.tab_id)
     persist()

--- a/frontend/src/composables/useSyncWebSocket.ts
+++ b/frontend/src/composables/useSyncWebSocket.ts
@@ -227,6 +227,13 @@ export function useSyncWebSocket(opts: {
         }
 
         for (const tab of msg.tabs) {
+          const existingTab = tabs.value.find((candidate) => {
+            if (candidate.type !== 'terminal') return false
+            return candidate.paneId === tab.tab_id || !!findLeaf(candidate.layout, tab.pane_id)
+          }) as TerminalTab | undefined
+          if (existingTab && tab.workspace_id) {
+            existingTab.workspaceId = tab.workspace_id
+          }
           if (
             !localLeafIds.has(tab.pane_id) &&
             !localTabIds.has(tab.pane_id) &&
@@ -278,7 +285,8 @@ export function useSyncWebSocket(opts: {
               customTitle: migrated?.customTitle,
               cwd: tab.cwd,
               connectionId: tab.connection_id,
-              workspaceId: migrated?.workspaceId ?? workspaceIdFromPaneId(tab.tab_id),
+              workspaceId:
+                tab.workspace_id ?? migrated?.workspaceId ?? workspaceIdFromPaneId(tab.tab_id),
             })
           }
         }
@@ -377,11 +385,21 @@ export function useSyncWebSocket(opts: {
           if (msg.connection_id && existing.type === 'terminal' && !existing.connectionId) {
             existing.connectionId = msg.connection_id
           }
+          let workspaceRepaired = false
+          if (
+            msg.workspace_id
+            && existing.type === 'terminal'
+            && existing.workspaceId !== msg.workspace_id
+          ) {
+            existing.workspaceId = msg.workspace_id
+            workspaceRepaired = true
+          }
           const decodedWorkspaceId = workspaceIdFromPaneId(msg.tab_id)
           if (existing.type === 'terminal' && !existing.workspaceId && decodedWorkspaceId) {
             existing.workspaceId = decodedWorkspaceId
-            persist()
+            workspaceRepaired = true
           }
+          if (workspaceRepaired) persist()
         }
         if (!existing) {
           const layout = msg.layout
@@ -407,7 +425,7 @@ export function useSyncWebSocket(opts: {
             previewKind: 'web',
             cwd: msg.cwd,
             connectionId: msg.connection_id,
-            workspaceId: workspaceIdFromPaneId(msg.tab_id),
+            workspaceId: msg.workspace_id ?? workspaceIdFromPaneId(msg.tab_id),
           })
           markRecentlyCreated(msg.tab_id)
           activePaneId.value = msg.tab_id

--- a/frontend/src/composables/useTabApi.ts
+++ b/frontend/src/composables/useTabApi.ts
@@ -6,6 +6,7 @@ export interface CreateTabResult {
   layout: any
   cwd?: string
   connection_id?: string
+  workspace_id?: string
 }
 
 export interface SplitPaneResult {
@@ -21,7 +22,15 @@ export interface ClosePaneResult {
 }
 
 export interface ListTabsResult {
-  tabs: Array<{ tab_id: string; pane_id: string; layout?: any; active_pane_id?: string; cwd?: string; connection_id?: string }>
+  tabs: Array<{
+    tab_id: string
+    pane_id: string
+    layout?: any
+    active_pane_id?: string
+    cwd?: string
+    connection_id?: string
+    workspace_id?: string
+  }>
   active_pane_id: string | null
 }
 
@@ -250,6 +259,8 @@ export interface SshConnectRequest {
 
 export interface SshProfileConnectRequest {
   profile_id: string
+  initial_cwd?: string
+  workspace_id?: string
 }
 
 export async function apiCreateSshQuickTab(req: SshConnectRequest, signal?: AbortSignal): Promise<CreateTabResult> {
@@ -269,12 +280,17 @@ export async function apiCreateSshQuickTab(req: SshConnectRequest, signal?: Abor
 export async function apiCreateSshTab(
   profileId: string,
   initialCwd?: string,
+  workspaceId?: string,
   signal?: AbortSignal
 ): Promise<CreateTabResult> {
   const res = await authFetch(apiUrl('/api/tabs/ssh'), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ profile_id: profileId, initial_cwd: initialCwd }),
+    body: JSON.stringify({
+      profile_id: profileId,
+      initial_cwd: initialCwd,
+      workspace_id: workspaceId,
+    }),
     signal,
   })
   if (!res.ok) {

--- a/frontend/src/composables/useTabLifecycle.ts
+++ b/frontend/src/composables/useTabLifecycle.ts
@@ -105,7 +105,7 @@ export function useTabLifecycle(opts: TabLifecycleOptions): TabLifecycleState {
         ? workspaces.value.find((w) => w.id === activeWorkspaceId.value)
         : null
       if (!argv && useActiveFallback && activeWs?.connection_id) {
-        const result = await apiCreateSshTab(activeWs.connection_id, activeWs.path)
+        const result = await apiCreateSshTab(activeWs.connection_id, activeWs.path, activeWs.id)
         await onSshConnectRef.value(result)
         return result.pane_id
       }

--- a/frontend/src/composables/useWorkspaces.ts
+++ b/frontend/src/composables/useWorkspaces.ts
@@ -180,8 +180,11 @@ export function useWorkspaces() {
     const ws = workspaces.value.find((w) => w.id === workspaceId)
     if (!ws) return []
     if (ws.connection_id) {
-      // Remote workspace: match by connection_id on the tab
-      return tabs.filter((tab) => tab.connectionId === ws.connection_id)
+      // Explicit attribution disambiguates workspaces that share one SSH profile.
+      // Keep the connection fallback for tabs created by older servers/clients.
+      return tabs.filter((tab) =>
+        tab.workspaceId ? tab.workspaceId === workspaceId : tab.connectionId === ws.connection_id
+      )
     }
     // Local workspace: match by path prefix
     return tabs.filter((tab) => {

--- a/frontend/src/composables/useWorkspaces.ts
+++ b/frontend/src/composables/useWorkspaces.ts
@@ -15,6 +15,41 @@ import { useI18n } from './useI18n'
 
 export const DEFAULT_WORKSPACE_ID = '__default__'
 
+function isWindowsPath(path: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(path) || /^(?:\\\\|\/\/)/.test(path)
+}
+
+function normalizeWindowsPath(path: string): string {
+  return path
+    .replace(/[\\/]+/g, '/')
+    .replace(/\/+$/, '')
+    .replace(/[A-Z]/g, (char) => char.toLowerCase())
+}
+
+export function isPathWithinWorkspace(cwd: string, workspacePath: string): boolean {
+  if (!cwd || !workspacePath) return false
+
+  const windowsPath = isWindowsPath(cwd) || isWindowsPath(workspacePath)
+  const normalizedCwd = windowsPath ? normalizeWindowsPath(cwd) : cwd.replace(/\/+$/, '')
+  const normalizedWorkspace = windowsPath
+    ? normalizeWindowsPath(workspacePath)
+    : workspacePath.replace(/\/+$/, '')
+
+  return (
+    normalizedCwd === normalizedWorkspace ||
+    (normalizedCwd.startsWith(normalizedWorkspace) &&
+      normalizedCwd[normalizedWorkspace.length] === '/')
+  )
+}
+
+export function workspaceBasename(path: string): string {
+  const trimmed = path.trim().replace(/[\\/]+$/, '')
+  if (!trimmed) return ''
+  const parts = trimmed.split(/[\\/]/).filter(Boolean)
+  const basename = parts[parts.length - 1] ?? ''
+  return /^[A-Za-z]:$/.test(basename) ? '' : basename
+}
+
 const workspaces = ref<Workspace[]>([])
 const activeWorkspaceId = ref<string | null>(null)
 const { t } = useI18n()
@@ -128,7 +163,7 @@ export function useWorkspaces() {
     for (const ws of candidates) {
       if (ws.connection_id) continue // skip remote workspaces for path matching
       if (!ws.path) continue
-      if (cwd === ws.path || (cwd.startsWith(ws.path) && cwd[ws.path.length] === '/')) {
+      if (isPathWithinWorkspace(cwd, ws.path)) {
         if (ws.path.length > bestLen) {
           best = ws
           bestLen = ws.path.length

--- a/frontend/src/test/useOverviewCallbacksWorkspace.test.ts
+++ b/frontend/src/test/useOverviewCallbacksWorkspace.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { useOverviewCallbacks } from '../composables/useOverviewCallbacks'
+import type { Tab } from '../types/pane'
+
+const mocks = vi.hoisted(() => ({
+  apiCreateSshTab: vi.fn(),
+}))
+
+vi.mock('../composables/useTabApi', () => ({
+  apiCreateSshTab: mocks.apiCreateSshTab,
+}))
+
+function createOptions() {
+  const activeWorkspaceId = ref<string | null>('workspace-current')
+  const tabs = ref<Tab[]>([])
+  const activateWorkspace = vi.fn(async (workspaceId: string | null) => {
+    activeWorkspaceId.value = workspaceId
+    return true
+  })
+  const newTab = vi.fn(async () => '')
+
+  return {
+    activeWorkspaceId,
+    tabs,
+    activateWorkspace,
+    newTab,
+    options: {
+      tabs,
+      activePaneId: ref<string | null>(null),
+      activeWorkspaceId,
+      termRefs: {},
+      session: { renameTab: vi.fn() },
+      activateTab: vi.fn(async () => true),
+      activateWorkspace,
+      closeTab: vi.fn(async () => {}),
+      requestCloseTab: vi.fn(),
+      newTab,
+      persist: vi.fn(),
+      commitLocalActivePane: vi.fn(),
+      focusActive: vi.fn(),
+      sendSync: vi.fn(),
+    },
+  }
+}
+
+describe('useOverviewCallbacks workspace activation', () => {
+  beforeEach(() => {
+    mocks.apiCreateSshTab.mockReset()
+  })
+
+  it('activates a selected local workspace before creating its tab', async () => {
+    const { options, activateWorkspace, newTab } = createOptions()
+    const callbacks = useOverviewCallbacks(options)
+
+    await callbacks.onOverviewNewTab('C:/work/other', 'workspace-other')
+
+    expect(activateWorkspace).toHaveBeenCalledWith('workspace-other')
+    expect(newTab).toHaveBeenCalledWith('C:/work/other', undefined, undefined, 'workspace-other')
+    expect(activateWorkspace.mock.invocationCallOrder[0]).toBeLessThan(
+      newTab.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('activates the default workspace before creating its tab', async () => {
+    const { options, activateWorkspace, newTab } = createOptions()
+    const callbacks = useOverviewCallbacks(options)
+
+    await callbacks.onOverviewNewTab('C:/work/default', null)
+
+    expect(activateWorkspace).toHaveBeenCalledWith(null)
+    expect(newTab).toHaveBeenCalledOnce()
+  })
+
+  it('activates a selected SSH workspace before creating its tab', async () => {
+    const { options, activateWorkspace } = createOptions()
+    mocks.apiCreateSshTab.mockResolvedValue({
+      tab_id: 'tab-ssh',
+      pane_id: 'pane-ssh',
+      layout: {
+        type: 'leaf',
+        paneId: 'pane-ssh',
+        title: 'Terminal',
+        ratio: 1,
+        zoomed: false,
+      },
+    })
+    const callbacks = useOverviewCallbacks(options)
+
+    await callbacks.onOverviewNewTabSsh('connection-1', '/srv/app', 'workspace-ssh')
+
+    expect(activateWorkspace).toHaveBeenCalledWith('workspace-ssh')
+    expect(mocks.apiCreateSshTab).toHaveBeenCalledWith('connection-1', '/srv/app')
+    expect(activateWorkspace.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.apiCreateSshTab.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('does not create a tab when workspace activation is superseded', async () => {
+    const { options, activateWorkspace, newTab } = createOptions()
+    activateWorkspace.mockResolvedValue(false)
+    const callbacks = useOverviewCallbacks(options)
+
+    await callbacks.onOverviewNewTab('C:/work/other', 'workspace-other')
+    await callbacks.onOverviewNewTabSsh('connection-1', '/srv/app', 'workspace-ssh')
+
+    expect(newTab).not.toHaveBeenCalled()
+    expect(mocks.apiCreateSshTab).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/test/useOverviewCallbacksWorkspace.test.ts
+++ b/frontend/src/test/useOverviewCallbacksWorkspace.test.ts
@@ -73,7 +73,7 @@ describe('useOverviewCallbacks workspace activation', () => {
   })
 
   it('activates a selected SSH workspace before creating its tab', async () => {
-    const { options, activateWorkspace } = createOptions()
+    const { options, activateWorkspace, tabs } = createOptions()
     mocks.apiCreateSshTab.mockResolvedValue({
       tab_id: 'tab-ssh',
       pane_id: 'pane-ssh',
@@ -90,10 +90,55 @@ describe('useOverviewCallbacks workspace activation', () => {
     await callbacks.onOverviewNewTabSsh('connection-1', '/srv/app', 'workspace-ssh')
 
     expect(activateWorkspace).toHaveBeenCalledWith('workspace-ssh')
-    expect(mocks.apiCreateSshTab).toHaveBeenCalledWith('connection-1', '/srv/app')
+    expect(mocks.apiCreateSshTab).toHaveBeenCalledWith(
+      'connection-1',
+      '/srv/app',
+      'workspace-ssh'
+    )
+    expect(tabs.value).toHaveLength(1)
+    expect(tabs.value[0]).toMatchObject({
+      connectionId: 'connection-1',
+      workspaceId: 'workspace-ssh',
+    })
     expect(activateWorkspace.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.apiCreateSshTab.mock.invocationCallOrder[0]
     )
+  })
+
+  it('repairs workspace attribution when the SSH tab broadcast wins the race', async () => {
+    const { options, tabs } = createOptions()
+    tabs.value.push({
+      type: 'terminal',
+      paneId: 'tab-ssh',
+      layout: {
+        type: 'leaf',
+        paneId: 'pane-ssh',
+        title: 'Terminal',
+        ratio: 1,
+        zoomed: false,
+      },
+      activePaneId: 'pane-ssh',
+      paneMru: ['pane-ssh'],
+      broadcastMode: false,
+      broadcastActivity: 0,
+      previewVisible: false,
+      previewAddress: '',
+      previewUrl: '',
+      previewKind: 'web',
+      connectionId: 'connection-1',
+    })
+    mocks.apiCreateSshTab.mockResolvedValue({
+      tab_id: 'tab-ssh',
+      pane_id: 'pane-ssh',
+      layout: tabs.value[0].type === 'terminal' ? tabs.value[0].layout : undefined,
+      workspace_id: 'workspace-ssh',
+    })
+    const callbacks = useOverviewCallbacks(options)
+
+    await callbacks.onOverviewNewTabSsh('connection-1', '/srv/app', 'workspace-ssh')
+
+    expect(tabs.value).toHaveLength(1)
+    expect(tabs.value[0]).toMatchObject({ workspaceId: 'workspace-ssh' })
   })
 
   it('does not create a tab when workspace activation is superseded', async () => {

--- a/frontend/src/test/useSyncWebSocketPluginWorkspace.test.ts
+++ b/frontend/src/test/useSyncWebSocketPluginWorkspace.test.ts
@@ -162,6 +162,42 @@ describe('useSyncWebSocket plugin workspace attribution', () => {
     expect((session.tabs[0] as TerminalTab).workspaceId).toBe('workspace-b')
   })
 
+  it('uses the explicit SSH workspace from tab_created instead of the shared profile', async () => {
+    const { session, emit } = await setup()
+    emit({
+      type: 'tab_created',
+      tab_id: 'ssh-tab',
+      pane_id: 'ssh-pane',
+      connection_id: 'shared-profile',
+      workspace_id: 'workspace-b',
+    })
+
+    expect(session.tabs[0]).toMatchObject({
+      connectionId: 'shared-profile',
+      workspaceId: 'workspace-b',
+    })
+  })
+
+  it('restores an existing SSH tab workspace from tab_list', async () => {
+    const existing = terminal('ssh-tab')
+    existing.connectionId = 'shared-profile'
+    const { emit } = await setup([existing])
+    emit({
+      type: 'tab_list',
+      tabs: [
+        {
+          tab_id: existing.paneId,
+          pane_id: existing.activePaneId,
+          connection_id: 'shared-profile',
+          workspace_id: 'workspace-b',
+        },
+      ],
+      active_pane_id: existing.activePaneId,
+    })
+
+    expect(existing.workspaceId).toBe('workspace-b')
+  })
+
   it('scenario 6: close-time read fallback attributes a missing field to a live workspace', async () => {
     const pluginTab = terminal('plugin:session-browser:workspace-b')
     const successor = terminal('workspace-b-successor', { workspaceId: 'workspace-b' })

--- a/frontend/src/test/windowTitle.test.ts
+++ b/frontend/src/test/windowTitle.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  formatWindowTitle,
+  setTauriWindowTitle,
+  updateDocumentTitle,
+} from '../utils/windowTitle'
+
+describe('window title', () => {
+  it('updates the title when the active workspace changes', () => {
+    const target = { title: '' }
+
+    updateDocumentTitle('Default', target)
+    expect(target.title).toBe('Dinotty - Default')
+
+    updateDocumentTitle('Project Atlas', target)
+    expect(target.title).toBe('Dinotty - Project Atlas')
+  })
+
+  it('uses the application name when the workspace name is empty', () => {
+    expect(formatWindowTitle()).toBe('Dinotty')
+    expect(formatWindowTitle('   ')).toBe('Dinotty')
+  })
+
+  it('falls back to the window API when the command fails', async () => {
+    const invoke = vi.fn(async () => {
+      throw new Error('command unavailable')
+    })
+    const setTitle = vi.fn(async () => {})
+
+    await setTauriWindowTitle('Dinotty - Project Atlas', invoke, () => ({ setTitle }))
+
+    expect(invoke).toHaveBeenCalledWith('set_window_title', {
+      title: 'Dinotty - Project Atlas',
+    })
+    expect(setTitle).toHaveBeenCalledWith('Dinotty - Project Atlas')
+  })
+
+  it('absorbs synchronous fallback errors and rejected title updates', async () => {
+    const invoke = vi.fn(async () => {
+      throw new Error('command unavailable')
+    })
+
+    await expect(
+      setTauriWindowTitle('Dinotty', invoke, () => {
+        throw new Error('window API unavailable')
+      })
+    ).resolves.toBeUndefined()
+
+    await expect(
+      setTauriWindowTitle('Dinotty', invoke, () => ({
+        setTitle: () => Promise.reject(new Error('title update failed')),
+      }))
+    ).resolves.toBeUndefined()
+  })
+})

--- a/frontend/src/test/windowTitle.test.ts
+++ b/frontend/src/test/windowTitle.test.ts
@@ -10,10 +10,10 @@ describe('window title', () => {
     const target = { title: '' }
 
     updateDocumentTitle('Default', target)
-    expect(target.title).toBe('Dinotty - Default')
+    expect(target.title).toBe('Default')
 
     updateDocumentTitle('Project Atlas', target)
-    expect(target.title).toBe('Dinotty - Project Atlas')
+    expect(target.title).toBe('Project Atlas')
   })
 
   it('uses the application name when the workspace name is empty', () => {
@@ -27,12 +27,12 @@ describe('window title', () => {
     })
     const setTitle = vi.fn(async () => {})
 
-    await setTauriWindowTitle('Dinotty - Project Atlas', invoke, () => ({ setTitle }))
+    await setTauriWindowTitle('Project Atlas', invoke, () => ({ setTitle }))
 
     expect(invoke).toHaveBeenCalledWith('set_window_title', {
-      title: 'Dinotty - Project Atlas',
+      title: 'Project Atlas',
     })
-    expect(setTitle).toHaveBeenCalledWith('Dinotty - Project Atlas')
+    expect(setTitle).toHaveBeenCalledWith('Project Atlas')
   })
 
   it('absorbs synchronous fallback errors and rejected title updates', async () => {

--- a/frontend/src/types/protocol.ts
+++ b/frontend/src/types/protocol.ts
@@ -102,6 +102,7 @@ export interface SyncTabList {
     active_pane_id?: string
     cwd?: string
     connection_id?: string
+    workspace_id?: string
     title?: string
   }[]
   active_pane_id: string | null
@@ -114,6 +115,7 @@ export interface SyncTabCreated {
   layout?: any
   cwd?: string
   connection_id?: string
+  workspace_id?: string
 }
 
 export interface SyncTabClosed {

--- a/frontend/src/types/template.ts
+++ b/frontend/src/types/template.ts
@@ -63,4 +63,5 @@ export interface ApplyTemplateResult {
   warnings: string[]
   cwd?: string
   connection_id?: string
+  workspace_id?: string
 }

--- a/frontend/src/utils/windowTitle.ts
+++ b/frontend/src/utils/windowTitle.ts
@@ -1,0 +1,34 @@
+type TitleTarget = { title: string }
+
+interface TauriWindow {
+  setTitle?: (title: string) => void | Promise<void>
+}
+
+export function formatWindowTitle(workspaceName?: string): string {
+  const name = workspaceName?.trim()
+  return name ? `Dinotty - ${name}` : 'Dinotty'
+}
+
+export function updateDocumentTitle(
+  workspaceName?: string,
+  target: TitleTarget = document
+): string {
+  const title = formatWindowTitle(workspaceName)
+  target.title = title
+  return title
+}
+
+export async function setTauriWindowTitle(
+  title: string,
+  invoke: (command: string, args: Record<string, unknown>) => Promise<unknown>,
+  getCurrentWindow: () => TauriWindow | undefined
+): Promise<void> {
+  try {
+    await invoke('set_window_title', { title })
+    return
+  } catch {}
+
+  try {
+    await getCurrentWindow()?.setTitle?.(title)
+  } catch {}
+}

--- a/frontend/src/utils/windowTitle.ts
+++ b/frontend/src/utils/windowTitle.ts
@@ -5,8 +5,7 @@ interface TauriWindow {
 }
 
 export function formatWindowTitle(workspaceName?: string): string {
-  const name = workspaceName?.trim()
-  return name ? `Dinotty - ${name}` : 'Dinotty'
+  return workspaceName?.trim() || 'Dinotty'
 }
 
 export function updateDocumentTitle(

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -471,7 +471,10 @@ async fn pick_workspace_dir(base: Option<String>) -> Option<String> {
     if let Some(dir) = resolved {
         dialog = dialog.set_directory(dir);
     }
-    dialog.pick_folder().await.map(|folder| folder.path().to_string_lossy().into_owned())
+    dialog
+        .pick_folder()
+        .await
+        .map(|folder| dunce::simplified(folder.path()).to_string_lossy().into_owned())
 }
 
 #[tauri::command]

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -7,7 +7,7 @@ use crate::session::{
 use crate::vt_screen::VirtualScreen;
 use portable_pty::{Child, CommandBuilder, NativePtySystem, PtySize, PtySystem};
 use std::io::{Read, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing::{error, info, warn};
 
@@ -268,7 +268,7 @@ pub fn create_session(
 
     let home_path = shell::home_dir();
 
-    let effective_cwd = cwd.filter(|p| p.is_dir()).unwrap_or_else(|| home_path.clone());
+    let effective_cwd = resolve_local_cwd(cwd, &home_path);
     cmd.cwd(&effective_cwd);
 
     // Shell-specific hooks depend on HOME-style prompt expansion.
@@ -296,8 +296,6 @@ pub fn create_session(
         }
     }
 
-    let home_for_cwd = effective_cwd;
-
     let child = pair.slave.spawn_command(cmd).map_err(|e| format!("spawn shell: {e}"))?;
     let mut pending_spawn = PendingSpawn::new(child, pane_id);
     drop(pair.slave);
@@ -315,13 +313,7 @@ pub fn create_session(
     let reader = pair.master.try_clone_reader().map_err(|e| e.to_string())?;
     let writer: Box<dyn Write + Send> = pair.master.take_writer().map_err(|e| e.to_string())?;
 
-    // Strip the \\?\ verbatim prefix that std::canonicalize adds on Windows.
-    // PowerShell renders verbatim paths as `Microsoft.PowerShell.Core\FileSystem::\\?\D:\...`
-    // which breaks tools that parse $PWD (e.g. pi agent). dunce::simplified is a
-    // no-op on non-Windows.
-    let initial_cwd =
-        dunce::simplified(&home_for_cwd.canonicalize().unwrap_or_else(|_| home_for_cwd.clone()))
-            .to_path_buf();
+    let initial_cwd = effective_cwd;
     let (resize_tx, resize_rx) = tokio::sync::watch::channel(None);
     let (output_tx, output_rx) = tokio::sync::mpsc::unbounded_channel();
     let registered_child = pending_spawn.take_child()?;
@@ -576,6 +568,12 @@ pub fn create_session(
     Ok((session, shell_type))
 }
 
+fn resolve_local_cwd(cwd: Option<PathBuf>, home: &Path) -> PathBuf {
+    let selected = cwd.filter(|path| path.is_dir()).unwrap_or_else(|| home.to_path_buf());
+    let canonical = dunce::canonicalize(&selected).unwrap_or(selected);
+    dunce::simplified(&canonical).to_path_buf()
+}
+
 #[must_use]
 pub fn setup_zsh_title_hooks(home: &str) -> Option<std::path::PathBuf> {
     let zdotdir = std::env::temp_dir().join(format!("dinotty_zsh_{}", std::process::id()));
@@ -729,7 +727,10 @@ pub fn get_shell_args(shell: &str) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_claude_session_env_key, locale_adjustment, notify_url_for, LocaleAdjustment};
+    use super::{
+        is_claude_session_env_key, locale_adjustment, notify_url_for, resolve_local_cwd,
+        LocaleAdjustment,
+    };
 
     #[test]
     fn builds_notify_url_for_bound_port() {
@@ -765,6 +766,18 @@ mod tests {
         ] {
             assert!(!is_claude_session_env_key(k), "should preserve {k}");
         }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn local_cwd_is_simplified_before_pty_spawn() {
+        let temp = std::env::temp_dir();
+        let verbatim = std::path::PathBuf::from(format!(r"\\?\{}", temp.display()));
+
+        let effective = resolve_local_cwd(Some(verbatim), &temp);
+
+        assert!(!effective.to_string_lossy().starts_with(r"\\?\"));
+        assert_eq!(effective, dunce::canonicalize(temp).unwrap());
     }
 
     #[test]

--- a/src/session/backend.rs
+++ b/src/session/backend.rs
@@ -11,6 +11,8 @@ pub struct SshSessionParams {
     pub default_command: Option<String>,
     /// The `SshProfile.id` when created from a saved profile. `None` for quick-connect.
     pub profile_id: Option<String>,
+    /// The workspace that initiated this SSH session, when explicitly selected.
+    pub workspace_id: Option<String>,
     /// Initial remote directory to `cd` into after the shell starts.
     /// When `None` or empty, the shell starts in the remote `$HOME`.
     pub initial_cwd: Option<String>,

--- a/src/session/cwd.rs
+++ b/src/session/cwd.rs
@@ -15,6 +15,7 @@ pub(crate) fn sniff_cwd_from_title_osc(
     chunk: &[u8],
     home: &Path,
     cwd: &mut PathBuf,
+    canonicalize_local: bool,
 ) {
     buf.extend_from_slice(chunk);
     if buf.len() > OSC_SNIFF_CAP {
@@ -36,10 +37,7 @@ pub(crate) fn sniff_cwd_from_title_osc(
         let title_end = payload_start + rel;
         let title = String::from_utf8_lossy(&buf[payload_start..title_end]);
         if let Some(p) = parse_title_cwd(&title, home) {
-            // canonicalize resolves symlinks on the local filesystem. For SSH
-            // sessions the path is remote and canonicalize fails - fall back
-            // to the raw path so cwd tracking still works.
-            *cwd = p.canonicalize().unwrap_or(p);
+            *cwd = if canonicalize_local { dunce::canonicalize(&p).unwrap_or(p) } else { p };
         }
         buf.drain(..title_end + terminator_len);
     }

--- a/src/session/manager.rs
+++ b/src/session/manager.rs
@@ -76,6 +76,8 @@ pub enum SyncMsg {
         cwd: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         connection_id: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        workspace_id: Option<String>,
     },
     TabClosed {
         pane_id: String,
@@ -241,6 +243,9 @@ pub struct TabInfo {
     /// The `SshProfile.id` if this tab is an SSH session created from a profile.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub connection_id: Option<String>,
+    /// Explicit workspace assignment for tabs that cannot be identified by CWD.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspace_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
 }
@@ -462,6 +467,7 @@ impl SessionManager {
             layout: Some(layout),
             cwd: None,
             connection_id: None,
+            workspace_id: None,
         });
         if self.is_current_session(pane_id, session) {
             true
@@ -843,8 +849,21 @@ impl SessionManager {
                     .sessions
                     .get(&pane_id)
                     .and_then(|s| s.ssh_params.as_ref().and_then(|p| p.profile_id.clone()));
+                let workspace_id = self
+                    .sessions
+                    .get(&pane_id)
+                    .and_then(|s| s.ssh_params.as_ref().and_then(|p| p.workspace_id.clone()));
                 let title = v.get("title").and_then(|v| v.as_str()).map(String::from);
-                TabInfo { tab_id, pane_id, layout, active_pane_id, cwd, connection_id, title }
+                TabInfo {
+                    tab_id,
+                    pane_id,
+                    layout,
+                    active_pane_id,
+                    cwd,
+                    connection_id,
+                    workspace_id,
+                    title,
+                }
             })
             .collect();
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -582,7 +582,7 @@ impl Session {
         let home = remote_home_guard.as_ref().unwrap_or(&default_home);
         let mut state = self.cwd_state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         let CwdState { ref mut cwd, ref mut sniff_buf } = *state;
-        cwd::sniff_cwd_from_title_osc(sniff_buf, data, home, cwd);
+        cwd::sniff_cwd_from_title_osc(sniff_buf, data, home, cwd, self.ssh_params.is_none());
     }
 
     /// Replace the input channel, closing the old one (if any) so the previous

--- a/src/session/tests.rs
+++ b/src/session/tests.rs
@@ -977,6 +977,31 @@ fn tab_list_returns_empty_for_no_tabs() {
     assert!(active.is_none());
 }
 
+#[test]
+fn tab_list_restores_ssh_workspace_assignment_from_session() {
+    let manager = SessionManager::new();
+    let mut session = local_session_for_write_input();
+    Arc::get_mut(&mut session).unwrap().ssh_params = Some(SshSessionParams {
+        host: "example.test".into(),
+        port: 22,
+        username: "user".into(),
+        auth_method: crate::settings::SshAuthMethod::default(),
+        default_command: None,
+        profile_id: Some("shared-profile".into()),
+        workspace_id: Some("workspace-b".into()),
+        initial_cwd: Some("/srv/b".into()),
+    });
+    manager.sessions.insert("p1".into(), session);
+    manager
+        .insert_tab("t1".into(), serde_json::json!({"layout": leaf("p1"), "active_pane_id": "p1"}));
+
+    let (tabs, _) = manager.tab_list();
+
+    assert_eq!(tabs.len(), 1);
+    assert_eq!(tabs[0].connection_id.as_deref(), Some("shared-profile"));
+    assert_eq!(tabs[0].workspace_id.as_deref(), Some("workspace-b"));
+}
+
 // ── CWD state tracking ─────────────────────────────────────────────
 
 #[test]
@@ -1013,6 +1038,22 @@ fn sniff_cwd_falls_back_to_raw_path_when_canonicalize_fails() {
         true,
     );
     assert_eq!(cwd, PathBuf::from("/nonexistent_path_12345"));
+}
+
+#[test]
+fn tab_created_serializes_explicit_workspace_assignment() {
+    let msg = SyncMsg::TabCreated {
+        tab_id: "tab-1".into(),
+        pane_id: "pane-1".into(),
+        layout: None,
+        cwd: None,
+        connection_id: Some("shared-profile".into()),
+        workspace_id: Some("workspace-b".into()),
+    };
+
+    let value = serde_json::to_value(msg).unwrap();
+
+    assert_eq!(value["workspace_id"], "workspace-b");
 }
 
 #[test]

--- a/src/session/tests.rs
+++ b/src/session/tests.rs
@@ -257,8 +257,8 @@ fn parse_title_cwd_windows_drive_path() {
 
 #[test]
 fn sniff_cwd_extracts_from_bel_terminated_osc() {
-    // Use a real directory and canonicalize the expected path, because
-    // parse_title_cwd calls canonicalize() which resolves symlinks
+    // Use a real directory and canonicalize the expected local path, because
+    // CWD sniffing resolves symlinks
     // (e.g. /tmp -> /private/tmp on macOS).
     let home = PathBuf::from("/home/user");
     let mut cwd = PathBuf::from("/home/user");
@@ -267,8 +267,8 @@ fn sniff_cwd_extracts_from_bel_terminated_osc() {
     let tmp = std::env::temp_dir();
     let tmp_str = tmp.to_string_lossy();
     let data = format!("\x1b]0;user@host:{}\x07", tmp_str);
-    sniff_cwd_from_title_osc(&mut buf, data.as_bytes(), &home, &mut cwd);
-    assert_eq!(cwd, tmp.canonicalize().unwrap_or(tmp));
+    sniff_cwd_from_title_osc(&mut buf, data.as_bytes(), &home, &mut cwd, true);
+    assert_eq!(cwd, dunce::canonicalize(&tmp).unwrap_or(tmp));
 }
 
 #[test]
@@ -279,8 +279,8 @@ fn sniff_cwd_extracts_from_st_terminated_osc() {
     let tmp = std::env::temp_dir();
     let tmp_str = tmp.to_string_lossy();
     let data = format!("\x1b]0;user@host:{}\x1b\\", tmp_str);
-    sniff_cwd_from_title_osc(&mut buf, data.as_bytes(), &home, &mut cwd);
-    assert_eq!(cwd, tmp.canonicalize().unwrap_or(tmp));
+    sniff_cwd_from_title_osc(&mut buf, data.as_bytes(), &home, &mut cwd, true);
+    assert_eq!(cwd, dunce::canonicalize(&tmp).unwrap_or(tmp));
 }
 
 #[test]
@@ -290,11 +290,11 @@ fn sniff_cwd_handles_chunked_input() {
     let mut buf = Vec::new();
     let target = std::env::temp_dir();
     let target_str = target.to_string_lossy();
-    sniff_cwd_from_title_osc(&mut buf, b"\x1b]0;user", &home, &mut cwd);
+    sniff_cwd_from_title_osc(&mut buf, b"\x1b]0;user", &home, &mut cwd, true);
     assert_eq!(cwd, PathBuf::from("/home/user")); // not yet
     let chunk = format!("@host:{target_str}\x07");
-    sniff_cwd_from_title_osc(&mut buf, chunk.as_bytes(), &home, &mut cwd);
-    assert_eq!(cwd, target.canonicalize().unwrap_or(target));
+    sniff_cwd_from_title_osc(&mut buf, chunk.as_bytes(), &home, &mut cwd, true);
+    assert_eq!(cwd, dunce::canonicalize(&target).unwrap_or(target));
 }
 
 #[test]
@@ -304,7 +304,7 @@ fn sniff_cwd_buffers_beyond_cap() {
     let mut buf = Vec::new();
     // Fill buffer with garbage beyond the cap
     let big_data = vec![b'x'; OSC_SNIFF_CAP + 1000];
-    sniff_cwd_from_title_osc(&mut buf, &big_data, &home, &mut cwd);
+    sniff_cwd_from_title_osc(&mut buf, &big_data, &home, &mut cwd, true);
     assert!(buf.len() <= OSC_SNIFF_CAP);
 }
 
@@ -319,9 +319,9 @@ fn sniff_cwd_accepts_powershell_title_with_windows_path() {
     let mut buf = Vec::new();
     let data = format!("\x1b]0;user@host:{}\x07", target.display());
 
-    sniff_cwd_from_title_osc(&mut buf, data.as_bytes(), &home, &mut cwd);
+    sniff_cwd_from_title_osc(&mut buf, data.as_bytes(), &home, &mut cwd, true);
 
-    assert_eq!(cwd, target.canonicalize().unwrap());
+    assert_eq!(cwd, dunce::canonicalize(target).unwrap());
 }
 
 #[cfg(windows)]
@@ -334,16 +334,17 @@ fn sniff_cwd_buffers_chunked_powershell_title_with_windows_path() {
     let mut cwd = home.clone();
     let mut buf = Vec::new();
 
-    sniff_cwd_from_title_osc(&mut buf, b"\x1b]0;user@host:", &home, &mut cwd);
+    sniff_cwd_from_title_osc(&mut buf, b"\x1b]0;user@host:", &home, &mut cwd, true);
     assert_eq!(cwd, home);
     sniff_cwd_from_title_osc(
         &mut buf,
         format!("{}\x07", target.display()).as_bytes(),
         &home,
         &mut cwd,
+        true,
     );
 
-    assert_eq!(cwd, target.canonicalize().unwrap());
+    assert_eq!(cwd, dunce::canonicalize(target).unwrap());
 }
 
 #[cfg(windows)]
@@ -358,7 +359,7 @@ fn sniff_cwd_falls_back_to_raw_windows_path_when_missing() {
     let mut buf = Vec::new();
     let data = format!("\x1b]0;user@host:{}\x07", missing.display());
 
-    sniff_cwd_from_title_osc(&mut buf, data.as_bytes(), &home, &mut cwd);
+    sniff_cwd_from_title_osc(&mut buf, data.as_bytes(), &home, &mut cwd, true);
 
     assert_eq!(cwd, missing);
 }
@@ -994,8 +995,8 @@ fn sniff_cwd_updates_cwd_state() {
     let target_str = target.to_string_lossy();
     // OSC 0: \x1b]0;user@host:path\x07
     let data = format!("\x1b]0;user@host:{target_str}\x07");
-    sniff_cwd_from_title_osc(&mut buf, data.as_bytes(), &home, &mut cwd);
-    assert_eq!(cwd, target.canonicalize().unwrap_or(target));
+    sniff_cwd_from_title_osc(&mut buf, data.as_bytes(), &home, &mut cwd, true);
+    assert_eq!(cwd, dunce::canonicalize(&target).unwrap_or(target));
 }
 
 #[test]
@@ -1003,12 +1004,29 @@ fn sniff_cwd_falls_back_to_raw_path_when_canonicalize_fails() {
     let home = PathBuf::from("/");
     let mut cwd = home.clone();
     let mut buf = Vec::new();
-    // Path does not exist — canonicalize() fails; the raw path is used as fallback so SSH remote cwd tracking still works (a89eb0a4)
+    // Path does not exist, so local canonicalization falls back to the parsed path.
     sniff_cwd_from_title_osc(
         &mut buf,
         b"\x1b]0;user@host:/nonexistent_path_12345\x07",
         &home,
         &mut cwd,
+        true,
     );
     assert_eq!(cwd, PathBuf::from("/nonexistent_path_12345"));
+}
+
+#[test]
+fn sniff_remote_cwd_does_not_canonicalize_against_host_filesystem() {
+    let temp = tempfile::tempdir().unwrap();
+    let nested = temp.path().join("nested");
+    std::fs::create_dir(&nested).unwrap();
+    let remote_path = nested.join("..");
+    let home = PathBuf::from("/remote/home");
+    let mut cwd = home.clone();
+    let mut buf = Vec::new();
+    let data = format!("\x1b]0;user@host:{}\x07", remote_path.display());
+
+    sniff_cwd_from_title_osc(&mut buf, data.as_bytes(), &home, &mut cwd, false);
+
+    assert_eq!(cwd, remote_path);
 }

--- a/src/ssh/mod.rs
+++ b/src/ssh/mod.rs
@@ -799,6 +799,7 @@ impl SshConnectRequest {
             auth_method: self.auth.clone(),
             default_command: self.default_command.clone(),
             profile_id: self.profile_id.clone(),
+            workspace_id: None,
             initial_cwd: self.initial_cwd.clone(),
         }
     }
@@ -808,6 +809,10 @@ impl SshConnectRequest {
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct SshProfileConnectRequest {
     pub profile_id: String,
+    /// Workspace selected by the caller. This disambiguates workspaces that
+    /// share one SSH profile but use different remote roots.
+    #[serde(default)]
+    pub workspace_id: Option<String>,
     /// Optional initial remote directory. When set, the shell runs `cd` to this
     /// path after startup. Ignored if the profile has a `default_command`.
     #[serde(default)]

--- a/src/tabs/handlers.rs
+++ b/src/tabs/handlers.rs
@@ -146,6 +146,7 @@ pub async fn create_tab(
             layout: Some(layout.clone()),
             cwd: cwd_str.clone(),
             connection_id: None,
+            workspace_id: None,
         });
         if manager.is_current_session(&pane_id, &session) {
             true
@@ -515,6 +516,7 @@ pub async fn create_plugin_tab(
         layout: Some(layout.clone()),
         cwd: None,
         connection_id: None,
+        workspace_id: None,
     });
 
     Json(serde_json::json!({
@@ -898,6 +900,7 @@ pub async fn extract_pane(
         layout: Some(new_layout.clone()),
         cwd: None,
         connection_id: None,
+        workspace_id: None,
     });
 
     Json(serde_json::json!({

--- a/src/tabs/handlers.rs
+++ b/src/tabs/handlers.rs
@@ -86,12 +86,6 @@ pub async fn create_tab(
         let shell_spec = crate::platform::shell::shell_with_preference(&s.shell, &s.shell_path);
         (cwd, shell_spec)
     };
-    // String form of the resolved cwd, used for the TabCreated broadcast and
-    // the HTTP response. We must return the *resolved* cwd (not `req.cwd`)
-    // so the frontend can match the tab to the correct workspace - when the
-    // caller omits cwd, `req.cwd` is None but the PTY actually runs in
-    // `resolved_default_workspace_root()`.
-    let cwd_str = cwd.as_deref().and_then(|p| p.to_str()).map(std::string::ToString::to_string);
     let is_argv_command = req.argv.is_some();
 
     // Create PTY session
@@ -111,6 +105,15 @@ pub async fn create_tab(
                 .into_response();
         }
     };
+    let cwd_str = Some(
+        session
+            .cwd_state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .cwd
+            .to_string_lossy()
+            .into_owned(),
+    );
 
     // Create initial layout with single leaf
     let title = req.title.as_deref().unwrap_or("Terminal");

--- a/src/tabs/ssh.rs
+++ b/src/tabs/ssh.rs
@@ -64,6 +64,7 @@ pub async fn create_ssh_quick_tab(
         layout: Some(layout.clone()),
         cwd: None,
         connection_id: req.profile_id.clone(),
+        workspace_id: None,
     });
     manager.recheck_publish_or_correct(&pane_id, &session);
 
@@ -97,6 +98,7 @@ pub async fn create_ssh_tab(
                 auth_method: profile.auth_method.clone(),
                 default_command: profile.default_command.clone(),
                 profile_id: Some(profile.id.clone()),
+                workspace_id: req.workspace_id.clone(),
                 initial_cwd: req.initial_cwd.clone(),
             },
             None => {
@@ -158,6 +160,7 @@ pub async fn create_ssh_tab(
         layout: Some(layout.clone()),
         cwd: None,
         connection_id: Some(req.profile_id.clone()),
+        workspace_id: req.workspace_id.clone(),
     });
     manager.recheck_publish_or_correct(&pane_id, &session);
 
@@ -166,6 +169,7 @@ pub async fn create_ssh_tab(
         "pane_id": pane_id,
         "layout": layout,
         "connection_id": req.profile_id,
+        "workspace_id": req.workspace_id,
     }))
     .into_response()
 }

--- a/src/templates/apply.rs
+++ b/src/templates/apply.rs
@@ -286,6 +286,7 @@ pub async fn apply_template(
         collect_first_terminal_cwd(&layout)
     });
     let connection_id = workspace.as_ref().and_then(|ws| ws.connection_id.clone());
+    let workspace_id = workspace.as_ref().map(|ws| ws.id.clone());
 
     manager.insert_tab(
         new_tab_id.clone(),
@@ -303,6 +304,7 @@ pub async fn apply_template(
         layout: Some(layout.clone()),
         cwd: effective_cwd.clone(),
         connection_id: connection_id.clone(),
+        workspace_id: workspace_id.clone(),
     });
     manager.broadcast_sync(&SyncMsg::LayoutUpdated {
         pane_id: new_tab_id.clone(),
@@ -334,6 +336,7 @@ pub async fn apply_template(
         "warnings": warnings,
         "cwd": effective_cwd,
         "connection_id": connection_id,
+        "workspace_id": workspace_id,
     }))
     .into_response()
 }

--- a/src/workspace_mgmt/mod.rs
+++ b/src/workspace_mgmt/mod.rs
@@ -85,6 +85,15 @@ pub(crate) fn migrate_colors(ws: &mut Vec<Workspace>) -> bool {
     changed
 }
 
+fn simplify_local_workspace_paths(workspaces: &mut [Workspace]) {
+    for workspace in workspaces {
+        if workspace.connection_id.is_none() {
+            workspace.path =
+                dunce::simplified(FsPath::new(&workspace.path)).to_string_lossy().into_owned();
+        }
+    }
+}
+
 fn workspaces_path() -> PathBuf {
     settings::config_dir().join("workspaces.json")
 }
@@ -94,8 +103,9 @@ pub fn load_workspaces() -> Vec<Workspace> {
     let path = workspaces_path();
     if path.exists() {
         match std::fs::read_to_string(&path) {
-            Ok(data) => match serde_json::from_str(&data) {
+            Ok(data) => match serde_json::from_str::<Vec<Workspace>>(&data) {
                 Ok(mut ws) => {
+                    simplify_local_workspace_paths(&mut ws);
                     if migrate_colors(&mut ws) {
                         if let Err(e) = save_workspaces(&ws) {
                             error!("save workspaces: {}", e);
@@ -164,7 +174,7 @@ pub fn validate_workspace_path(path: &str) -> Result<PathBuf, String> {
     if is_sensitive_workspace_target(raw) {
         return Err(format!("cannot use sensitive system directory: {}", raw.display()));
     }
-    let canonical = std::fs::canonicalize(trimmed).map_err(|e| format!("invalid path: {e}"))?;
+    let canonical = dunce::canonicalize(trimmed).map_err(|e| format!("invalid path: {e}"))?;
     if !canonical.is_dir() {
         return Err("path is not a directory".into());
     }

--- a/src/workspace_mgmt/tests.rs
+++ b/src/workspace_mgmt/tests.rs
@@ -139,6 +139,51 @@ fn test_validate_path_accepts_real_dir() {
 }
 
 #[test]
+#[cfg(windows)]
+fn test_validate_path_simplifies_windows_verbatim_prefix() {
+    let temp_dir = std::env::temp_dir();
+    let canonical = validate_workspace_path(&temp_dir.to_string_lossy()).unwrap();
+
+    assert!(!canonical.to_string_lossy().starts_with(r"\\?\"));
+}
+
+#[test]
+fn test_simplify_local_workspace_paths_preserves_remote_paths() {
+    let remote_path = r"\\?\C:\remote\project";
+    let mut workspaces = vec![Workspace {
+        id: "remote".to_string(),
+        name: "remote".to_string(),
+        path: remote_path.to_string(),
+        order: 0,
+        connection_id: Some("ssh-profile".to_string()),
+        abbr: None,
+        color: None,
+    }];
+
+    simplify_local_workspace_paths(&mut workspaces);
+
+    assert_eq!(workspaces[0].path, remote_path);
+}
+
+#[test]
+#[cfg(windows)]
+fn test_simplify_local_workspace_paths_updates_legacy_windows_paths_in_memory() {
+    let mut workspaces = vec![Workspace {
+        id: "local".to_string(),
+        name: "local".to_string(),
+        path: r"\\?\C:\repo\dinotty".to_string(),
+        order: 0,
+        connection_id: None,
+        abbr: None,
+        color: None,
+    }];
+
+    simplify_local_workspace_paths(&mut workspaces);
+
+    assert_eq!(workspaces[0].path, r"C:\repo\dinotty");
+}
+
+#[test]
 fn test_derive_name_with_special_chars() {
     assert_eq!(derive_name("/home/user/my project"), "my project");
     assert_eq!(derive_name("/home/user/项目"), "项目");

--- a/src/ws/sync.rs
+++ b/src/ws/sync.rs
@@ -284,6 +284,7 @@ async fn handle_sync_socket(
                                     layout: Some(layout.clone()),
                                     cwd: None,
                                     connection_id: None,
+                                    workspace_id: None,
                                 })
                                 .unwrap(),
                             );
@@ -295,6 +296,7 @@ async fn handle_sync_socket(
                                     layout: Some(layout),
                                     cwd: None,
                                     connection_id: None,
+                                    workspace_id: None,
                                 },
                                 &client_id,
                             );

--- a/tests/terminal_exit_regression.rs
+++ b/tests/terminal_exit_regression.rs
@@ -330,15 +330,27 @@ async fn shell_exit_notifies_ws_and_removes_tab() -> TestResult {
     let base = format!("http://127.0.0.1:{port}");
     wait_until_ready(&client, &base, port, &mut child, tmp.path()).await?;
 
+    #[cfg(windows)]
+    let requested_cwd = format!(r"\\?\{}", userprofile.display());
+    #[cfg(unix)]
+    let requested_cwd = userprofile.to_string_lossy().into_owned();
+
     let created: Value = client
         .post(format!("{base}/api/tabs"))
         .bearer_auth("regression-token")
-        .json(&serde_json::json!({ "cwd": null }))
+        .json(&serde_json::json!({ "cwd": requested_cwd }))
         .send()
         .await?
         .error_for_status()?
         .json()
         .await?;
+    let created_cwd = created
+        .get("cwd")
+        .and_then(Value::as_str)
+        .ok_or_else(|| test_error("create tab response missing cwd"))?;
+    assert_eq!(PathBuf::from(created_cwd), dunce::canonicalize(&userprofile)?);
+    #[cfg(windows)]
+    assert!(!created_cwd.starts_with(r"\\?\"));
     let tab_id = created
         .get("tab_id")
         .and_then(Value::as_str)
@@ -365,6 +377,27 @@ async fn shell_exit_notifies_ws_and_removes_tab() -> TestResult {
     .await?;
 
     wait_for_shell_prompt(&mut ws).await?;
+
+    let tabs: Value = client
+        .get(format!("{base}/api/tabs"))
+        .bearer_auth("regression-token")
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    let listed_cwd = tabs
+        .get("tabs")
+        .and_then(Value::as_array)
+        .and_then(|tabs| {
+            tabs.iter().find(|tab| tab.get("tab_id").and_then(Value::as_str) == Some(&tab_id))
+        })
+        .and_then(|tab| tab.get("cwd"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| test_error("tab list missing created tab cwd"))?;
+    assert_eq!(PathBuf::from(listed_cwd), dunce::canonicalize(&userprofile)?);
+    #[cfg(windows)]
+    assert!(!listed_cwd.starts_with(r"\\?\"));
 
     ws.send(Message::Text(serde_json::json!({ "type": "input", "data": "exit\r" }).to_string()))
         .await?;


### PR DESCRIPTION
## Summary

- Keep browser and Tauri window titles synchronized with the active workspace name, falling back to `Dinotty` for blank names.
- Normalize Windows workspace and PTY CWD paths to avoid user-visible `\\?\` prefixes and path-matching failures.
- Activate the selected local, default, or SSH workspace before creating a tab from Mission Control.

## Changes

- Add shared title formatting/updating utilities and native Tauri title command integration.
- Simplify local workspace paths at validation, loading, matching, PTY, and session boundaries.
- Carry target workspace IDs through new-tab callbacks and abort stale workspace activations.
- Add frontend and Rust regression coverage for title synchronization and Windows path handling.

## Test Plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cd frontend && pnpm exec vue-tsc --noEmit`
- [x] `cd frontend && pnpm test` (78 files, 891 tests)
- [x] Windows path behavior covered by Windows-specific automated tests

## Visual Checklist

- [x] No colors, icons, SVGs, or workspace palette values changed.