### PR TITLE
fix(notification): preserve history across page reloads

### DIFF
--- a/frontend/src/components/notification/NotificationPanel.vue
+++ b/frontend/src/components/notification/NotificationPanel.vue
@@ -19,7 +19,7 @@
       />
       <div v-if="notifications.length === 0" class="panel-empty">{{ t('notification.empty') }}</div>
     </div>
-    <button v-if="notifications.length > 0" class="panel-clear" @click="clearAll">
+    <button class="panel-clear" @click="clearAll">
       {{ t('notification.clearAll') }}
     </button>
   </div>

--- a/frontend/src/composables/__tests__/useNotificationProtocol.spec.ts
+++ b/frontend/src/composables/__tests__/useNotificationProtocol.spec.ts
@@ -47,7 +47,9 @@ import { settings } from '../useSettings'
 import {
   __dispatchServerMessageForTest,
   __pendingRequestCountForTest,
+  __restoreNotificationSessionHistoryForTest,
   __resetForTest,
+  NOTIFICATION_SESSION_HISTORY_KEY,
   useNotification,
   type NotificationItem,
 } from '../useNotification'
@@ -227,6 +229,147 @@ describe('useNotification protocol dispatcher', () => {
       legacyEvent({ pane_id: '', notifId: 'notif-1', eventSeq: '11', body: 'new epoch' })
     )
     expect(notif.historyCount.value).toBe(4)
+  })
+
+  it('restores notification cards across a page reload before the same-epoch snapshot arrives', () => {
+    const notif = current()
+    __dispatchServerMessageForTest(snapshot('1'))
+    __dispatchServerMessageForTest(legacyEvent({ body: 'survives reload' }))
+    __dispatchServerMessageForTest(
+      legacyEvent({ pane_id: '', notifId: 'notif-1', eventSeq: '2', body: 'plugin survives' })
+    )
+
+    const persisted = sessionStorage.getItem(NOTIFICATION_SESSION_HISTORY_KEY)
+    expect(persisted).not.toBeNull()
+
+    notif.notifications.value = []
+    sessionStorage.setItem(NOTIFICATION_SESSION_HISTORY_KEY, persisted!)
+    __restoreNotificationSessionHistoryForTest()
+
+    expect(notif.notifications.value.map(({ body }) => body)).toEqual([
+      'plugin survives',
+      'survives reload',
+    ])
+
+    __dispatchServerMessageForTest(snapshot(
+      '2',
+      [{ paneId: 'pane-a', latestEventSeq: '1', readThroughSeq: '0', severity: 'info' }],
+      [{ notifId: 'notif-1', read: false }],
+    ))
+    expect(notif.unreadAttentionCount.value).toBe(2)
+    expect(notif.notifications.value).toHaveLength(2)
+  })
+
+  it('ignores corrupt persisted notification history', () => {
+    const notif = current()
+    sessionStorage.setItem(NOTIFICATION_SESSION_HISTORY_KEY, '{not-json')
+
+    __restoreNotificationSessionHistoryForTest()
+
+    expect(notif.notifications.value).toEqual([])
+    expect(sessionStorage.getItem(NOTIFICATION_SESSION_HISTORY_KEY)).toBeNull()
+  })
+
+  it('defers restored-card dismissal until the first snapshot resolves its epoch', () => {
+    const notif = current()
+    sessionStorage.setItem(NOTIFICATION_SESSION_HISTORY_KEY, JSON.stringify([{
+      id: 'restored-pane',
+      type: 'warning',
+      paneId: 'pane-a',
+      title: null,
+      body: 'restored',
+      timestamp: 100,
+      source: 'terminal',
+      eventSeq: '1',
+      epoch: 'epoch-a',
+    }]))
+    __restoreNotificationSessionHistoryForTest()
+
+    notif.dismissOne('restored-pane')
+
+    expect(notif.notifications.value).toHaveLength(1)
+    expect(syncMock.sentPayloads).toEqual([])
+
+    __dispatchServerMessageForTest(snapshot(
+      '1',
+      [{ paneId: 'pane-a', latestEventSeq: '1', readThroughSeq: '0', severity: 'warning' }],
+    ))
+
+    expect(notif.notifications.value).toEqual([])
+    expect(syncMock.sentPayloads).toHaveLength(1)
+    expect(syncMock.sentPayloads[0]).toMatchObject({
+      reason: 'dismiss',
+      panes: [{ paneId: 'pane-a', throughEventSeq: '1' }],
+    })
+  })
+
+  it('defers restored-card clear actions until the first snapshot can mark their targets read', () => {
+    const notif = current()
+    sessionStorage.setItem(NOTIFICATION_SESSION_HISTORY_KEY, JSON.stringify([
+      {
+        id: 'restored-pane', type: 'info', paneId: 'pane-a', title: null,
+        body: 'pane', timestamp: 100, source: 'terminal', eventSeq: '1', epoch: 'epoch-a',
+      },
+      {
+        id: 'restored-notif', type: 'success', title: null,
+        body: 'plugin', timestamp: 101, source: 'plugin', eventSeq: '2',
+        notifId: 'notif-a', epoch: 'epoch-a',
+      },
+    ]))
+    __restoreNotificationSessionHistoryForTest()
+
+    notif.clearForPaneIds(['pane-a'], 'tab_activate')
+    notif.clearAll()
+
+    expect(notif.notifications.value).toHaveLength(2)
+    expect(syncMock.sentPayloads).toEqual([])
+
+    __dispatchServerMessageForTest(snapshot(
+      '1',
+      [{ paneId: 'pane-a', latestEventSeq: '1', readThroughSeq: '0', severity: 'info' }],
+      [{ notifId: 'notif-a', read: false }],
+    ))
+
+    expect(notif.notifications.value).toEqual([])
+    expect(syncMock.sentPayloads.map(({ reason }) => reason)).toEqual(['tab_activate', 'clear_all'])
+    expect(notif.unreadAttentionCount.value).toBe(0)
+  })
+
+  it('keeps restored-card actions deferred when a delta arrives before the first snapshot', () => {
+    const notif = current()
+    sessionStorage.setItem(NOTIFICATION_SESSION_HISTORY_KEY, JSON.stringify([{
+      id: 'restored-pane',
+      type: 'warning',
+      paneId: 'pane-a',
+      title: null,
+      body: 'restored',
+      timestamp: 100,
+      source: 'terminal',
+      eventSeq: '1',
+      epoch: 'epoch-a',
+    }]))
+    __restoreNotificationSessionHistoryForTest()
+
+    notif.clearAll()
+    __dispatchServerMessageForTest(delta(
+      '1',
+      [{ paneId: 'pane-a', latestEventSeq: '1', readThroughSeq: '0', severity: 'warning' }],
+    ))
+
+    expect(notif.notifications.value).toHaveLength(1)
+    expect(syncMock.sentPayloads).toEqual([])
+
+    __dispatchServerMessageForTest(snapshot(
+      '2',
+      [{ paneId: 'pane-a', latestEventSeq: '1', readThroughSeq: '0', severity: 'warning' }],
+    ))
+
+    expect(notif.notifications.value).toEqual([])
+    expect(syncMock.sentPayloads).toHaveLength(1)
+    expect(syncMock.sentPayloads[0]).toMatchObject({
+      reason: 'clear_all',
+      panes: [{ paneId: 'pane-a', throughEventSeq: '1' }],
+    })
   })
 
   it('keeps authoritative attention count independent from history count', () => {

--- a/frontend/src/composables/__tests__/useNotificationTriggers.spec.ts
+++ b/frontend/src/composables/__tests__/useNotificationTriggers.spec.ts
@@ -325,6 +325,50 @@ describe('raised envelope compatibility', () => {
 })
 
 describe('notification panel visibility', () => {
+  it('keeps the clear action visible when both history and unread attention are empty', async () => {
+    const notif = useNotification()
+    const wrapper = mount(NotificationPanel, {
+      props: { paneLabels: {} },
+    })
+
+    expect(notif.notifications.value).toEqual([])
+    expect(notif.unreadAttentionCount.value).toBe(0)
+    expect(wrapper.find('.panel-empty').exists()).toBe(true)
+    expect(wrapper.find('.panel-clear').exists()).toBe(true)
+
+    await wrapper.find('.panel-clear').trigger('click')
+
+    expect(syncMock.sentPayloads).toEqual([])
+    wrapper.unmount()
+  })
+
+  it('can clear authoritative unread attention when reconnect history is empty', async () => {
+    const notif = useNotification()
+    __dispatchServerMessageForTest(
+      snapshot('1', [
+        pane('pane-a', '1'),
+        pane('pane-b', '2'),
+        pane('pane-c', '3'),
+        pane('pane-d', '4'),
+      ])
+    )
+    notif.panelVisible.value = true
+    const wrapper = mount(NotificationPanel, {
+      props: { paneLabels: {} },
+    })
+
+    expect(notif.notifications.value).toEqual([])
+    expect(notif.unreadAttentionCount.value).toBe(4)
+    expect(wrapper.find('.panel-empty').exists()).toBe(true)
+
+    await wrapper.find('.panel-clear').trigger('click')
+
+    expect(notif.unreadAttentionCount.value).toBe(0)
+    expect(syncMock.sentPayloads).toHaveLength(1)
+    expect(syncMock.sentPayloads[0]).toMatchObject({ reason: 'clear_all' })
+    wrapper.unmount()
+  })
+
   it('hides the panel when a notification goto emits the pane target', async () => {
     const notif = useNotification()
     pushNotification({ type: 'info', body: 'done', paneId: 'pane-a' })

--- a/frontend/src/composables/useNotification.ts
+++ b/frontend/src/composables/useNotification.ts
@@ -94,8 +94,103 @@ const MAX_SEND_ATTEMPTS = 4
 const PENDING_CAP = 64
 const HISTORY_DEDUP_CAP = 512
 const PANEL_EMPTY_AUTOHIDE_MS = 250
+export const NOTIFICATION_SESSION_HISTORY_KEY = 'dinotty_notification_history_v1'
 
-const notifications = ref<NotificationItem[]>([])
+const notificationTypes = new Set<NotificationType>([
+  'info',
+  'success',
+  'warning',
+  'error',
+  'urgent',
+])
+
+function parseNotificationSessionHistory(raw: string | null): NotificationItem[] {
+  if (raw === null) return []
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.slice(0, 100).flatMap((value): NotificationItem[] => {
+      if (typeof value !== 'object' || value === null) return []
+      const item = value as Record<string, unknown>
+      if (
+        typeof item.id !== 'string' ||
+        !notificationTypes.has(item.type as NotificationType) ||
+        (item.title !== null && typeof item.title !== 'string') ||
+        typeof item.body !== 'string' ||
+        typeof item.timestamp !== 'number' ||
+        !Number.isFinite(item.timestamp) ||
+        (item.source !== undefined && item.source !== 'terminal' && item.source !== 'plugin') ||
+        (item.paneId !== undefined && typeof item.paneId !== 'string') ||
+        (item.eventSeq !== undefined && typeof item.eventSeq !== 'string') ||
+        (item.notifId !== undefined && typeof item.notifId !== 'string') ||
+        (item.epoch !== undefined && typeof item.epoch !== 'string')
+      ) return []
+      return [{
+        id: item.id,
+        type: item.type as NotificationType,
+        paneId: item.paneId as string | undefined,
+        title: item.title,
+        body: item.body,
+        timestamp: item.timestamp,
+        source: item.source as NotificationItem['source'],
+        eventSeq: item.eventSeq as string | undefined,
+        notifId: item.notifId as string | undefined,
+        epoch: item.epoch as string | undefined,
+      }]
+    })
+  } catch {
+    return []
+  }
+}
+
+function loadNotificationSessionHistory(): NotificationItem[] {
+  if (typeof sessionStorage === 'undefined') return []
+  try {
+    const raw = sessionStorage.getItem(NOTIFICATION_SESSION_HISTORY_KEY)
+    const items = parseNotificationSessionHistory(raw)
+    if (raw !== null && items.length === 0) {
+      sessionStorage.removeItem(NOTIFICATION_SESSION_HISTORY_KEY)
+    }
+    return items
+  } catch {
+    return []
+  }
+}
+
+function persistNotificationSessionHistory(items: NotificationItem[]) {
+  if (typeof sessionStorage === 'undefined') return
+  try {
+    if (items.length === 0) {
+      sessionStorage.removeItem(NOTIFICATION_SESSION_HISTORY_KEY)
+      return
+    }
+    sessionStorage.setItem(
+      NOTIFICATION_SESSION_HISTORY_KEY,
+      JSON.stringify(items.map(({
+        id,
+        type,
+        paneId,
+        title,
+        body,
+        timestamp,
+        source,
+        eventSeq,
+        notifId,
+        epoch,
+      }) => ({ id, type, paneId, title, body, timestamp, source, eventSeq, notifId, epoch }))),
+    )
+  } catch {
+    // Session storage is an optional reload bridge. The authoritative ledger and
+    // the panel's clear-all recovery path remain available when it is blocked.
+  }
+}
+
+const notifications = ref<NotificationItem[]>(loadNotificationSessionHistory())
+watch(
+  notifications,
+  (items) => persistNotificationSessionHistory(items),
+  { deep: true, flush: 'sync' },
+)
 const panelVisible = ref(false)
 let panelEmptyAutohideTimer: ReturnType<typeof setTimeout> | null = null
 
@@ -138,7 +233,7 @@ const firstUnreadAtByPane = shallowReactive<Record<string, number | null>>({})
 const projectionVersion = ref(0)
 const historyCount = computed(() => notifications.value.length)
 const unreadAttentionCount = computed(() => {
-  projectionVersion.value
+  void projectionVersion.value
   return attentionStore.unreadAttentionCount()
 })
 
@@ -148,6 +243,27 @@ let initialized = false
 let requestCounter = 0
 const pendingRequests = new Map<string, PendingRequest>()
 const historyDedup = new Set<string>()
+const deferredHistoryActions = new Map<string, () => void>()
+let hasReceivedInitialSnapshot = false
+
+function hasRestoredHistoryAwaitingSnapshot(predicate: (item: NotificationItem) => boolean) {
+  return !hasReceivedInitialSnapshot
+    && notifications.value.some((item) => item.epoch !== undefined && predicate(item))
+}
+
+function deferHistoryAction(key: string, action: () => void) {
+  if (deferredHistoryActions.size >= PENDING_CAP && !deferredHistoryActions.has(key)) {
+    const oldest = deferredHistoryActions.keys().next().value
+    if (oldest !== undefined) deferredHistoryActions.delete(oldest)
+  }
+  deferredHistoryActions.set(key, action)
+}
+
+function flushDeferredHistoryActions() {
+  const actions = [...deferredHistoryActions.values()]
+  deferredHistoryActions.clear()
+  for (const action of actions) action()
+}
 
 interface ActiveReadContext {
   getActiveFocusedPaneId: () => string | null
@@ -739,6 +855,9 @@ export function __dispatchServerMessageForTest(msg: unknown) {
       if (applied) cancelPresentationForState(snapshot)
       prunePendingWithoutOverlay()
       refreshProjection()
+      const receivedInitialSnapshot = applied && !hasReceivedInitialSnapshot
+      if (applied) hasReceivedInitialSnapshot = true
+      if (receivedInitialSnapshot) flushDeferredHistoryActions()
       if (applied) evaluateActiveRead()
       if (previousEpoch !== null && epochChanged) {
         resendPendingAfterSnapshot()
@@ -784,6 +903,11 @@ export function __pendingPresentationCountForTest(): number {
   return presentationScheduler.pendingCount()
 }
 
+export function __restoreNotificationSessionHistoryForTest() {
+  hasReceivedInitialSnapshot = false
+  notifications.value = loadNotificationSessionHistory()
+}
+
 export function __resetForTest() {
   resetPresentationEffects()
   clearPanelEmptyAutohide()
@@ -795,6 +919,8 @@ export function __resetForTest() {
   attentionStore = createAttentionStore()
   projectionVersion.value++
   historyDedup.clear()
+  deferredHistoryActions.clear()
+  hasReceivedInitialSnapshot = false
   idCounter = 0
   requestCounter = 0
   initialized = false
@@ -820,6 +946,10 @@ export function useNotification() {
     markNotifsRead,
     dismissOne(id: string) {
       const item = notifications.value.find((notification) => notification.id === id)
+      if (item && hasRestoredHistoryAwaitingSnapshot((candidate) => candidate.id === id)) {
+        deferHistoryAction(`dismiss:${id}`, () => useNotification().dismissOne(id))
+        return
+      }
       if (item) cancelPresentationForItem(item)
       notifications.value = notifications.value.filter((notification) => notification.id !== id)
       if (!item || item.epoch !== attentionStore.epoch) return
@@ -830,6 +960,10 @@ export function useNotification() {
       }
     },
     clearAll() {
+      if (hasRestoredHistoryAwaitingSnapshot(() => true)) {
+        deferHistoryAction('clear_all', () => useNotification().clearAll())
+        return
+      }
       presentationScheduler.cancelAllPanes()
       presentationScheduler.cancelAllNotifs()
       notifications.value = []
@@ -858,6 +992,14 @@ export function useNotification() {
     },
     clearForPaneIds(paneIds: string[], reason: MarkReadReason = 'tab_activate') {
       const idSet = new Set(paneIds)
+      if (hasRestoredHistoryAwaitingSnapshot(
+        (notification) => Boolean(notification.paneId && idSet.has(notification.paneId))
+      )) {
+        const deferredPaneIds = [...paneIds]
+        const key = `clear_panes:${reason}:${[...idSet].sort().join(',')}`
+        deferHistoryAction(key, () => useNotification().clearForPaneIds(deferredPaneIds, reason))
+        return
+      }
       notifications.value = notifications.value.filter(
         (notification) => !notification.paneId || !idSet.has(notification.paneId)
       )


### PR DESCRIPTION
## Summary

- preserve notification cards in session storage across page reloads so the panel history remains aligned with the authoritative unread badge
- defer dismiss/clear actions on restored cards until the first full snapshot establishes authoritative targets, including when a state delta arrives first
- keep the panel's clear action visible in an empty panel as a recovery path

## Why

After a page reload, the server-side unread ledger can restore the badge count while the in-memory notification card history starts empty. That leaves users with a non-zero badge and no corresponding cards to inspect or clear.

The session-scoped history bridge keeps the two surfaces aligned until the initial snapshot arrives. The authoritative ledger remains the source of truth; corrupt or unavailable session storage falls back safely.

## Testing

- `pnpm vitest run` — 103 files, 1045 tests passed
- `pnpm vue-tsc -b --noEmit`
- `pnpm build`
- `git diff --check`
- regression coverage for reload restore, corrupt storage, deferred dismiss/clear, delta-before-snapshot ordering, empty clear no-op, and authoritative unread clearing with empty local history
