### PR TITLE
fix(workspace): keep default plugin tabs visible

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -466,7 +466,11 @@ import {
 import WorkspaceOverview from './components/overview/WorkspaceOverview.vue'
 import { refreshPluginPreview, invalidatePluginPreview } from './composables/useTabPreview'
 import { useIsMobile } from './composables/useIsMobile'
-import { useWorkspaces, DEFAULT_WORKSPACE_ID } from './composables/useWorkspaces'
+import {
+  useWorkspaces,
+  DEFAULT_WORKSPACE_ID,
+  toActiveWorkspaceId,
+} from './composables/useWorkspaces'
 // formatCloseTabMessage moved to ConfirmCloseDialog component
 import LoginPage from './components/LoginPage.vue'
 import SetupPage from './components/SetupPage.vue'
@@ -621,9 +625,9 @@ const {
 
 function workspaceIdOfTab(tab: Tab): string | null {
   if (tab.type === 'plugin') {
-    return tab.workspaceId ?? workspaceIdFromPaneId(tab.paneId) ?? null
+    return toActiveWorkspaceId(tab.workspaceId ?? workspaceIdFromPaneId(tab.paneId))
   }
-  return (
+  return toActiveWorkspaceId(
     matchWorkspace(
       tab.cwd ?? '',
       tab.connectionId,
@@ -1589,8 +1593,11 @@ window.__dinotty_terminal_api = {
   },
   async createTerminalTab(opts: { cwd: string; argv: string[]; title?: string }) {
     const ws = matchWorkspace(opts.cwd)
-    const targetId = ws?.id ?? null
-    if (targetId !== activeWorkspaceId.value) await activateWorkspace(targetId)
+    const targetId = toActiveWorkspaceId(ws?.id)
+    if (targetId !== activeWorkspaceId.value) {
+      const committed = await activateWorkspace(targetId)
+      if (!committed) return ''
+    }
     return newTab(opts.cwd, opts.argv, opts.title)
   },
 }

--- a/frontend/src/composables/__tests__/useWorkspaces.spec.ts
+++ b/frontend/src/composables/__tests__/useWorkspaces.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import {
   DEFAULT_WORKSPACE_ID,
   isPathWithinWorkspace,
+  toActiveWorkspaceId,
   useWorkspaces,
   workspaceBasename,
 } from '../useWorkspaces'
@@ -25,6 +26,13 @@ function makeTab(paneId: string, cwd?: string): TerminalTab {
 }
 
 describe('workspace path helpers', () => {
+  it('normalizes the default workspace sentinel to the runtime null identity', () => {
+    expect(toActiveWorkspaceId(undefined)).toBeNull()
+    expect(toActiveWorkspaceId(null)).toBeNull()
+    expect(toActiveWorkspaceId(DEFAULT_WORKSPACE_ID)).toBeNull()
+    expect(toActiveWorkspaceId('workspace-a')).toBe('workspace-a')
+  })
+
   it.each([
     [String.raw`C:\repo\dinotty`, 'dinotty'],
     ['C:/repo/dinotty/', 'dinotty'],

--- a/frontend/src/composables/useOverviewCallbacks.ts
+++ b/frontend/src/composables/useOverviewCallbacks.ts
@@ -5,6 +5,7 @@ import { ensureSplitRoot } from '../types/pane'
 import type { TerminalTab, Tab } from '../types/pane'
 import type { SyncClientMsg } from '../types/protocol'
 import { useMissionControlState } from './useMissionControlState'
+import { toActiveWorkspaceId } from './useWorkspaces'
 
 export interface OverviewCallbacksOptions {
   tabs: Ref<Tab[]>
@@ -96,15 +97,16 @@ export function useOverviewCallbacks(opts: OverviewCallbacksOptions): OverviewCa
 
   async function onOverviewNewTab(cwd?: string, workspaceId?: string | null): Promise<void> {
     closeOverview()
-    if (workspaceId !== undefined && workspaceId !== activeWorkspaceId.value) {
+    const targetWorkspaceId = toActiveWorkspaceId(workspaceId)
+    if (workspaceId !== undefined && targetWorkspaceId !== activeWorkspaceId.value) {
       try {
-        if (!(await activateWorkspace(workspaceId))) return
+        if (!(await activateWorkspace(targetWorkspaceId))) return
       } catch (e) {
         console.error('Failed to activate workspace:', e)
         return
       }
     }
-    await newTab(cwd, undefined, undefined, workspaceId)
+    await newTab(cwd, undefined, undefined, targetWorkspaceId)
   }
 
   async function onOverviewNewTabSsh(
@@ -114,10 +116,11 @@ export function useOverviewCallbacks(opts: OverviewCallbacksOptions): OverviewCa
   ): Promise<void> {
     closeOverview()
     try {
+      const targetWorkspaceId = toActiveWorkspaceId(workspaceId)
       if (
         workspaceId !== undefined
-        && workspaceId !== activeWorkspaceId.value
-        && !(await activateWorkspace(workspaceId))
+        && targetWorkspaceId !== activeWorkspaceId.value
+        && !(await activateWorkspace(targetWorkspaceId))
       ) return
       const result = await apiCreateSshTab(connectionId, initialCwd, workspaceId)
       const resolvedWorkspaceId = result.workspace_id ?? workspaceId

--- a/frontend/src/composables/useSyncWebSocket.ts
+++ b/frontend/src/composables/useSyncWebSocket.ts
@@ -18,7 +18,7 @@ import {
 } from './apiBase'
 import { isTauri } from './useTransport'
 import { handlePluginChanged } from './usePluginLoader'
-import { useWorkspaces } from './useWorkspaces'
+import { toActiveWorkspaceId, useWorkspaces } from './useWorkspaces'
 import { apiCreatePluginTab } from './useTabApi'
 import { clearFileWorkspaceState } from './useFileWorkspaceState'
 import { useMissionControlState } from './useMissionControlState'
@@ -111,9 +111,9 @@ export function useSyncWebSocket(opts: {
 
   function workspaceIdOfTab(tab: Tab): string | null {
     if (tab.type === 'plugin') {
-      return tab.workspaceId ?? workspaceIdFromPaneId(tab.paneId) ?? null
+      return toActiveWorkspaceId(tab.workspaceId ?? workspaceIdFromPaneId(tab.paneId))
     }
-    return (
+    return toActiveWorkspaceId(
       matchWorkspace(
         tab.cwd ?? '',
         tab.connectionId,
@@ -615,7 +615,7 @@ export function useSyncWebSocket(opts: {
         onSshAuthPrompt?.(msg.pane_id, msg.prompts)
       } else if (msg.type === 'workspace_list') {
         workspaces.value = msg.workspaces
-        activeWorkspaceId.value = msg.active_workspace_id
+        activeWorkspaceId.value = toActiveWorkspaceId(msg.active_workspace_id)
         workspaceListReceived = true
         if (pendingAutoNewTab) {
           pendingAutoNewTab = false
@@ -643,7 +643,7 @@ export function useSyncWebSocket(opts: {
           }
         }
       } else if (msg.type === 'workspace_activated') {
-        activeWorkspaceId.value = msg.id
+        activeWorkspaceId.value = toActiveWorkspaceId(msg.id)
       } else if (msg.type === 'workspace_reordered') {
         for (let i = 0; i < msg.ids.length; i++) {
           const ws = workspaces.value.find((w) => w.id === msg.ids[i])

--- a/frontend/src/composables/useTabLifecycle.ts
+++ b/frontend/src/composables/useTabLifecycle.ts
@@ -12,6 +12,7 @@ import { apiApplyTemplate } from './useTemplateApi'
 import type { SshConnectResult } from './useSshConnectFlow'
 import type { MarkReadReason } from './useNotification'
 import type { SyncClientMsg } from '../types/protocol'
+import { toActiveWorkspaceId } from './useWorkspaces'
 
 export interface TabLifecycleOptions {
   tabs: Ref<Tab[]>
@@ -184,7 +185,7 @@ export function useTabLifecycle(opts: TabLifecycleOptions): TabLifecycleState {
       const targetWorkspace = workspaceId
         ? (workspaces.value.find((w) => w.id === workspaceId) ?? null)
         : matchWorkspace(result.cwd ?? '', result.connection_id, undefined)
-      const targetWorkspaceId = targetWorkspace?.id ?? null
+      const targetWorkspaceId = toActiveWorkspaceId(targetWorkspace?.id)
 
       const tabFields = {
         cwd: result.cwd,
@@ -196,7 +197,7 @@ export function useTabLifecycle(opts: TabLifecycleOptions): TabLifecycleState {
       if (existing) {
         Object.assign(existing, tabFields)
         commitLocalActivePane(result.tab_id)
-        if (targetWorkspaceId && targetWorkspaceId !== activeWorkspaceId.value) {
+        if (targetWorkspace && targetWorkspaceId !== activeWorkspaceId.value) {
           await activateWorkspace(targetWorkspaceId)
         }
         persist()
@@ -216,7 +217,7 @@ export function useTabLifecycle(opts: TabLifecycleOptions): TabLifecycleState {
         ...tabFields,
       })
       commitLocalActivePane(result.tab_id)
-      if (targetWorkspaceId && targetWorkspaceId !== activeWorkspaceId.value) {
+      if (targetWorkspace && targetWorkspaceId !== activeWorkspaceId.value) {
         await activateWorkspace(targetWorkspaceId)
       }
       persist()
@@ -276,13 +277,14 @@ export function useTabLifecycle(opts: TabLifecycleOptions): TabLifecycleState {
     if (!tab) return false
 
     const targetWs = resolveTabWorkspace(tab)
+    const targetWorkspaceId = toActiveWorkspaceId(targetWs?.id)
     const needsSwitch =
       tab.type === 'terminal'
-        ? (targetWs?.id ?? null) !== activeWorkspaceId.value
-        : targetWs && targetWs.id !== activeWorkspaceId.value
+        ? targetWorkspaceId !== activeWorkspaceId.value
+        : !!targetWs && targetWorkspaceId !== activeWorkspaceId.value
     if (needsSwitch) {
       try {
-        const committed = await activateWorkspace(targetWs?.id ?? null)
+        const committed = await activateWorkspace(targetWorkspaceId)
         if (!committed) return false
       } catch {
         return false
@@ -333,13 +335,14 @@ export function useTabLifecycle(opts: TabLifecycleOptions): TabLifecycleState {
     if (!tab) return false
 
     const targetWs = resolveTabWorkspace(tab)
+    const targetWorkspaceId = toActiveWorkspaceId(targetWs?.id)
     const needsSwitch =
       tab.type === 'terminal'
-        ? (targetWs?.id ?? null) !== activeWorkspaceId.value
-        : targetWs && targetWs.id !== activeWorkspaceId.value
+        ? targetWorkspaceId !== activeWorkspaceId.value
+        : !!targetWs && targetWorkspaceId !== activeWorkspaceId.value
     if (needsSwitch) {
       try {
-        const committed = await activateWorkspace(targetWs?.id ?? null)
+        const committed = await activateWorkspace(targetWorkspaceId)
         if (!committed) return false
       } catch {
         return false

--- a/frontend/src/composables/useWorkspaces.ts
+++ b/frontend/src/composables/useWorkspaces.ts
@@ -15,6 +15,11 @@ import { useI18n } from './useI18n'
 
 export const DEFAULT_WORKSPACE_ID = '__default__'
 
+/** Convert a UI workspace identity into the canonical runtime active identity. */
+export function toActiveWorkspaceId(id: string | null | undefined): string | null {
+  return !id || id === DEFAULT_WORKSPACE_ID ? null : id
+}
+
 function isWindowsPath(path: string): boolean {
   return /^[A-Za-z]:[\\/]/.test(path) || /^(?:\\\\|\/\/)/.test(path)
 }
@@ -109,13 +114,14 @@ export function useWorkspaces() {
 
   async function activateWorkspace(id: string | null): Promise<boolean> {
     const gen = ++wsNavGen
-    if (id) {
-      await apiActivateWorkspace(id)
+    const activeId = toActiveWorkspaceId(id)
+    if (activeId) {
+      await apiActivateWorkspace(activeId)
     } else {
       await apiDeactivateWorkspace()
     }
     if (gen !== wsNavGen) return false
-    activeWorkspaceId.value = id
+    activeWorkspaceId.value = activeId
     return true
   }
 

--- a/frontend/src/test/appPaneClose/_setup.ts
+++ b/frontend/src/test/appPaneClose/_setup.ts
@@ -341,7 +341,10 @@ export const SplitContainerStub = defineComponent({
 
 export const TabBarStub = defineComponent({
   name: 'TabBar',
-  props: { indicators: { type: Object, default: () => ({}) } },
+  props: {
+    tabs: { type: Array as PropType<any[]>, default: () => [] },
+    indicators: { type: Object, default: () => ({}) },
+  },
   setup(props, { slots, expose }) {
     expose({
       hasTab: () => true,

--- a/frontend/src/test/appPaneClose/confirm-gate.test.ts
+++ b/frontend/src/test/appPaneClose/confirm-gate.test.ts
@@ -217,6 +217,94 @@ describe('App.vue - onClosePane routes through confirmation gate', () => {
     expect(session.activePaneId).toBe('workspace-a-successor')
   })
 
+  it('does not hop workspaces when closing a default-root tab selects a default successor', async () => {
+    const previousDefaultRoot = settings.default_workspace_root
+    settings.default_workspace_root = '/workspace/default'
+    try {
+      const wrapper = await mountWithTabs()
+      const session = useSessionStore()
+      const workspaceState = useWorkspaces()
+      workspaceState.activeWorkspaceId.value = null
+      const terminalTab = (paneId: string): Tab => ({
+        type: 'terminal',
+        paneId,
+        layout: {
+          type: 'leaf',
+          paneId: `${paneId}-leaf`,
+          title: paneId,
+          ratio: 1,
+          zoomed: false,
+        },
+        activePaneId: `${paneId}-leaf`,
+        paneMru: [`${paneId}-leaf`],
+        broadcastMode: false,
+        broadcastActivity: 0,
+        cwd: `/workspace/default/${paneId}`,
+      })
+      session.setTabs([terminalTab('default-closed'), terminalTab('default-successor')])
+      session.setActivePane('default-closed')
+      mocks.apiActivateWorkspace.mockClear()
+      mocks.apiDeactivateWorkspace.mockClear()
+
+      await (wrapper.vm as any).closeTab('default-closed')
+      await nextTick()
+
+      expect(session.activePaneId).toBe('default-successor')
+      expect(workspaceState.activeWorkspaceId.value).toBeNull()
+      expect(mocks.apiActivateWorkspace).not.toHaveBeenCalled()
+      expect(mocks.apiDeactivateWorkspace).not.toHaveBeenCalled()
+    } finally {
+      settings.default_workspace_root = previousDefaultRoot
+    }
+  })
+
+  it('deactivates once when closing a named workspace last tab selects a default successor', async () => {
+    const previousDefaultRoot = settings.default_workspace_root
+    settings.default_workspace_root = '/workspace/default'
+    try {
+      const wrapper = await mountWithTabs()
+      const session = useSessionStore()
+      const workspaceState = useWorkspaces()
+      workspaceState.workspaces.value = [
+        { id: 'workspace-a', name: 'Workspace A', path: '/workspace/a', order: 0 },
+      ]
+      workspaceState.activeWorkspaceId.value = 'workspace-a'
+      const terminalTab = (paneId: string, cwd: string): Tab => ({
+        type: 'terminal',
+        paneId,
+        layout: {
+          type: 'leaf',
+          paneId: `${paneId}-leaf`,
+          title: paneId,
+          ratio: 1,
+          zoomed: false,
+        },
+        activePaneId: `${paneId}-leaf`,
+        paneMru: [`${paneId}-leaf`],
+        broadcastMode: false,
+        broadcastActivity: 0,
+        cwd,
+      })
+      session.setTabs([
+        terminalTab('workspace-a-closed', '/workspace/a'),
+        terminalTab('default-successor', '/workspace/default/project'),
+      ])
+      session.setActivePane('workspace-a-closed')
+      mocks.apiActivateWorkspace.mockClear()
+      mocks.apiDeactivateWorkspace.mockClear()
+
+      await (wrapper.vm as any).closeTab('workspace-a-closed')
+      await nextTick()
+
+      expect(session.activePaneId).toBe('default-successor')
+      expect(workspaceState.activeWorkspaceId.value).toBeNull()
+      expect(mocks.apiActivateWorkspace).not.toHaveBeenCalled()
+      expect(mocks.apiDeactivateWorkspace).toHaveBeenCalledOnce()
+    } finally {
+      settings.default_workspace_root = previousDefaultRoot
+    }
+  })
+
   it('moves to the successor workspace when closing its active workspace last tab', async () => {
     const wrapper = await mountWithTabs()
     const session = useSessionStore()

--- a/frontend/src/test/appPaneClose/cross-workspace.test.ts
+++ b/frontend/src/test/appPaneClose/cross-workspace.test.ts
@@ -1,6 +1,13 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
-import { mountWithTabs, mocks, SplitContainerStub, localStorageMock } from './_setup'
+import {
+  mountWithTabs,
+  mocks,
+  SplitContainerStub,
+  TabBarStub,
+  localStorageMock,
+} from './_setup'
+import { settings } from '../../composables/useSettings'
 import { useSessionStore } from '../../stores/sessionStore'
 import { useWorkspaces } from '../../composables/useWorkspaces'
 import type { Tab } from '../../types/pane'
@@ -15,6 +22,25 @@ describe('App.vue - activateTab cross-workspace', () => {
     broadcastMode: false,
     broadcastActivity: 0,
     cwd,
+  })
+
+  const modernPluginTab = (workspaceId?: string): Tab => ({
+    type: 'terminal',
+    paneId: `plugin:session-browser:${workspaceId ?? ''}`,
+    layout: {
+      type: 'leaf',
+      kind: 'plugin',
+      paneId: `plugin:session-browser:${workspaceId ?? ''}`,
+      title: 'Session Browser',
+      pluginId: 'session-browser',
+      ratio: 1,
+      zoomed: false,
+    },
+    activePaneId: `plugin:session-browser:${workspaceId ?? ''}`,
+    paneMru: [`plugin:session-browser:${workspaceId ?? ''}`],
+    broadcastMode: false,
+    broadcastActivity: 0,
+    ...(workspaceId ? { workspaceId } : {}),
   })
 
   async function seedCrossWorkspaceTabs() {
@@ -46,6 +72,171 @@ describe('App.vue - activateTab cross-workspace', () => {
     expect(result).toBe(true)
     expect(mocks.apiDeactivateWorkspace).not.toHaveBeenCalled()
     expect(workspaceState.activeWorkspaceId.value).toBe('ws-active')
+  })
+
+  it('keeps a modern plugin scoped to its owning named workspace', async () => {
+    const wrapper = await mountWithTabs()
+    const session = useSessionStore()
+    const workspaceState = useWorkspaces()
+    workspaceState.workspaces.value = [
+      { id: 'ws-active', name: 'Active', path: '/workspace/active', order: 0 },
+      { id: 'ws-other', name: 'Other', path: '/workspace/other', order: 1 },
+    ]
+    session.setTabs([
+      modernPluginTab('ws-active'),
+      terminalTab('terminal-active', '/workspace/active'),
+      terminalTab('terminal-other', '/workspace/other'),
+      { type: 'plugin', paneId: 'legacy-plugin', title: 'Legacy', pluginId: 'legacy' },
+    ])
+
+    const visibleTabs = () => wrapper.findComponent(TabBarStub).props('tabs') as any[]
+
+    workspaceState.activeWorkspaceId.value = 'ws-active'
+    await nextTick()
+    expect(visibleTabs().map((tab) => tab.paneId)).toEqual([
+      'plugin:session-browser:ws-active',
+      'terminal-active',
+      'legacy-plugin',
+    ])
+
+    workspaceState.activeWorkspaceId.value = 'ws-other'
+    await nextTick()
+    expect(visibleTabs().map((tab) => tab.paneId)).toEqual([
+      'terminal-other',
+      'legacy-plugin',
+    ])
+
+    workspaceState.activeWorkspaceId.value = null
+    await nextTick()
+    expect(visibleTabs().map((tab) => tab.paneId)).toEqual(['legacy-plugin'])
+  })
+
+  it('keeps the runtime default workspace stable when activating a default-root terminal', async () => {
+    const previousDefaultRoot = settings.default_workspace_root
+    settings.default_workspace_root = '/workspace/default'
+    try {
+      const wrapper = await mountWithTabs()
+      const session = useSessionStore()
+      const workspaceState = useWorkspaces()
+      session.setTabs([
+        modernPluginTab(),
+        terminalTab('terminal-default', '/workspace/default/project'),
+      ])
+      session.setActivePane('plugin:session-browser:')
+      await nextTick()
+
+      const visibleTabs = () => wrapper.findComponent(TabBarStub).props('tabs') as any[]
+      expect(visibleTabs().map((tab) => tab.paneId)).toEqual([
+        'plugin:session-browser:',
+        'terminal-default',
+      ])
+      mocks.apiActivateWorkspace.mockClear()
+      mocks.apiDeactivateWorkspace.mockClear()
+
+      const result = await (wrapper.vm as any).activateTab('terminal-default')
+      await nextTick()
+
+      expect(result).toBe(true)
+      expect(workspaceState.activeWorkspaceId.value).toBeNull()
+      expect(mocks.apiActivateWorkspace).not.toHaveBeenCalled()
+      expect(mocks.apiDeactivateWorkspace).not.toHaveBeenCalled()
+      expect(visibleTabs().map((tab) => tab.paneId)).toEqual([
+        'plugin:session-browser:',
+        'terminal-default',
+      ])
+    } finally {
+      settings.default_workspace_root = previousDefaultRoot
+    }
+  })
+
+  it('keeps the runtime default workspace stable when revealing a default-root pane', async () => {
+    const previousDefaultRoot = settings.default_workspace_root
+    settings.default_workspace_root = '/workspace/default'
+    try {
+      const wrapper = await mountWithTabs()
+      const session = useSessionStore()
+      const workspaceState = useWorkspaces()
+      session.setTabs([
+        modernPluginTab(),
+        terminalTab('terminal-default', '/workspace/default/project'),
+      ])
+      session.setActivePane('plugin:session-browser:')
+      await nextTick()
+      mocks.apiActivateWorkspace.mockClear()
+      mocks.apiDeactivateWorkspace.mockClear()
+
+      const result = await (wrapper.vm as any).revealPane('terminal-default-leaf')
+      await nextTick()
+
+      expect(result).toBe(true)
+      expect(workspaceState.activeWorkspaceId.value).toBeNull()
+      expect(mocks.apiActivateWorkspace).not.toHaveBeenCalled()
+      expect(mocks.apiDeactivateWorkspace).not.toHaveBeenCalled()
+      expect(session.activePaneId).toBe('terminal-default')
+    } finally {
+      settings.default_workspace_root = previousDefaultRoot
+    }
+  })
+
+  it('creates a plugin-requested terminal in the current default workspace without a hop', async () => {
+    const previousDefaultRoot = settings.default_workspace_root
+    settings.default_workspace_root = '/workspace/default'
+    try {
+      await mountWithTabs()
+      const workspaceState = useWorkspaces()
+      workspaceState.activeWorkspaceId.value = null
+      mocks.apiCreateTab.mockClear()
+      mocks.apiActivateWorkspace.mockClear()
+      mocks.apiDeactivateWorkspace.mockClear()
+
+      const result = await window.__dinotty_terminal_api!.createTerminalTab({
+        cwd: '/workspace/default/plugin-output',
+        argv: ['echo', 'ok'],
+      })
+
+      expect(result).toBe('p-new')
+      expect(mocks.apiActivateWorkspace).not.toHaveBeenCalled()
+      expect(mocks.apiDeactivateWorkspace).not.toHaveBeenCalled()
+      expect(mocks.apiCreateTab).toHaveBeenCalledOnce()
+    } finally {
+      settings.default_workspace_root = previousDefaultRoot
+    }
+  })
+
+  it('abandons plugin terminal creation when its workspace hop is superseded', async () => {
+    const previousDefaultRoot = settings.default_workspace_root
+    settings.default_workspace_root = '/workspace/default'
+    try {
+      const wrapper = await mountWithTabs()
+      const session = useSessionStore()
+      const workspaceState = useWorkspaces()
+      workspaceState.workspaces.value = [
+        { id: 'workspace-a', name: 'Workspace A', path: '/workspace/a', order: 0 },
+      ]
+      workspaceState.activeWorkspaceId.value = 'workspace-a'
+      session.setTabs([terminalTab('terminal-current', '/workspace/a/project')])
+      session.setActivePane('terminal-current')
+      let releaseDeactivate!: () => void
+      mocks.apiDeactivateWorkspace.mockImplementationOnce(
+        () => new Promise<void>((resolve) => (releaseDeactivate = resolve))
+      )
+      mocks.apiCreateTab.mockClear()
+
+      const createPromise = window.__dinotty_terminal_api!.createTerminalTab({
+        cwd: '/workspace/default/plugin-output',
+        argv: ['echo', 'stale'],
+      })
+      await vi.waitFor(() => expect(mocks.apiDeactivateWorkspace).toHaveBeenCalledOnce())
+      expect(await (wrapper.vm as any).activateTab('terminal-current')).toBe(true)
+      releaseDeactivate()
+
+      expect(await createPromise).toBe('')
+      expect(workspaceState.activeWorkspaceId.value).toBe('workspace-a')
+      expect(session.activePaneId).toBe('terminal-current')
+      expect(mocks.apiCreateTab).not.toHaveBeenCalled()
+    } finally {
+      settings.default_workspace_root = previousDefaultRoot
+    }
   })
 
   it('switches to the default workspace for an ungrouped terminal tab', async () => {

--- a/frontend/src/test/useOverviewCallbacksWorkspace.test.ts
+++ b/frontend/src/test/useOverviewCallbacksWorkspace.test.ts
@@ -72,6 +72,17 @@ describe('useOverviewCallbacks workspace activation', () => {
     expect(newTab).toHaveBeenCalledOnce()
   })
 
+  it('treats the default workspace sentinel as the already-active runtime default', async () => {
+    const { options, activeWorkspaceId, activateWorkspace, newTab } = createOptions()
+    activeWorkspaceId.value = null
+    const callbacks = useOverviewCallbacks(options)
+
+    await callbacks.onOverviewNewTab('C:/work/default', '__default__')
+
+    expect(activateWorkspace).not.toHaveBeenCalled()
+    expect(newTab).toHaveBeenCalledWith('C:/work/default', undefined, undefined, null)
+  })
+
   it('activates a selected SSH workspace before creating its tab', async () => {
     const { options, activateWorkspace, tabs } = createOptions()
     mocks.apiCreateSshTab.mockResolvedValue({

--- a/frontend/src/test/useSyncWebSocketPluginWorkspace.test.ts
+++ b/frontend/src/test/useSyncWebSocketPluginWorkspace.test.ts
@@ -59,6 +59,7 @@ vi.mock('../composables/useWorkspaceApi', () => ({
 
 import { useSyncWebSocket } from '../composables/useSyncWebSocket'
 import { useWorkspaces } from '../composables/useWorkspaces'
+import { settings } from '../composables/useSettings'
 import { useSessionStore } from '../stores/sessionStore'
 
 function leaf(paneId: string): PaneLayout {
@@ -127,6 +128,37 @@ describe('useSyncWebSocket plugin workspace attribution', () => {
     })
 
     expect((session.tabs[0] as TerminalTab).workspaceId).toBe('workspace-a')
+  })
+
+  it('normalizes the default sentinel from workspace restore and activation broadcasts', async () => {
+    const { workspaceState, emit } = await setup()
+
+    emit({ type: 'workspace_list', workspaces: [], active_workspace_id: '__default__' })
+    expect(workspaceState.activeWorkspaceId.value).toBeNull()
+
+    workspaceState.activeWorkspaceId.value = 'workspace-a'
+    emit({ type: 'workspace_activated', id: '__default__' })
+    expect(workspaceState.activeWorkspaceId.value).toBeNull()
+  })
+
+  it('does not hop when a synchronized default close selects a default-root successor', async () => {
+    const previousDefaultRoot = settings.default_workspace_root
+    settings.default_workspace_root = '/workspace/default'
+    try {
+      const closed = terminal('default-closed', { cwd: '/workspace/default/closed' })
+      const successor = terminal('default-successor', { cwd: '/workspace/default/successor' })
+      const { session, workspaceState, emit } = await setup([closed, successor], closed.paneId)
+      workspaceState.activeWorkspaceId.value = null
+
+      emit({ type: 'tab_closed', pane_id: closed.paneId })
+
+      await vi.waitFor(() => expect(session.activePaneId).toBe(successor.paneId))
+      expect(workspaceState.activeWorkspaceId.value).toBeNull()
+      expect(mocks.apiActivateWorkspace).not.toHaveBeenCalled()
+      expect(mocks.apiDeactivateWorkspace).not.toHaveBeenCalled()
+    } finally {
+      settings.default_workspace_root = previousDefaultRoot
+    }
   })
 
   it('scenario 11: backfills an existing tab and persists the repair', async () => {

--- a/frontend/src/test/useTabLifecycleClose.test.ts
+++ b/frontend/src/test/useTabLifecycleClose.test.ts
@@ -5,6 +5,7 @@ import type { Workspace } from '../types/workspace'
 
 const mocks = vi.hoisted(() => ({
   apiCloseTab: vi.fn(),
+  apiApplyTemplate: vi.fn(),
   clearFileWorkspaceState: vi.fn(),
   invalidatePluginPreview: vi.fn(),
 }))
@@ -15,7 +16,7 @@ vi.mock('../composables/useTabApi', () => ({
   apiCreateTab: vi.fn(),
   apiCreateSshTab: vi.fn(),
 }))
-vi.mock('../composables/useTemplateApi', () => ({ apiApplyTemplate: vi.fn() }))
+vi.mock('../composables/useTemplateApi', () => ({ apiApplyTemplate: mocks.apiApplyTemplate }))
 vi.mock('../composables/useTerminal', () => ({ isKbTypingLocked: () => false }))
 vi.mock('../composables/useFileWorkspaceState', () => ({
   clearFileWorkspaceState: mocks.clearFileWorkspaceState,
@@ -38,7 +39,10 @@ function terminalTab(tabId: string, paneId: string): Tab {
   }
 }
 
-function setup() {
+function setup(options: {
+  activeWorkspaceId?: string | null
+  matchWorkspace?: () => Workspace | null
+} = {}) {
   const tabs = ref<Tab[]>([
     terminalTab('tab-closing', 'pane-closing'),
     terminalTab('tab-remaining', 'pane-remaining'),
@@ -47,16 +51,18 @@ function setup() {
   const termRef = { focus: vi.fn() }
   const termRefs: Record<string, unknown> = { 'pane-closing': termRef }
   const clearForPaneIds = vi.fn()
+  const activeWorkspaceId = ref<string | null>(options.activeWorkspaceId ?? null)
+  const activateWorkspace = vi.fn(async () => true)
   const lifecycle = useTabLifecycle({
     tabs,
     activePaneId,
     session: { reorderTab: vi.fn(), renameTab: vi.fn() },
     ui: { requestCloseTab: vi.fn(), requestClosePane: vi.fn(), cancelClose: vi.fn() },
     appSettings: {},
-    activeWorkspaceId: ref<string | null>(null),
+    activeWorkspaceId,
     workspaces: ref<Workspace[]>([]),
-    matchWorkspace: () => null,
-    activateWorkspace: vi.fn(async () => true),
+    matchWorkspace: options.matchWorkspace ?? (() => null),
+    activateWorkspace,
     cancelPendingWorkspaceActivation: vi.fn(),
     workspaceIdOfTab: () => null,
     activeWorkspacePath: ref<string | undefined>(undefined),
@@ -70,7 +76,7 @@ function setup() {
     sendSync: vi.fn(),
     showCreateTerminalError: vi.fn(),
   })
-  return { lifecycle, tabs, termRefs, termRef, clearForPaneIds }
+  return { lifecycle, tabs, termRefs, termRef, clearForPaneIds, activeWorkspaceId, activateWorkspace }
 }
 
 describe('useTabLifecycle close consistency', () => {
@@ -101,5 +107,59 @@ describe('useTabLifecycle close consistency', () => {
     expect(termRefs).not.toHaveProperty('pane-closing')
     expect(mocks.clearFileWorkspaceState).toHaveBeenCalledWith('pane-closing')
     expect(clearForPaneIds).toHaveBeenCalledWith(['tab-closing', 'pane-closing'], 'tab_close')
+  })
+})
+
+describe('useTabLifecycle template workspace identity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.apiApplyTemplate.mockResolvedValue({
+      tab_id: 'template-tab',
+      layout: {
+        type: 'leaf',
+        paneId: 'template-pane',
+        title: 'Template',
+        ratio: 1,
+        zoomed: false,
+      },
+      cwd: '/workspace/default/project',
+      connection_id: null,
+      warnings: [],
+    })
+  })
+
+  const defaultWorkspace: Workspace = {
+    id: '__default__',
+    name: 'Default',
+    path: '/workspace/default',
+    order: 0,
+  }
+
+  it('stores default template ownership as undefined without a same-workspace hop', async () => {
+    const { lifecycle, tabs, activateWorkspace } = setup({
+      matchWorkspace: () => defaultWorkspace,
+    })
+
+    await lifecycle.applyTemplate('template-default')
+
+    expect(activateWorkspace).not.toHaveBeenCalled()
+    expect(tabs.value.find((tab) => tab.paneId === 'template-tab')).toMatchObject({
+      workspaceId: undefined,
+    })
+  })
+
+  it('deactivates to the default workspace before selecting a default template tab', async () => {
+    const { lifecycle, tabs, activateWorkspace } = setup({
+      activeWorkspaceId: 'workspace-a',
+      matchWorkspace: () => defaultWorkspace,
+    })
+
+    await lifecycle.applyTemplate('template-default')
+
+    expect(activateWorkspace).toHaveBeenCalledOnce()
+    expect(activateWorkspace).toHaveBeenCalledWith(null)
+    expect(tabs.value.find((tab) => tab.paneId === 'template-tab')).toMatchObject({
+      workspaceId: undefined,
+    })
   })
 })


### PR DESCRIPTION
## Summary

- normalize the default-workspace UI sentinel to the runtime `null` representation at tab navigation, restore, overview, template, and close-successor boundaries
- keep modern plugin tabs workspace-scoped while preventing same-default-workspace tab switches from hiding them
- guard plugin-requested terminal creation against superseded workspace navigation
- preserve legacy global plugin-tab behavior and named-workspace isolation

## Verification

- focused Vitest: 6 files, 90 tests passed
- full frontend Vitest suite passed
- production frontend build passed
- ESLint passed for every changed TypeScript/Vue file
- `cargo test --workspace` passed, including Windows smoke, terminal-exit, and authentication suites
- Cargo metadata resolved for `x86_64-pc-windows-msvc`, `aarch64-apple-darwin`, and `x86_64-unknown-linux-gnu`
- Windows NSIS `0.21.0` built and installed; Chrome QA passed repeated Session Browser → Terminal → Session Browser switching and reload persistence

Full-repository ESLint still reports five pre-existing errors in unchanged files (`CsvPreview.vue`, `useNotification.ts`, `useOpenApiTest.ts`, and `usePluginLoader.ts`).

## Platform coverage

The product change is shared Vue/TypeScript workspace-state logic with no OS-specific branches. Windows received native build/install/runtime QA. macOS and Linux received dependency-resolution and packaging-configuration checks; native runtime execution remains CI coverage on their respective runners.
