### PR TITLE
fix(settings): drop unused quick-send threshold test re-export

### DIFF
--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -28,8 +28,8 @@ pub use types::{
 pub(crate) use io::migrate_settings;
 #[cfg(test)]
 pub(crate) use normalize::{
-    clamp_custom_fonts, clamp_quick_send_threshold, clamp_text_config, clamp_text_on_load,
-    clamp_theme_on_put, normalize_action_keyboards,
+    clamp_custom_fonts, clamp_text_config, clamp_text_on_load, clamp_theme_on_put,
+    normalize_action_keyboards,
 };
 #[cfg(test)]
 pub(crate) use types::default_scroll_acceleration;


### PR DESCRIPTION
## Summary

- Remove `clamp_quick_send_threshold` from the `#[cfg(test)]` re-export list in `src/settings/mod.rs`
- The function has no test consumer (production code imports it directly from `io`/`handlers`), so the re-export was an unused import that broke CI test builds under `-D warnings` (Windows + all platforms with that flag)
- Verified locally: `cargo test -p dinotty-server --lib` passes (506 tests), clippy clean with `-D warnings`

## Test plan

- [ ] Windows CI test job passes
- [ ] Rust test build with `-D warnings` passes