### PR TITLE
fix(shell): suppress zsh's reverse-video cell before a wrapped double-width glyph

### DIFF
--- a/src/pty.rs
+++ b/src/pty.rs
@@ -631,6 +631,13 @@ ZDOTDIR=  # reset so child shells behave normally
 
 [[ -f "{home}/.zshrc" ]] && source "{home}/.zshrc"
 
+# dinotty: zsh paints the leftover cell before a wrapped double-width glyph as a
+# reverse-video block (man zshzle, "Wrapped double-width characters"). Suppress it,
+# but never override a value the user set themselves.
+if [[ -z "${{zle_highlight[(r)special:*]}}" ]]; then
+  zle_highlight+=(special:none)
+fi
+
 # Ensure history is saved — fallback if user config doesn't set these
 [[ $HISTSIZE -gt 0 ]] || HISTSIZE=10000
 [[ $SAVEHIST -gt 0 ]] || SAVEHIST=10000


### PR DESCRIPTION
### Problem

When a double-width character does not fit in the terminal's last column, zsh's line editor paints the leftover cell as a reverse-video block. This is documented zsh behaviour — `man zshzle`, under "Wrapped double-width characters" — and it shows up in Dinotty as a stray bright/white cell at the right edge of a line.

It is easy to mistake for a rendering bug in the terminal itself, because it moves around as the window is resized.

### Reproducing it

Resize the window in steps of one column with a line long enough to wrap on a double-width glyph. The cell appears and disappears with the column parity: it is present when the wrap lands such that one cell is left over, absent otherwise.

At a fixed width with identical content, the cell is present with the default `zle_highlight` and gone with `zle_highlight=(special:none)` — so the highlight setting, not the wrap itself, is what makes it visible.

### Fix

Set `zle_highlight+=(special:none)` in the zshrc that Dinotty synthesizes for the PTY, after sourcing the user's own `~/.zshrc`:

```zsh
if [[ -z "${zle_highlight[(r)special:*]}" ]]; then
  zle_highlight+=(special:none)
fi
```

Two things about the shape:

- **Guarded.** If the user already set a `special:...` entry themselves, theirs stands. We only fill in a default.
- **`special:none`, not a colour.** `none` means the cell carries no display attribute at all, so it renders as plain background under any theme. Picking a colour would only make it less visible on the themes we happened to test.

Because it is appended after the user's `~/.zshrc` is sourced, it also cannot clobber a setting made there.

### Scope

`src/pty.rs`, +7 lines inside the synthesized zshrc string. No behaviour change for anyone who has already configured `zle_highlight`.
