### PR TITLE
ci: add xdg-utils for linux-arm64 AppImage bundling

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -174,6 +174,7 @@ jobs:
             libxdo-dev \
             librsvg2-dev \
             patchelf \
+            xdg-utils \
             wget
 
       - name: Install frontend dependencies


### PR DESCRIPTION
## Summary
- Add `xdg-utils` to the Linux bundle dependencies in `package.yml`.
- Fixes linux-arm64 AppImage bundling failure: `xdg-open binary not found /usr/bin/xdg-open` on `ubuntu-22.04-arm`.

## Test plan
- [ ] Re-tag v0.21.0 on main and verify the Package workflow's linux-arm64 AppImage bundle step succeeds