### PR TITLE
feat: allow application shortcuts to repeat on hold

### DIFF
--- a/frontend/src/components/keyboard/MkbKey.vue
+++ b/frontend/src/components/keyboard/MkbKey.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, onBeforeUnmount } from 'vue'
 import type { AppActionOptions, KeyDef, ModState } from './mkbTypes'
 import { settings } from '../../composables/useSettings'
 
@@ -109,7 +109,7 @@ function fireWithFeedback() {
 function onTouchDown() {
   touchActive = true
   fireWithFeedback()
-  if (props.k.repeat && !props.k.act) {
+  if (props.k.repeat) {
     repeatTimer = setTimeout(() => {
       repeatInterval = setInterval(fireWithFeedback, 80)
     }, 400)
@@ -119,7 +119,7 @@ function onTouchDown() {
 function onMouseDown() {
   if (touchActive) return
   fireWithFeedback()
-  if (props.k.repeat && !props.k.act) {
+  if (props.k.repeat) {
     repeatTimer = setTimeout(() => {
       repeatInterval = setInterval(fireWithFeedback, 80)
     }, 400)
@@ -127,14 +127,7 @@ function onMouseDown() {
 }
 
 function onUp(e: Event) {
-  if (repeatTimer) {
-    clearTimeout(repeatTimer)
-    repeatTimer = null
-  }
-  if (repeatInterval) {
-    clearInterval(repeatInterval)
-    repeatInterval = null
-  }
+  stopRepeat()
   if (e.type === 'touchend' || e.type === 'touchcancel') {
     setTimeout(() => {
       touchActive = false
@@ -143,4 +136,17 @@ function onUp(e: Event) {
     touchActive = false
   }
 }
+
+function stopRepeat() {
+  if (repeatTimer) {
+    clearTimeout(repeatTimer)
+    repeatTimer = null
+  }
+  if (repeatInterval) {
+    clearInterval(repeatInterval)
+    repeatInterval = null
+  }
+}
+
+onBeforeUnmount(stopRepeat)
 </script>

--- a/frontend/src/components/settings/KeyboardTab.vue
+++ b/frontend/src/components/settings/KeyboardTab.vue
@@ -622,10 +622,10 @@
               <option value="danger">{{ t('settings.style.danger') }}</option>
             </select>
           </label>
-          <label v-if="akSupportsAutoEnter" class="shortcut-check">
+          <label v-if="akSupportsAutoEnter" class="shortcut-check ak-auto-enter-check">
             <input type="checkbox" v-model="akEdit.auto_enter" /> {{ t('settings.appendEnter') }}
           </label>
-          <label v-if="akEdit.kind === 'send' && !akIsEnterEdit" class="shortcut-check">
+          <label v-if="!akIsEnterEdit" class="shortcut-check ak-repeat-check">
             <input type="checkbox" v-model="akEdit.repeat" /> {{ t('settings.repeatHold') }}
           </label>
           <div class="ak-modal-actions">
@@ -1193,6 +1193,7 @@ function saveActionKey() {
           action: edit.action,
           display: edit.display,
           style: edit.style || undefined,
+          repeat: edit.repeat || undefined,
           ...(edit.action === 'pasteTerminal' ? { auto_enter: edit.auto_enter } : {}),
           grow: edit.grow,
         }

--- a/frontend/src/composables/useSettings.ts
+++ b/frontend/src/composables/useSettings.ts
@@ -284,7 +284,6 @@ function normalizeActionKey(key: ActionKey): void {
   if (key.kind !== 'action' || typeof key.action !== 'string' || key.action.trim() === '') return
   delete key.send
   delete key.special
-  delete key.repeat
   if (key.action === 'pasteTerminal') {
     if (typeof key.auto_enter !== 'boolean') key.auto_enter = true
   } else {

--- a/frontend/src/test/MkbKey.appAction.test.ts
+++ b/frontend/src/test/MkbKey.appAction.test.ts
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import MkbKey from '../components/keyboard/MkbKey.vue'
 
 vi.mock('../composables/useSettings', () => ({
@@ -7,6 +7,8 @@ vi.mock('../composables/useSettings', () => ({
 }))
 
 describe('MkbKey app-action options', () => {
+  afterEach(() => vi.useRealTimers())
+
   it.each([true, false])('emits the key autoEnter=%s value with the action id', async (autoEnter) => {
     const wrapper = mount(MkbKey, {
       props: {
@@ -42,5 +44,43 @@ describe('MkbKey app-action options', () => {
 
     expect(wrapper.emitted('app-action')).toEqual([[action, {}]])
     wrapper.unmount()
+  })
+
+  it('repeats an opted-in app action and stops on release', async () => {
+    vi.useFakeTimers()
+    const wrapper = mount(MkbKey, {
+      props: {
+        k: { l: 'New tab', act: 'newTab', repeat: true },
+        state: { shift: false, ctrl: false, alt: false },
+      },
+    })
+
+    await wrapper.trigger('mousedown')
+    expect(wrapper.emitted('app-action')).toHaveLength(1)
+    await vi.advanceTimersByTimeAsync(560)
+    expect(wrapper.emitted('app-action')!.length).toBeGreaterThan(2)
+
+    await wrapper.trigger('mouseup')
+    const countAfterRelease = wrapper.emitted('app-action')!.length
+    await vi.advanceTimersByTimeAsync(240)
+    expect(wrapper.emitted('app-action')).toHaveLength(countAfterRelease)
+    wrapper.unmount()
+  })
+
+  it('cancels pending action repeat when the key unmounts', async () => {
+    vi.useFakeTimers()
+    const wrapper = mount(MkbKey, {
+      props: {
+        k: { l: 'Close tab', act: 'closeTab', repeat: true },
+        state: { shift: false, ctrl: false, alt: false },
+      },
+    })
+
+    await wrapper.trigger('mousedown')
+    expect(wrapper.emitted('app-action')).toHaveLength(1)
+    const emissions = wrapper.emitted('app-action')!
+    wrapper.unmount()
+    await vi.advanceTimersByTimeAsync(640)
+    expect(emissions).toHaveLength(1)
   })
 })

--- a/frontend/src/test/actionKeyboard.test.ts
+++ b/frontend/src/test/actionKeyboard.test.ts
@@ -328,7 +328,7 @@ describe('normalizeActionKeyboard', () => {
     expect(keys).toEqual(before)
   })
 
-  it('purges send-only fields and stored icons from a valid action key', () => {
+  it('purges send-only fields and stored icons but preserves repeat on a valid action key', () => {
     const icon = { render: () => null }
     const key: ActionKey = {
       label: 'New tab',
@@ -347,9 +347,21 @@ describe('normalizeActionKeyboard', () => {
       label: 'New tab',
       kind: 'action',
       action: 'newTab',
+      repeat: true,
       style: 'danger',
       grow: 1.5,
     })
+  })
+
+  it('maps action repeat into the rendered key definition', () => {
+    expect(
+      actionKeyToKeyDef({
+        label: 'New tab',
+        kind: 'action',
+        action: 'newTab',
+        repeat: true,
+      }).repeat
+    ).toBe(true)
   })
 
   it('defaults and preserves per-key auto_enter only for pasteTerminal actions', () => {

--- a/frontend/src/test/keybindings.test.ts
+++ b/frontend/src/test/keybindings.test.ts
@@ -170,7 +170,7 @@ describe('unified keybindings', () => {
       await actionSelect.setValue('pasteTerminal')
       await nextTick()
       const autoEnter = wrapper.get<HTMLInputElement>(
-        '.ak-modal .shortcut-check input[type="checkbox"]',
+        '.ak-modal .ak-auto-enter-check input[type="checkbox"]',
       )
       expect(autoEnter.element.checked).toBe(true)
       await autoEnter.setValue(false)
@@ -211,10 +211,17 @@ describe('unified keybindings', () => {
 
       await actionSelect.setValue(id)
       await nextTick()
-      expect(wrapper.find('.ak-modal .shortcut-check input[type="checkbox"]').exists()).toBe(false)
+      expect(wrapper.find('.ak-modal .ak-auto-enter-check').exists()).toBe(false)
+      const repeat = wrapper.get<HTMLInputElement>('.ak-modal .ak-repeat-check input')
+      expect(repeat.element.checked).toBe(false)
+      await repeat.setValue(true)
 
       await wrapper.get('.ak-modal .settings-save').trigger('click')
-      expect(settings.action_keyboard.rows[0][0]).toMatchObject({ kind: 'action', action: id })
+      expect(settings.action_keyboard.rows[0][0]).toMatchObject({
+        kind: 'action',
+        action: id,
+        repeat: true,
+      })
       expect(settings.action_keyboard.rows[0][0]).not.toHaveProperty('auto_enter')
     } finally {
       settings.action_keyboard = previous

--- a/frontend/src/utils/actionKeyDef.ts
+++ b/frontend/src/utils/actionKeyDef.ts
@@ -45,6 +45,7 @@ export function actionKeyToKeyDef(ak: ActionKey, opts?: { bottomIdx?: number }):
           disabled: true,
         }
     if (ak.grow != null && ak.grow > 0) def.g = ak.grow
+    def.repeat = ak.repeat
     return def
   }
 

--- a/src/settings/normalize.rs
+++ b/src/settings/normalize.rs
@@ -230,7 +230,6 @@ fn normalize_action_key(key: &mut ActionKey) {
     if is_valid_action {
         key.send.clear();
         key.special = None;
-        key.repeat = false;
         if key.action.as_deref() == Some("pasteTerminal") {
             key.auto_enter.get_or_insert(true);
         } else {

--- a/src/settings/tests/action_keyboard.rs
+++ b/src/settings/tests/action_keyboard.rs
@@ -225,12 +225,13 @@ fn action_keyboard_normalize_applies_kind_contract() {
 
     assert!(keys[3].send.is_empty());
     assert!(keys[3].special.is_none());
-    assert!(!keys[3].repeat);
+    assert!(keys[3].repeat);
     assert_eq!(keys[3].auto_enter, None);
     let valid_action_json = serde_json::to_value(&keys[3]).unwrap();
-    for forbidden in ["send", "special", "repeat", "auto_enter"] {
+    for forbidden in ["send", "special", "auto_enter"] {
         assert!(valid_action_json.get(forbidden).is_none(), "{forbidden} survived");
     }
+    assert_eq!(valid_action_json["repeat"], true);
 
     assert_eq!(keys[4].auto_enter, Some(true));
     assert_eq!(keys[5].auto_enter, Some(false));

--- a/src/settings/types/action.rs
+++ b/src/settings/types/action.rs
@@ -58,6 +58,8 @@ impl Serialize for ActionKey {
             map.serialize_entry("send", &self.send)?;
             map.serialize_entry("repeat", &self.repeat)?;
             map.serialize_entry("special", &self.special)?;
+        } else if self.repeat {
+            map.serialize_entry("repeat", &true)?;
         }
         if (!is_valid_action || is_paste_action) && self.auto_enter.is_some() {
             map.serialize_entry("auto_enter", &self.auto_enter)?;


### PR DESCRIPTION
## Summary

- preserve the repeat setting for application action keys across Rust and frontend normalization
- expose the existing long-press repeat option in the action-key editor
- reuse the keyboard repeat timer for actions and cancel timers on release or unmount

## Verification

- frontend: 103 files / 1048 tests passed
- frontend production build passed
- targeted ESLint: 0 errors
- cargo fmt --check
- cargo clippy -- -D warnings
- cargo check
- cargo test --all-targets: 506 unit tests passed, 10 ignored, integration tests passed

Repeat remains opt-in per shortcut, matching the existing send-key behavior.