### PR TITLE
fix(frontend): use monospace by default on Linux Tauri

### DIFF
--- a/frontend/src/composables/useTerminal.ts
+++ b/frontend/src/composables/useTerminal.ts
@@ -16,7 +16,7 @@ import {
 } from './useDeviceTextSettings'
 import { wsUrlWithToken } from './apiBase'
 import { useKeybindings } from './useKeybindings'
-import { isWindowsClient } from '../utils/clientPlatform'
+import { hostTarget, isWindowsClient } from '../utils/clientPlatform'
 import { setupTouchScroll } from '../utils/touchScroll'
 import {
   DEDUP_WINDOW_MS,
@@ -49,6 +49,12 @@ export {
 let _activePaneId: string | null = null
 export function setActivePaneId(paneId: string | null) {
   _activePaneId = paneId
+}
+
+function resolveTerminalFontFamily(configuredFamily: string, cssFallback: string): string {
+  if (configuredFamily) return configuredFamily
+  if (isTauri() && hostTarget()?.startsWith('linux-')) return 'monospace'
+  return cssFallback
 }
 
 // Sticky typing mode (mobile web): while the user is typing in the app's own
@@ -209,7 +215,7 @@ export class TerminalInstance {
     const v = (name: string) => s.getPropertyValue(name).trim()
 
     const text = getEffectiveText()
-    const fontFamily = text.font_family || v('--font-mono')
+    const fontFamily = resolveTerminalFontFamily(text.font_family, v('--font-mono'))
 
     this.xterm = new XTerm({
       cursorBlink: text.cursor_blink,
@@ -612,9 +618,10 @@ export class TerminalInstance {
         text.letter_spacing !== lastLayout.letter_spacing ||
         text.scrollback !== lastLayout.scrollback
       this.xterm.options.fontSize = text.font_size
-      this.xterm.options.fontFamily =
-        text.font_family ||
-        getComputedStyle(document.documentElement).getPropertyValue('--font-mono').trim()
+      this.xterm.options.fontFamily = resolveTerminalFontFamily(
+        text.font_family,
+        getComputedStyle(document.documentElement).getPropertyValue('--font-mono').trim(),
+      )
       this.xterm.options.lineHeight = text.line_height
       this.xterm.options.letterSpacing = text.letter_spacing
       this.xterm.options.cursorBlink = text.cursor_blink

--- a/frontend/src/test/useTerminalDeviceText.test.ts
+++ b/frontend/src/test/useTerminalDeviceText.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const xtermMocks = vi.hoisted(() => ({ instances: [] as any[] }))
+const mocks = vi.hoisted(() => ({
+  hostTarget: vi.fn<() => string | null>(),
+  instances: [] as any[],
+  isTauri: vi.fn<() => boolean>(),
+}))
 
 vi.mock('@xterm/xterm', () => ({
   Terminal: class {
@@ -10,7 +14,7 @@ vi.mock('@xterm/xterm', () => ({
     buffer = { active: { getLine: () => null, cursorY: 0, cursorX: 0 } }
     constructor(options: Record<string, any>) {
       this.options = { ...options }
-      xtermMocks.instances.push(this)
+      mocks.instances.push(this)
     }
     loadAddon() {}
     open(wrapper: HTMLElement) {
@@ -34,10 +38,14 @@ vi.mock('@xterm/addon-unicode11', () => ({ Unicode11Addon: class {} }))
 vi.mock('@xterm/addon-webgl', () => ({ WebglAddon: class { onContextLoss() {}; dispose() {} } }))
 vi.mock('@xterm/addon-search', () => ({ SearchAddon: class {} }))
 vi.mock('../composables/useTransport', () => ({
-  isTauri: () => true,
+  isTauri: mocks.isTauri,
   createTransport: () => ({
     onConnect() {}, onMessage() {}, onDisconnect() {}, connect() {}, disconnect() {}, send() {},
   }),
+}))
+vi.mock('../utils/clientPlatform', () => ({
+  hostTarget: mocks.hostTarget,
+  isWindowsClient: false,
 }))
 vi.mock('../composables/useTerminalWheel', () => ({
   createTerminalWheel: () => ({
@@ -53,6 +61,7 @@ import { settings, notifyTextChange } from '../composables/useSettings'
 import {
   getEffectiveText,
   resetAllOverrides,
+  resetOverride,
   setOverride,
 } from '../composables/useDeviceTextSettings'
 
@@ -76,7 +85,9 @@ function attach(id: string) {
 
 describe('useTerminal device text integration', () => {
   beforeEach(() => {
-    xtermMocks.instances.length = 0
+    mocks.instances.length = 0
+    mocks.hostTarget.mockReturnValue('linux-x86_64')
+    mocks.isTauri.mockReturnValue(true)
     const storage = new MemoryStorage()
     Object.defineProperty(window, 'localStorage', { value: storage, configurable: true })
     vi.stubGlobal('localStorage', storage)
@@ -88,7 +99,14 @@ describe('useTerminal device text integration', () => {
     settings.text.letter_spacing = 1
     settings.text.cursor_blink = true
     settings.text.scrollback = 10000
+    document.documentElement.style.setProperty('--font-mono', 'test-mono-stack')
     vi.stubGlobal('ResizeObserver', class { observe() {}; disconnect() {} })
+    vi.stubGlobal('WebSocket', class {
+      static OPEN = 1
+      readyState = 0
+      close() {}
+      send() {}
+    })
   })
 
   it('initializes xterm from effective text', () => {
@@ -98,6 +116,50 @@ describe('useTerminal device text integration', () => {
     expect(term.xterm?.options).toMatchObject({ fontSize: 24, fontFamily: 'local-font' })
     term.destroy()
   })
+
+  it('uses monospace for an empty font on Linux Tauri', () => {
+    settings.text.font_family = ''
+    const term = attach('p1')
+    expect(term.xterm?.options.fontFamily).toBe('monospace')
+    term.destroy()
+  })
+
+  it('keeps an explicit server font on Linux Tauri', () => {
+    settings.text.font_family = 'server-font'
+    const term = attach('p1')
+    expect(term.xterm?.options.fontFamily).toBe('server-font')
+    term.destroy()
+  })
+
+  it('resets the runtime font to monospace on Linux Tauri and refits once', () => {
+    settings.text.font_family = ''
+    setOverride('font_family', 'local-font')
+    const term = attach('p1')
+    const refit = term['_refit'] as ReturnType<typeof vi.fn>
+    resetOverride('font_family')
+    expect(term.xterm?.options.fontFamily).toBe('monospace')
+    expect(refit).toHaveBeenCalledTimes(1)
+    term.destroy()
+  })
+
+  it('keeps the CSS font stack for an empty font in a Linux browser', () => {
+    mocks.isTauri.mockReturnValue(false)
+    settings.text.font_family = ''
+    const term = attach('p1')
+    expect(term.xterm?.options.fontFamily).toBe('test-mono-stack')
+    term.destroy()
+  })
+
+  it.each(['windows-x86_64', 'macos-aarch64'])(
+    'keeps the CSS font stack for an empty font on %s Tauri',
+    (target) => {
+      mocks.hostTarget.mockReturnValue(target)
+      settings.text.font_family = ''
+      const term = attach('p1')
+      expect(term.xterm?.options.fontFamily).toBe('test-mono-stack')
+      term.destroy()
+    },
+  )
 
   it('broadcasts local changes to two panes and refits each once', () => {
     const one = attach('p1')


### PR DESCRIPTION
## Summary

- use the generic `monospace` family when Linux Tauri starts a terminal without an explicit font
- preserve configured fonts and the existing `--font-mono` fallback for browsers, Windows, and macOS
- share the same font resolution logic between terminal initialization and runtime settings updates
- add coverage for Linux Tauri defaults, explicit fonts, runtime reset/refit, Linux browsers, Windows, and macOS

## Root cause

On Linux Tauri/WebKitGTK, the first unavailable family in the default font stack can be substituted through Fontconfig with a proportional font instead of continuing to the generic `monospace` fallback. xterm then measures an oversized cell width, producing visibly wide spacing, especially for CJK text.

The fallback is applied only at the xterm rendering boundary. It does not modify server settings, device overrides, localStorage, or font selection UI behavior.

## Behavior matrix

| Client | Empty `font_family` | Explicit `font_family` |
| --- | --- | --- |
| Linux Tauri | `monospace` | configured font |
| Linux browser | existing `--font-mono` stack | configured font |
| Windows/macOS Tauri | existing `--font-mono` stack | configured font |

## Testing

- [x] `pnpm exec vitest run src/test/useTerminalDeviceText.test.ts` (10 tests)
- [x] `pnpm exec vue-tsc --noEmit`
- [x] `pnpm test` (76 files, 881 tests)
- [x] `pnpm run build`
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test --workspace`