### PR TITLE
fix: size mobile keyboard to active panel

### DIFF
--- a/frontend/src/components/keyboard/MobileKeyboard.vue
+++ b/frontend/src/components/keyboard/MobileKeyboard.vue
@@ -353,7 +353,11 @@ import { formatMB, useUpload, type UploadProgress } from '../../composables/useU
 import type { UploadResponse } from '../../types/uploads'
 import { POSITION, useToast } from 'vue-toastification'
 import { useTextareaMetrics } from '../../composables/useTextareaMetrics'
-import { useSwipePanel } from '../../composables/useSwipePanel'
+import {
+  observeSwipePanelHeightTargets,
+  resolveSwipePanelHeight,
+  useSwipePanel,
+} from '../../composables/useSwipePanel'
 import { useKeyboardLayout } from '../../composables/useKeyboardLayout'
 import type { SendDataFn } from '../../utils/frozenSend'
 import { hasCollapseGuard } from '../../utils/keyboardGuardMode'
@@ -614,10 +618,7 @@ function onSpecial(sp: string) {
   if (sp === 'ctrl') modState.ctrl = !modState.ctrl
   if (sp === 'alt') modState.alt = !modState.alt
   if (sp === 'kbswitch') {
-    swipeTransition.value = true
-    kbMode.value = kbMode.value === 'action' ? 'default' : 'action'
-    if (kbMode.value === 'default') fetchSuggestions()
-    nextTick(applyHeight)
+    switchMode(kbMode.value === 'action' ? 'default' : 'action')
   }
   if (sp === 'bookmarks') {
     emit('bookmarks')
@@ -802,7 +803,7 @@ function applyHeight() {
   if (swipeContainerRef.value) {
     const mainH = mainPanel ? mainPanel.scrollHeight : 0
     const actionH = actionPanel ? actionPanel.scrollHeight : 0
-    swipeContainerRef.value.style.height = `${Math.max(mainH, actionH) + 2}px`
+    swipeContainerRef.value.style.height = `${resolveSwipePanelHeight(kbMode.value, mainH, actionH)}px`
   }
   const h = props.visible ? barRef.value.getBoundingClientRect().height : 0
   document.documentElement.style.setProperty('--mkb-height', `${h}px`)
@@ -917,7 +918,7 @@ onMounted(() => {
       cancelAnimationFrame(roAf)
       roAf = requestAnimationFrame(() => updateHeight())
     })
-    resizeObserver.observe(barRef.value)
+    observeSwipePanelHeightTargets(resizeObserver, barRef.value)
   }
 })
 

--- a/frontend/src/composables/useSwipePanel.ts
+++ b/frontend/src/composables/useSwipePanel.ts
@@ -23,6 +23,25 @@ export interface SwipePanelState {
   switchMode: (mode: 'default' | 'action') => void
 }
 
+// Preserve the existing clipping guard below each panel.
+const SWIPE_PANEL_HEIGHT_GUARD = 2
+
+export function resolveSwipePanelHeight(
+  mode: 'default' | 'action',
+  mainHeight: number,
+  actionHeight: number
+): number {
+  return (mode === 'default' ? mainHeight : actionHeight) + SWIPE_PANEL_HEIGHT_GUARD
+}
+
+export function observeSwipePanelHeightTargets(observer: ResizeObserver, bar: HTMLElement) {
+  observer.observe(bar)
+  for (const selector of ['#mkb-main-panel', '#mkb-action-panel']) {
+    const panel = bar.querySelector(selector)
+    if (panel) observer.observe(panel)
+  }
+}
+
 export function useSwipePanel(opts: SwipePanelOptions): SwipePanelState {
   const { kbMode, barRef, applyHeight, fetchSuggestions } = opts
 

--- a/frontend/src/styles/mobile-keyboard.css
+++ b/frontend/src/styles/mobile-keyboard.css
@@ -210,6 +210,7 @@
 .mkb-swipe-container {
   overflow: hidden;
   width: 100%;
+  transition: height 0.25s ease-out;
 }
 .mkb-swipe-track {
   display: flex;

--- a/frontend/src/test/useSwipePanel.test.ts
+++ b/frontend/src/test/useSwipePanel.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  observeSwipePanelHeightTargets,
+  resolveSwipePanelHeight,
+} from '../composables/useSwipePanel'
+
+describe('swipe panel height', () => {
+  it('uses the active panel height instead of reserving the taller panel', () => {
+    expect(resolveSwipePanelHeight('default', 420, 180)).toBe(422)
+    expect(resolveSwipePanelHeight('action', 420, 180)).toBe(182)
+  })
+
+  it('observes both intrinsic panels so active content changes update the height', () => {
+    const main = document.createElement('div')
+    main.id = 'mkb-main-panel'
+    const action = document.createElement('div')
+    action.id = 'mkb-action-panel'
+    const bar = document.createElement('div')
+    bar.append(main, action)
+    const observe = vi.fn()
+
+    observeSwipePanelHeightTargets({ observe } as unknown as ResizeObserver, bar)
+
+    expect(observe.mock.calls.map(([target]) => target)).toEqual([bar, main, action])
+  })
+})


### PR DESCRIPTION
## Summary

- size the built-in mobile keyboard swipe container from the currently active panel instead of the taller of both pages
- observe each panel intrinsic size so layout changes update the container
- animate height with the existing 250ms page transition and route the keyboard switch key through the shared switch function

## Verification

- focused swipe-panel tests: 2 passed
- full frontend suite: 104 files / 1047 tests passed
- frontend production build passed
- targeted ESLint: 0 errors

## Scope

This only affects Dinotty built-in keyboard page sizing. It does not change system-keyboard, visualViewport, terminal-input, or mobile IME behavior.

Device-side visual confirmation of the transition remains recommended.