### PR TITLE
fix: polish pane, plugin, and preview interactions

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -48,8 +48,9 @@
           type="button"
           class="tab-bar-icon-btn"
           :title="t('app.preview')"
-          @click="openPreview"
-          @touchend.prevent="openPreview"
+          :aria-pressed="activeTab?.type === 'terminal' && activeTab.previewVisible"
+          @click="togglePreview"
+          @touchend.prevent="togglePreview"
         >
           <Monitor :size="16" />
         </button>
@@ -1154,6 +1155,16 @@ function openPreview() {
       previewPanelRef.value?.openFromPath(raw)
     }
   })
+}
+
+function togglePreview() {
+  const tab = activeTab.value
+  if (!tab || tab.type !== 'terminal') return
+  if (tab.previewVisible) {
+    closePreview(tab.paneId)
+    return
+  }
+  openPreview()
 }
 
 function onFileClick(path: string) {

--- a/frontend/src/components/settings/KeyboardTab.vue
+++ b/frontend/src/components/settings/KeyboardTab.vue
@@ -32,9 +32,12 @@
             class="settings-row kb-shortcut-row"
             :data-kb-id="def.id"
           >
-            <label
-              ><component :is="def.icon" :size="14" class="kb-icon" /> {{ t(def.titleKey) }}</label
-            >
+            <label class="kb-shortcut-label">
+              <span class="kb-icon" aria-hidden="true"
+                ><component :is="def.icon" :size="14"
+              /></span>
+              <span>{{ t(def.titleKey) }}</span>
+            </label>
             <div class="kb-shortcut-ctrl">
               <span v-if="kbRecording !== def.id" class="kb-keys">
                 <kbd
@@ -81,9 +84,12 @@
             class="settings-row kb-shortcut-row"
             :data-kb-id="def.id"
           >
-            <label
-              ><component :is="def.icon" :size="14" class="kb-icon" /> {{ t(def.titleKey) }}</label
-            >
+            <label class="kb-shortcut-label">
+              <span class="kb-icon" aria-hidden="true"
+                ><component :is="def.icon" :size="14"
+              /></span>
+              <span>{{ t(def.titleKey) }}</span>
+            </label>
             <div class="kb-shortcut-ctrl">
               <span v-if="kbRecording !== def.id" class="kb-keys">
                 <kbd
@@ -126,10 +132,12 @@
         <CollapsibleSection :title="t('keybinding.group.nav')" level="section" default-open>
           <template v-for="def in navDefs" :key="def.id">
             <div class="settings-row kb-shortcut-row" :data-kb-id="def.id">
-              <label
-                ><component :is="def.icon" :size="14" class="kb-icon" />
-                {{ t(def.titleKey) }}</label
-              >
+              <label class="kb-shortcut-label">
+                <span class="kb-icon" aria-hidden="true"
+                  ><component :is="def.icon" :size="14"
+                /></span>
+                <span>{{ t(def.titleKey) }}</span>
+              </label>
               <div class="kb-shortcut-ctrl">
                 <span v-if="kbRecording !== def.id" class="kb-keys">
                   <kbd
@@ -207,9 +215,12 @@
             class="settings-row kb-shortcut-row"
             :data-kb-id="def.id"
           >
-            <label
-              ><component :is="def.icon" :size="14" class="kb-icon" /> {{ t(def.titleKey) }}</label
-            >
+            <label class="kb-shortcut-label">
+              <span class="kb-icon" aria-hidden="true"
+                ><component :is="def.icon" :size="14"
+              /></span>
+              <span>{{ t(def.titleKey) }}</span>
+            </label>
             <div class="kb-shortcut-ctrl">
               <span v-if="kbRecording !== def.id" class="kb-keys">
                 <kbd
@@ -259,9 +270,10 @@
           class="settings-row kb-shortcut-row"
           :data-kb-id="def.id"
         >
-          <label
-            ><component :is="def.icon" :size="14" class="kb-icon" /> {{ t(def.titleKey) }}</label
-          >
+          <label class="kb-shortcut-label">
+            <span class="kb-icon" aria-hidden="true"><component :is="def.icon" :size="14" /></span>
+            <span>{{ t(def.titleKey) }}</span>
+          </label>
           <div class="kb-shortcut-ctrl">
             <span v-if="kbRecording !== def.id" class="kb-keys">
               <kbd
@@ -1437,6 +1449,11 @@ onBeforeUnmount(() => {
 .kb-shortcut-row {
   justify-content: space-between;
 }
+.kb-shortcut-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
 .kb-group + .kb-group {
   margin-top: 12px;
 }
@@ -1499,6 +1516,9 @@ onBeforeUnmount(() => {
   height: 18px;
   flex-shrink: 0;
   color: var(--fg-muted);
+}
+.kb-icon > svg {
+  display: block;
 }
 .kb-stop {
   color: #ef4444 !important;

--- a/frontend/src/components/settings/PluginsTab.vue
+++ b/frontend/src/components/settings/PluginsTab.vue
@@ -844,16 +844,19 @@ async function onRefresh() {
   align-items: center;
   padding: 5px 12px;
   border-radius: 5px;
-  background: none;
+  background: var(--bg-input);
   color: var(--fg-bright, #d0d0d0);
   font-size: 12px;
   font-weight: 500;
   cursor: pointer;
-  border: none;
-  transition: background 0.15s;
+  border: 1px solid var(--border, #444);
+  transition:
+    background 0.15s,
+    border-color 0.15s;
 }
 .plugin-install-btn:hover {
   background: var(--bg-hover);
+  border-color: var(--fg-muted, #858585);
 }
 .plugin-action-btn {
   display: inline-flex;

--- a/frontend/src/components/settings/PluginsTab.vue
+++ b/frontend/src/components/settings/PluginsTab.vue
@@ -203,7 +203,7 @@
         </button>
       </div>
       <div v-if="showDirInstall" class="plugin-dir-install">
-        <button class="plugin-browse-btn" @click="showPicker = true">
+        <button class="plugin-browse-btn" @click="browseInstallDirectory">
           {{ installDirPath || t('settings.plugins.browseFolder') }}
         </button>
         <label class="plugin-dev-toggle" :title="t('settings.plugins.devLinkHint')">
@@ -312,6 +312,7 @@
     </div>
 
     <FilePickerModal
+      v-if="!isTauri()"
       :visible="showPicker"
       pane-id=""
       root="~"
@@ -341,6 +342,7 @@ import { useMarketplace, type MarketPlugin } from '../../composables/useMarketpl
 import { describeHttpError, describeRequestError } from '../../utils/httpError'
 import { uiConfirm } from '../../composables/useConfirm'
 import { settings, saveSettings } from '../../composables/useSettings'
+import { isTauri, tauriInvoke } from '../../composables/useTransport'
 import ConfirmModal from '../ui/ConfirmModal.vue'
 import FilePickerModal from '../preview/FilePickerModal.vue'
 
@@ -558,6 +560,23 @@ async function onUpdateFromRepo(mp: MarketPlugin) {
 
 function onPickerSelect(path: string) {
   installDirPath.value = path
+  showPicker.value = false
+}
+
+async function browseInstallDirectory() {
+  if (!isTauri()) {
+    showPicker.value = true
+    return
+  }
+
+  try {
+    const selected = (await tauriInvoke('pick_workspace_dir', {
+      base: installDirPath.value.trim() || undefined,
+    })) as string | null
+    if (selected) onPickerSelect(selected)
+  } catch (error) {
+    setStatus(describeRequestError(error, 'Unable to open folder picker'), false)
+  }
 }
 
 async function requestedNativePermissions(res: Response): Promise<string[] | null> {

--- a/frontend/src/components/split/PaneHeader.vue
+++ b/frontend/src/components/split/PaneHeader.vue
@@ -1,18 +1,34 @@
 <template>
   <div
     class="pane-header"
-    :class="[direction ? `direction-${direction}` : '', { active: isActive, dragging: isDragging }]"
+    :class="[
+      direction ? `direction-${direction}` : '',
+      { active: isActive, dragging: isDragging, 'has-close': allowClose },
+    ]"
     @mousedown.prevent="onMouseDown"
     @touchstart.prevent="onTouchStart"
   >
+    <button
+      v-if="allowClose"
+      type="button"
+      class="pane-close-btn"
+      :title="t('split.closePane')"
+      @mousedown.stop
+      @touchstart.stop
+      @click.stop="emit('close')"
+    >
+      <X :size="14" aria-hidden="true" />
+    </button>
     <span class="pane-header-title">{{ title }}</span>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, onBeforeUnmount } from 'vue'
+import { X } from 'lucide-vue-next'
 import type { DropPosition } from '../../types/pane'
 import { usePaneDrag, type DropZone, type DropTargetKind } from '../../composables/paneDragContext'
+import { useI18n } from '../../composables/useI18n'
 
 const props = defineProps<{
   paneId: string
@@ -20,13 +36,17 @@ const props = defineProps<{
   title: string
   isActive: boolean
   direction?: 'horizontal' | 'vertical'
+  allowClose?: boolean
 }>()
 
 const emit = defineEmits<{
+  close: []
   reorder: [sourcePaneId: string, targetPaneId: string, position: DropPosition]
   'drop-on-tab': [sourceTabId: string, sourcePaneId: string, dstTabId: string, position: DropPosition]
   'drop-extract': [sourceTabId: string, sourcePaneId: string, targetIndex: number]
 }>()
+
+const { t } = useI18n()
 
 const drag = usePaneDrag()
 
@@ -355,6 +375,47 @@ onBeforeUnmount(() => {
 .pane-header.direction-vertical {
   padding: 8px 8px;
   height: auto;
+}
+
+.pane-header.has-close {
+  padding-left: 28px;
+}
+
+.pane-close-btn {
+  position: absolute;
+  top: 50%;
+  left: 4px;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-secondary, #888);
+  cursor: pointer;
+  opacity: 0;
+  transform: translateY(-50%);
+  transition:
+    opacity 0.15s,
+    background 0.15s,
+    color 0.15s;
+}
+
+.pane-close-btn:focus-visible {
+  opacity: 1;
+}
+
+.pane-close-btn:hover {
+  background: var(--hover-bg, var(--bg-hover));
+  color: var(--text-primary, var(--fg-bright));
+}
+
+.pane-close-btn svg {
+  display: block;
 }
 
 .pane-header:active {

--- a/frontend/src/components/split/SplitContainer.vue
+++ b/frontend/src/components/split/SplitContainer.vue
@@ -21,20 +21,12 @@
       :title="leaf.title || 'Terminal'"
       :is-active="leaf.paneId === activePaneId"
       :direction="parentDirection"
+      :allow-close="allowClose"
+      @close="emit('close', leaf.paneId)"
       @reorder="(src, tgt, pos) => emit('reorder', src, tgt, pos)"
       @drop-on-tab="(srcTab, srcPane, dstTab, pos) => emit('dropOnTab', srcTab, srcPane, dstTab, pos)"
       @drop-extract="(srcTab, srcPane, idx) => emit('dropExtract', srcTab, srcPane, idx)"
     />
-    <button
-      v-if="allowClose"
-      type="button"
-      class="pane-close-btn"
-      :title="t('split.closePane')"
-      @mousedown.stop
-      @click.stop="emit('close', leaf!.paneId)"
-    >
-      <X :size="14" aria-hidden="true" />
-    </button>
     <template v-if="broadcastActive">
       <div class="broadcast-icon broadcast-icon--active" :title="t('split.broadcastTooltip')">
         <svg
@@ -149,7 +141,6 @@ import PaneContent from './PaneContent.vue'
 import SplitDivider from './SplitDivider.vue'
 import PaneHeader from './PaneHeader.vue'
 import { useI18n } from '../../composables/useI18n'
-import { X } from 'lucide-vue-next'
 
 const props = withDefaults(
   defineProps<{
@@ -294,50 +285,8 @@ function getChildStyle(idx: number) {
   opacity: 1;
 }
 
-/* Close button — visible on hover, positioned inside header when present */
-.pane-close-btn {
-  position: absolute;
-  top: 4px;
-  left: 4px;
-  z-index: 20;
-  width: 20px;
-  height: 20px;
-  border: none;
-  border-radius: 4px;
-  background: transparent;
-  color: var(--text-secondary, #888);
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  opacity: 0;
-  transition:
-    opacity 0.15s,
-    background 0.15s,
-    color 0.15s;
-}
-
-.pane-close-btn svg {
-  display: block;
-}
-
-/* Adjust close button position when vertical header with expanded padding is present */
-.split-leaf:has(.direction-vertical) .pane-close-btn {
-  top: 11px;
-}
-
-/* Push header title right to avoid overlapping the close button */
-.split-leaf:has(.pane-close-btn) .pane-header {
-  padding-left: 28px;
-}
-
-.split-leaf:hover .pane-close-btn {
+.split-leaf:hover :deep(.pane-close-btn) {
   opacity: 1;
-}
-
-.pane-close-btn:hover {
-  background: var(--hover-bg, var(--bg-hover));
-  color: var(--text-primary, var(--fg-bright));
 }
 
 /* Broadcast indicator — radar style */

--- a/frontend/src/components/split/SplitContainer.vue
+++ b/frontend/src/components/split/SplitContainer.vue
@@ -27,12 +27,13 @@
     />
     <button
       v-if="allowClose"
+      type="button"
       class="pane-close-btn"
       :title="t('split.closePane')"
       @mousedown.stop
       @click.stop="emit('close', leaf!.paneId)"
     >
-      &times;
+      <X :size="14" aria-hidden="true" />
     </button>
     <template v-if="broadcastActive">
       <div class="broadcast-icon broadcast-icon--active" :title="t('split.broadcastTooltip')">
@@ -148,6 +149,7 @@ import PaneContent from './PaneContent.vue'
 import SplitDivider from './SplitDivider.vue'
 import PaneHeader from './PaneHeader.vue'
 import { useI18n } from '../../composables/useI18n'
+import { X } from 'lucide-vue-next'
 
 const props = withDefaults(
   defineProps<{
@@ -304,8 +306,6 @@ function getChildStyle(idx: number) {
   border-radius: 4px;
   background: transparent;
   color: var(--text-secondary, #888);
-  font-size: 14px;
-  line-height: 1;
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -315,6 +315,10 @@ function getChildStyle(idx: number) {
     opacity 0.15s,
     background 0.15s,
     color 0.15s;
+}
+
+.pane-close-btn svg {
+  display: block;
 }
 
 /* Adjust close button position when vertical header with expanded padding is present */

--- a/frontend/src/composables/useTabLifecycle.ts
+++ b/frontend/src/composables/useTabLifecycle.ts
@@ -439,25 +439,22 @@ export function useTabLifecycle(opts: TabLifecycleOptions): TabLifecycleState {
       tab.type === 'terminal'
         ? [tab.paneId, ...getAllLeaves(tab.layout).map((l) => l.paneId)]
         : [tab.paneId]
-    if (tab.type === 'plugin') {
-      invalidatePluginPreview(tab.paneId)
-    } else if (tab.type === 'terminal') {
-      for (const leaf of getAllLeaves(tab.layout)) {
-        if (leaf.kind === 'plugin') invalidatePluginPreview(leaf.paneId)
-      }
-    }
-
     if (tab.type === 'terminal') {
-      for (const leaf of getAllLeaves(tab.layout)) {
-        delete termRefs[leaf.paneId]
-        clearFileWorkspaceState(leaf.paneId)
-      }
-
       try {
         await apiCloseTab(tabId)
       } catch (e) {
         console.error('Failed to close tab:', e)
         return
+      }
+    }
+
+    if (tab.type === 'plugin') {
+      invalidatePluginPreview(tab.paneId)
+    } else if (tab.type === 'terminal') {
+      for (const leaf of getAllLeaves(tab.layout)) {
+        if (leaf.kind === 'plugin') invalidatePluginPreview(leaf.paneId)
+        delete termRefs[leaf.paneId]
+        clearFileWorkspaceState(leaf.paneId)
       }
     }
 

--- a/frontend/src/composables/useTransport.ts
+++ b/frontend/src/composables/useTransport.ts
@@ -120,13 +120,28 @@ export class TauriIpcTransport implements Transport {
   private _connectHandler: (() => void) | null = null
   private _disconnectHandler: (() => void) | null = null
   private _unlistenFns: Array<() => void> = []
+  private _destroyed = false
 
   constructor(private paneId: string) {
-    this._init()
+    void this._init()
   }
 
   private _invoke(cmd: string, args?: Record<string, unknown>): Promise<unknown> {
     return tauriInvoke(cmd, { paneId: this.paneId, ...args })
+  }
+
+  private async _registerListener(
+    listen: (event: string, handler: (event: any) => void) => Promise<() => void>,
+    event: string,
+    handler: (event: any) => void
+  ): Promise<boolean> {
+    const unlisten = await listen(event, handler)
+    if (this._destroyed) {
+      unlisten()
+      return false
+    }
+    this._unlistenFns.push(unlisten)
+    return true
   }
 
   private async _init() {
@@ -138,67 +153,79 @@ export class TauriIpcTransport implements Transport {
       return
     }
 
-    this._unlistenFns.push(
-      await listen('pty-output', (e: any) => {
-        if (e.payload.pane_id === this.paneId) {
-          this._messageHandler?.({ type: 'output', data: e.payload.data })
-        }
-      })
-    )
-    this._unlistenFns.push(
-      await listen('pty-reconnected', (e: any) => {
-        const p = e.payload
-        if (p.pane_id === this.paneId) {
-          this._messageHandler?.({ type: 'reconnected', cols: p.cols, rows: p.rows })
-        }
-      })
-    )
-    this._unlistenFns.push(
-      await listen('pty-resize', (e: any) => {
-        const p = e.payload
-        if (p.pane_id === this.paneId) {
-          this._messageHandler?.({ type: 'resize', cols: p.cols, rows: p.rows })
-        }
-      })
-    )
-    this._unlistenFns.push(
-      await listen('pty-exit', (e: any) => {
-        if (e.payload.pane_id === this.paneId) {
-          this._disconnectHandler?.()
-        }
-      })
-    )
-    this._unlistenFns.push(
-      await listen('pty-sync', (e: any) => {
-        if (e.payload.pane_id === this.paneId) {
-          this._messageHandler?.({ type: e.payload.active ? 'sync_begin' : 'sync_end' })
-        }
-      })
-    )
-    this._unlistenFns.push(
-      await listen('pty-replay-begin', (e: any) => {
-        if (e.payload.pane_id === this.paneId) {
-          this._messageHandler?.({
-            type: 'replay_begin',
-            cols: e.payload.cols,
-            rows: e.payload.rows,
-          })
-        }
-      })
-    )
-    this._unlistenFns.push(
-      await listen('pty-replay-end', (e: any) => {
-        if (e.payload.pane_id === this.paneId) {
-          this._messageHandler?.({ type: 'replay_end' })
-        }
-      })
-    )
-
     try {
+      if (
+        !(await this._registerListener(listen, 'pty-output', (e: any) => {
+          if (e.payload.pane_id === this.paneId) {
+            this._messageHandler?.({ type: 'output', data: e.payload.data })
+          }
+        }))
+      )
+        return
+      if (
+        !(await this._registerListener(listen, 'pty-reconnected', (e: any) => {
+          const p = e.payload
+          if (p.pane_id === this.paneId) {
+            this._messageHandler?.({ type: 'reconnected', cols: p.cols, rows: p.rows })
+          }
+        }))
+      )
+        return
+      if (
+        !(await this._registerListener(listen, 'pty-resize', (e: any) => {
+          const p = e.payload
+          if (p.pane_id === this.paneId) {
+            this._messageHandler?.({ type: 'resize', cols: p.cols, rows: p.rows })
+          }
+        }))
+      )
+        return
+      if (
+        !(await this._registerListener(listen, 'pty-exit', (e: any) => {
+          if (e.payload.pane_id === this.paneId) {
+            this._disconnectHandler?.()
+          }
+        }))
+      )
+        return
+      if (
+        !(await this._registerListener(listen, 'pty-sync', (e: any) => {
+          if (e.payload.pane_id === this.paneId) {
+            this._messageHandler?.({ type: e.payload.active ? 'sync_begin' : 'sync_end' })
+          }
+        }))
+      )
+        return
+      if (
+        !(await this._registerListener(listen, 'pty-replay-begin', (e: any) => {
+          if (e.payload.pane_id === this.paneId) {
+            this._messageHandler?.({
+              type: 'replay_begin',
+              cols: e.payload.cols,
+              rows: e.payload.rows,
+            })
+          }
+        }))
+      )
+        return
+      if (
+        !(await this._registerListener(listen, 'pty-replay-end', (e: any) => {
+          if (e.payload.pane_id === this.paneId) {
+            this._messageHandler?.({ type: 'replay_end' })
+          }
+        }))
+      )
+        return
+
       const shellType: string = (await this._invoke('pty_spawn')) as string
+      if (this._destroyed) {
+        void this._invoke('pty_detach').catch(() => {})
+        return
+      }
       this._connectHandler?.()
       this._messageHandler?.({ type: 'shell_info', shell_type: shellType })
     } catch (e) {
+      if (this._destroyed) return
       console.error('pty_spawn failed:', e)
       const code =
         typeof e === 'object' && e !== null && 'code' in e
@@ -210,6 +237,7 @@ export class TauriIpcTransport implements Transport {
   }
 
   send(msg: ClientMsg) {
+    if (this._destroyed) return
     if (msg.type === 'input') {
       const invokePromise = this._invoke('pty_write', { data: msg.data }) as Promise<void>
       void invokePromise.catch((err: unknown) => {
@@ -243,11 +271,12 @@ export class TauriIpcTransport implements Transport {
   }
 
   disconnect() {
-    this._invoke('pty_detach')
-    for (const u of this._unlistenFns) {
+    if (this._destroyed) return
+    this._destroyed = true
+    void this._invoke('pty_detach').catch(() => {})
+    for (const u of this._unlistenFns.splice(0)) {
       u()
     }
-    this._unlistenFns = []
   }
 }
 

--- a/frontend/src/test/AppPaneClose.test.ts
+++ b/frontend/src/test/AppPaneClose.test.ts
@@ -494,6 +494,27 @@ afterEach(() => {
   settings.mobile_input_mode = null
 })
 
+describe('App.vue - preview toolbar toggle', () => {
+  it('opens and closes the active terminal preview on consecutive clicks', async () => {
+    const wrapper = await mountWithTabs()
+    const session = useSessionStore()
+    const previewButton = wrapper.find('button[title="app.preview"]')
+    const tab = session.tabs[0]
+    if (tab.type !== 'terminal') throw new Error('expected terminal tab')
+
+    expect(tab.previewVisible).toBe(false)
+    expect(previewButton.attributes('aria-pressed')).toBe('false')
+
+    await previewButton.trigger('click')
+    expect(tab.previewVisible).toBe(true)
+    expect(previewButton.attributes('aria-pressed')).toBe('true')
+
+    await previewButton.trigger('click')
+    expect(tab.previewVisible).toBe(false)
+    expect(previewButton.attributes('aria-pressed')).toBe('false')
+  })
+})
+
 describe('App.vue - terminal-sequence app actions', () => {
   it('sends each exact sequence through the active terminal input path and no-ops unknown ids', async () => {
     const wrapper = await mountWithTabs()

--- a/frontend/src/test/PluginsTab.test.ts
+++ b/frontend/src/test/PluginsTab.test.ts
@@ -1,0 +1,73 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import PluginsTab from '../components/settings/PluginsTab.vue'
+
+const transportMocks = vi.hoisted(() => ({
+  isTauri: vi.fn(),
+  tauriInvoke: vi.fn(),
+}))
+
+const pluginMocks = vi.hoisted(() => ({
+  fetchMarket: vi.fn(),
+  fetchReadme: vi.fn(),
+  installFromMarket: vi.fn(),
+  loadAll: vi.fn(),
+  unloadPlugin: vi.fn(),
+}))
+
+vi.mock('../composables/useTransport', () => ({
+  isTauri: transportMocks.isTauri,
+  tauriInvoke: transportMocks.tauriInvoke,
+}))
+
+vi.mock('../composables/usePluginLoader', () => ({
+  usePluginLoader: () => ({
+    loadedPlugins: new Map(),
+    loadAll: pluginMocks.loadAll,
+    unloadPlugin: pluginMocks.unloadPlugin,
+  }),
+}))
+
+vi.mock('../composables/useMarketplace', async () => {
+  const { ref } = await import('vue')
+  return {
+    useMarketplace: () => ({
+      plugins: ref([]),
+      loading: ref(false),
+      error: ref(''),
+      installing: ref(new Set<string>()),
+      fetchMarket: pluginMocks.fetchMarket,
+      fetchReadme: pluginMocks.fetchReadme,
+      installFromMarket: pluginMocks.installFromMarket,
+    }),
+  }
+})
+
+describe('PluginsTab folder picker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    transportMocks.isTauri.mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('uses the native system picker when installing a plugin folder in Tauri', async () => {
+    transportMocks.tauriInvoke.mockResolvedValue('C:\\plugins\\sample')
+    const wrapper = mount(PluginsTab, {
+      global: { stubs: { ConfirmModal: true } },
+    })
+
+    await wrapper.findAll('.plugin-tab')[1].trigger('click')
+    await wrapper.find('.plugin-toolbar .plugin-action-btn').trigger('click')
+    await wrapper.get('.plugin-browse-btn').trigger('click')
+
+    expect(transportMocks.tauriInvoke).toHaveBeenCalledWith('pick_workspace_dir', {
+      base: undefined,
+    })
+    expect(wrapper.get('.plugin-browse-btn').text()).toBe('C:\\plugins\\sample')
+    expect(wrapper.findComponent({ name: 'FilePickerModal' }).exists()).toBe(false)
+    wrapper.unmount()
+  })
+})

--- a/frontend/src/test/SplitContainer.test.ts
+++ b/frontend/src/test/SplitContainer.test.ts
@@ -14,35 +14,63 @@ const TerminalPaneStub = defineComponent({
 })
 
 describe('SplitContainer shell info', function splitContainerShellInfoSuite() {
-  it('uses a centered SVG icon for the pane close control', function rendersCloseIcon() {
-    const wrapper = mount(SplitContainer, {
-      props: {
-        layout: {
-          type: 'leaf',
-          paneId: 'pane-1',
-          title: 'Terminal',
-          ratio: 1,
-          zoomed: false,
+  it.each(['horizontal', 'vertical'] as const)(
+    'anchors both %s split close controls to their pane headers',
+    async function rendersCloseIcons(direction) {
+      const wrapper = mount(SplitContainer, {
+        props: {
+          layout: {
+            type: 'split',
+            id: 'split-1',
+            direction,
+            ratios: [0.5, 0.5],
+            children: [
+              {
+                type: 'leaf',
+                paneId: 'pane-1',
+                title: 'Terminal 1',
+                ratio: 0.5,
+                zoomed: false,
+              },
+              {
+                type: 'leaf',
+                paneId: 'pane-2',
+                title: 'Terminal 2',
+                ratio: 0.5,
+                zoomed: false,
+              },
+            ],
+          },
+          activePaneId: 'pane-1',
+          broadcastMode: false,
+          broadcastActivity: 0,
+          showHeader: true,
+          allowClose: true,
+          tabId: 'tab-1',
         },
-        activePaneId: 'pane-1',
-        broadcastMode: false,
-        broadcastActivity: 0,
-        showHeader: true,
-        allowClose: true,
-        tabId: 'tab-1',
-      },
-      global: {
-        stubs: {
-          TerminalPane: TerminalPaneStub,
+        global: {
+          stubs: {
+            TerminalPane: TerminalPaneStub,
+          },
         },
-      },
-    })
+      })
 
-    const closeButton = wrapper.get('.pane-close-btn')
-    expect(closeButton.find('svg').exists()).toBe(true)
-    expect(closeButton.text()).toBe('')
-    wrapper.unmount()
-  })
+      const leaves = wrapper.findAll('.split-leaf')
+      expect(leaves).toHaveLength(2)
+      for (const leaf of leaves) {
+        const header = leaf.get('.pane-header')
+        const closeButton = header.get('.pane-close-btn')
+        expect(header.classes()).toContain(`direction-${direction}`)
+        expect(closeButton.find('svg').exists()).toBe(true)
+        expect(closeButton.text()).toBe('')
+      }
+
+      await leaves[0].get('.pane-close-btn').trigger('click')
+      await leaves[1].get('.pane-close-btn').trigger('click')
+      expect(wrapper.emitted('close')).toEqual([['pane-1'], ['pane-2']])
+      wrapper.unmount()
+    }
+  )
 
   it('forwards the leaf shell type with its pane id', async function forwardsShellInfo() {
     // 步骤1：挂载一个最小叶子终端，并替换真实终端实现。

--- a/frontend/src/test/SplitContainer.test.ts
+++ b/frontend/src/test/SplitContainer.test.ts
@@ -14,6 +14,36 @@ const TerminalPaneStub = defineComponent({
 })
 
 describe('SplitContainer shell info', function splitContainerShellInfoSuite() {
+  it('uses a centered SVG icon for the pane close control', function rendersCloseIcon() {
+    const wrapper = mount(SplitContainer, {
+      props: {
+        layout: {
+          type: 'leaf',
+          paneId: 'pane-1',
+          title: 'Terminal',
+          ratio: 1,
+          zoomed: false,
+        },
+        activePaneId: 'pane-1',
+        broadcastMode: false,
+        broadcastActivity: 0,
+        showHeader: true,
+        allowClose: true,
+        tabId: 'tab-1',
+      },
+      global: {
+        stubs: {
+          TerminalPane: TerminalPaneStub,
+        },
+      },
+    })
+
+    const closeButton = wrapper.get('.pane-close-btn')
+    expect(closeButton.find('svg').exists()).toBe(true)
+    expect(closeButton.text()).toBe('')
+    wrapper.unmount()
+  })
+
   it('forwards the leaf shell type with its pane id', async function forwardsShellInfo() {
     // 步骤1：挂载一个最小叶子终端，并替换真实终端实现。
     const wrapper = mount(SplitContainer, {

--- a/frontend/src/test/keybindings.test.ts
+++ b/frontend/src/test/keybindings.test.ts
@@ -113,6 +113,17 @@ describe('unified keybindings', () => {
     expect(useKeybindings().defs.some((def) => def.id === 'pasteTerminal')).toBe(false)
   })
 
+  it('renders every shortcut icon inside the same fixed alignment slot', () => {
+    const wrapper = trackWrapper(mount(KeyboardTab))
+    const rows = wrapper.findAll('[data-kb-id]')
+
+    expect(rows.length).toBeGreaterThan(0)
+    for (const row of rows) {
+      const label = row.get('.kb-shortcut-label')
+      expect(label.get('.kb-icon').find('svg').exists()).toBe(true)
+    }
+  })
+
   it('ignores a persisted pasteTerminal keybinding override', () => {
     settings.keybindings.pasteTerminal = { key: 'v', shift: false }
 

--- a/frontend/src/test/useTabLifecycleClose.test.ts
+++ b/frontend/src/test/useTabLifecycleClose.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref, shallowRef } from 'vue'
+import type { Tab } from '../types/pane'
+import type { Workspace } from '../types/workspace'
+
+const mocks = vi.hoisted(() => ({
+  apiCloseTab: vi.fn(),
+  clearFileWorkspaceState: vi.fn(),
+  invalidatePluginPreview: vi.fn(),
+}))
+
+vi.mock('../composables/useTabApi', () => ({
+  apiActivatePane: vi.fn(),
+  apiCloseTab: mocks.apiCloseTab,
+  apiCreateTab: vi.fn(),
+  apiCreateSshTab: vi.fn(),
+}))
+vi.mock('../composables/useTemplateApi', () => ({ apiApplyTemplate: vi.fn() }))
+vi.mock('../composables/useTerminal', () => ({ isKbTypingLocked: () => false }))
+vi.mock('../composables/useFileWorkspaceState', () => ({
+  clearFileWorkspaceState: mocks.clearFileWorkspaceState,
+}))
+vi.mock('../composables/useTabPreview', () => ({
+  invalidatePluginPreview: mocks.invalidatePluginPreview,
+}))
+
+import { useTabLifecycle } from '../composables/useTabLifecycle'
+
+function terminalTab(tabId: string, paneId: string): Tab {
+  return {
+    type: 'terminal',
+    paneId: tabId,
+    layout: { type: 'leaf', paneId, title: 'Terminal', ratio: 1, zoomed: false },
+    activePaneId: paneId,
+    paneMru: [paneId],
+    broadcastMode: false,
+    broadcastActivity: 0,
+    previewVisible: false,
+    previewAddress: '',
+    previewUrl: '',
+    previewKind: 'web',
+  }
+}
+
+function setup() {
+  const tabs = ref<Tab[]>([
+    terminalTab('tab-closing', 'pane-closing'),
+    terminalTab('tab-remaining', 'pane-remaining'),
+  ])
+  const activePaneId = ref<string | null>('tab-closing')
+  const termRef = { focus: vi.fn() }
+  const termRefs: Record<string, unknown> = { 'pane-closing': termRef }
+  const clearForPaneIds = vi.fn()
+  const lifecycle = useTabLifecycle({
+    tabs,
+    activePaneId,
+    session: { reorderTab: vi.fn(), renameTab: vi.fn() },
+    ui: { requestCloseTab: vi.fn(), requestClosePane: vi.fn(), cancelClose: vi.fn() },
+    appSettings: {},
+    activeWorkspaceId: ref<string | null>(null),
+    workspaces: ref<Workspace[]>([]),
+    matchWorkspace: () => null,
+    activateWorkspace: vi.fn(async () => true),
+    cancelPendingWorkspaceActivation: vi.fn(),
+    workspaceIdOfTab: () => null,
+    activeWorkspacePath: ref<string | undefined>(undefined),
+    notif: { clearForPaneIds },
+    termRefs,
+    isMobile: ref(false),
+    tabBarRef: ref(null),
+    persist: vi.fn(),
+    persistNow: vi.fn(),
+    onSshConnectRef: shallowRef(async () => {}),
+    sendSync: vi.fn(),
+    showCreateTerminalError: vi.fn(),
+  })
+  return { lifecycle, tabs, termRefs, termRef, clearForPaneIds }
+}
+
+describe('useTabLifecycle close consistency', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  it('keeps terminal state intact when the close request fails', async () => {
+    mocks.apiCloseTab.mockRejectedValueOnce(new Error('network failure'))
+    const { lifecycle, tabs, termRefs, termRef, clearForPaneIds } = setup()
+
+    await lifecycle.closeTab('tab-closing')
+
+    expect(tabs.value.map((tab) => tab.paneId)).toContain('tab-closing')
+    expect(termRefs['pane-closing']).toBe(termRef)
+    expect(mocks.clearFileWorkspaceState).not.toHaveBeenCalled()
+    expect(clearForPaneIds).not.toHaveBeenCalled()
+  })
+
+  it('cleans terminal state after the close request succeeds', async () => {
+    mocks.apiCloseTab.mockResolvedValueOnce(undefined)
+    const { lifecycle, tabs, termRefs, clearForPaneIds } = setup()
+
+    await lifecycle.closeTab('tab-closing')
+
+    expect(tabs.value.map((tab) => tab.paneId)).toEqual(['tab-remaining'])
+    expect(termRefs).not.toHaveProperty('pane-closing')
+    expect(mocks.clearFileWorkspaceState).toHaveBeenCalledWith('pane-closing')
+    expect(clearForPaneIds).toHaveBeenCalledWith(['tab-closing', 'pane-closing'], 'tab_close')
+  })
+})

--- a/frontend/src/test/useTransportCancellation.test.ts
+++ b/frontend/src/test/useTransportCancellation.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { TauriIpcTransport } from '../composables/useTransport'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+afterEach(() => {
+  delete (window as any).__TAURI__
+  vi.restoreAllMocks()
+})
+
+describe('TauriIpcTransport cancellation', () => {
+  it('stops initialization when disconnected during listener registration', async () => {
+    const pendingListener = deferred<() => void>()
+    const unlisten = vi.fn()
+    const listen = vi.fn().mockReturnValueOnce(pendingListener.promise)
+    const invoke = vi.fn().mockResolvedValue(undefined)
+    ;(window as any).__TAURI__ = {
+      core: { invoke },
+      event: { listen },
+    }
+
+    const transport = new TauriIpcTransport('closing-pane')
+    await vi.waitFor(() => expect(listen).toHaveBeenCalledOnce())
+
+    transport.disconnect()
+    pendingListener.resolve(unlisten)
+
+    await vi.waitFor(() => expect(unlisten).toHaveBeenCalledOnce())
+    expect(listen).toHaveBeenCalledOnce()
+    expect(invoke.mock.calls.some(([command]) => command === 'pty_spawn')).toBe(false)
+  })
+
+  it('ignores a pty_spawn result that arrives after disconnect', async () => {
+    const pendingSpawn = deferred<string>()
+    const unlisteners = Array.from({ length: 7 }, () => vi.fn())
+    let listenerIndex = 0
+    const listen = vi.fn(async () => unlisteners[listenerIndex++])
+    const invoke = vi.fn((command: string) => {
+      if (command === 'pty_spawn') return pendingSpawn.promise
+      return Promise.resolve(undefined)
+    })
+    ;(window as any).__TAURI__ = {
+      core: { invoke },
+      event: { listen },
+    }
+
+    const transport = new TauriIpcTransport('closing-pane')
+    const onConnect = vi.fn()
+    const onMessage = vi.fn()
+    transport.onConnect(onConnect)
+    transport.onMessage(onMessage)
+    await vi.waitFor(() =>
+      expect(invoke.mock.calls.some(([command]) => command === 'pty_spawn')).toBe(true)
+    )
+
+    transport.disconnect()
+    pendingSpawn.resolve('pwsh')
+
+    await vi.waitFor(() =>
+      expect(invoke.mock.calls.filter(([command]) => command === 'pty_detach')).toHaveLength(2)
+    )
+    expect(onConnect).not.toHaveBeenCalled()
+    expect(onMessage).not.toHaveBeenCalled()
+    for (const unlisten of unlisteners) expect(unlisten).toHaveBeenCalledOnce()
+  })
+})

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,7 +1,6 @@
 #![cfg_attr(all(not(debug_assertions), windows), windows_subsystem = "windows")]
 
 use base64::Engine;
-use dinotty_server::pty;
 use dinotty_server::session::{
     CloseReason, SessionClientEvent, SessionManager, SessionStatus, TauriOnExit,
 };
@@ -248,12 +247,19 @@ impl PtySpawnError {
     }
 }
 
+fn session_for_tauri_attach(
+    manager: &SessionManager,
+    pane_id: &str,
+) -> Result<Arc<dinotty_server::session::Session>, PtySpawnError> {
+    // Tabs and PTYs are created by the HTTP API; IPC must never resurrect a closed pane.
+    manager.session_for_attach(pane_id).ok_or_else(|| PtySpawnError::new("session_unavailable"))
+}
+
 #[tauri::command]
-async fn pty_spawn(
+fn pty_spawn(
     pane_id: String,
     app: AppHandle,
     state: State<'_, Arc<SessionManager>>,
-    shell_probe: State<'_, Arc<dinotty_server::platform::shell_probe::ShellProbeService>>,
 ) -> Result<String, PtySpawnError> {
     let manager = state.inner().clone();
     let app_cb = app.clone();
@@ -261,62 +267,37 @@ async fn pty_spawn(
         let _ = app_cb.emit("pty-exit", PtyExit { pane_id: pid, exit_code });
     });
 
-    if let Some(session) = manager.session_for_attach(&pane_id) {
-        // Publish the reap veto before lifecycle membership revalidation.
-        session.set_status(SessionStatus::Connected);
-        if !manager.is_current_session(&pane_id, &session) {
-            session.mark_failed_attach();
-            return Err(PtySpawnError::new("session_unavailable"));
-        }
-        manager.register_singleton_tab(&pane_id, &session, &session.shell_type);
-        {
-            let mut g = session.tauri_on_exit.lock().unwrap_or_else(|e| e.into_inner());
-            if g.is_none() {
-                *g = Some(Arc::clone(&exit_cb));
-            }
-        }
-        // Remove only the prior Tauri forwarder; WebSocket clients remain attached.
-        if let Some(client_id) =
-            session.tauri_client_id.lock().unwrap_or_else(|e| e.into_inner()).take()
-        {
-            session.remove_client(client_id);
-        }
-        // Spawn forwarder BEFORE emit_reconnected so the new client
-        // (snapshot_pending=true via add_client) is registered before the
-        // frontend receives pty-reconnected and (after converging) calls
-        // pty_snapshot_request. The snapshot_pending flag drops live Output
-        // for this client until ReplayEnd is enqueued.
-        spawn_tauri_output_forwarder(app.clone(), pane_id.clone(), Arc::clone(&session));
-        emit_reconnected(&app, &pane_id, &session);
-        // Set up channel-based write task (replaces old input channel, if any)
-        spawn_tauri_write_task(Arc::clone(&session), pane_id.clone());
-        return Ok(session.shell_type.clone());
+    let session = session_for_tauri_attach(&manager, &pane_id)?;
+    // Publish the reap veto before lifecycle membership revalidation.
+    session.set_status(SessionStatus::Connected);
+    if !manager.is_current_session(&pane_id, &session) {
+        session.mark_failed_attach();
+        return Err(PtySpawnError::new("session_unavailable"));
     }
-
-    let settings = dinotty_server::settings::load_settings();
-    let preference = dinotty_server::platform::shell::ShellPreference::new(
-        settings.shell,
-        settings.shell_path,
-        settings.wsl_distro,
-    );
-    let shell_spec =
-        shell_probe.resolve(&preference).await.map_err(|error| PtySpawnError::new(error.code))?;
-    let (session, shell_type) = pty::create_session(
-        &manager,
-        &pane_id,
-        None,
-        Some(Arc::clone(&exit_cb)),
-        None,
-        None,
-        Some(shell_spec),
-    )
-    .map_err(|_| PtySpawnError::new("pty_spawn_failed"))?;
-    manager.register_singleton_tab(&pane_id, &session, &shell_type);
-
+    manager.register_singleton_tab(&pane_id, &session, &session.shell_type);
+    {
+        let mut g = session.tauri_on_exit.lock().unwrap_or_else(|e| e.into_inner());
+        if g.is_none() {
+            *g = Some(Arc::clone(&exit_cb));
+        }
+    }
+    // Remove only the prior Tauri forwarder; WebSocket clients remain attached.
+    if let Some(client_id) =
+        session.tauri_client_id.lock().unwrap_or_else(|e| e.into_inner()).take()
+    {
+        session.remove_client(client_id);
+    }
+    // Spawn forwarder BEFORE emit_reconnected so the new client
+    // (snapshot_pending=true via add_client) is registered before the
+    // frontend receives pty-reconnected and (after converging) calls
+    // pty_snapshot_request. The snapshot_pending flag drops live Output
+    // for this client until ReplayEnd is enqueued.
     spawn_tauri_output_forwarder(app.clone(), pane_id.clone(), Arc::clone(&session));
+    emit_reconnected(&app, &pane_id, &session);
+    // Set up channel-based write task (replaces old input channel, if any)
     spawn_tauri_write_task(Arc::clone(&session), pane_id.clone());
 
-    Ok(shell_type)
+    Ok(session.shell_type.clone())
 }
 
 #[tauri::command]
@@ -981,5 +962,23 @@ mod launch_tests {
             LaunchIntent::parse(&args(&["dinotty", "--background", "--server"])),
             LaunchIntent::Invalid
         );
+    }
+}
+
+#[cfg(test)]
+mod pty_spawn_tests {
+    use super::*;
+
+    #[test]
+    fn unknown_pane_is_rejected_instead_of_recreated() {
+        let manager = SessionManager::new();
+
+        let error = session_for_tauri_attach(&manager, "closed-pane")
+            .err()
+            .expect("an unknown pane must not be recreated");
+
+        assert_eq!(error.code, "session_unavailable");
+        assert!(manager.sessions.is_empty());
+        assert!(manager.tab_layouts.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- align split-pane close controls and keyboard shortcut icons across layouts
- match plugin install actions to Dinotty styling and use the native folder picker on desktop
- make the terminal preview toolbar action toggle the panel open and closed
- prevent closed panes from reconnecting during asynchronous Tauri teardown

## Testing

- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test --workspace
- cd frontend && pnpm exec vue-tsc --noEmit
- cd frontend && pnpm test (95 files, 992 tests)