### PR TITLE
test(desktop): give the lifecycle suite a real localStorage so its 10 tests run

### DIFF
--- a/frontend/src/test/desktopLifecycle.test.ts
+++ b/frontend/src/test/desktopLifecycle.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import TrayVisibilityDialog from '../components/ui/TrayVisibilityDialog.vue'
 import WindowCloseDialog from '../components/ui/WindowCloseDialog.vue'
@@ -6,6 +6,43 @@ import {
   TRAY_VISIBILITY_CONFIRM_KEY,
   useDesktopLifecycle,
 } from '../composables/useDesktopLifecycle'
+
+class MemoryStorage implements Storage {
+  private data = new Map<string, string>()
+
+  get length() {
+    return this.data.size
+  }
+
+  clear() {
+    this.data.clear()
+  }
+
+  getItem(key: string) {
+    return this.data.get(key) ?? null
+  }
+
+  key(index: number) {
+    return [...this.data.keys()][index] ?? null
+  }
+
+  removeItem(key: string) {
+    this.data.delete(key)
+  }
+
+  setItem(key: string, value: string) {
+    this.data.set(key, String(value))
+  }
+}
+
+beforeEach(() => {
+  const storage = new MemoryStorage()
+  Object.defineProperty(window, 'localStorage', {
+    value: storage,
+    configurable: true,
+  })
+  vi.stubGlobal('localStorage', storage)
+})
 
 afterEach(() => {
   document.body.innerHTML = ''


### PR DESCRIPTION
### Problem

Every test in `frontend/src/test/desktopLifecycle.test.ts` fails on `dev` today:

```
 FAIL  src/test/desktopLifecycle.test.ts > desktop lifecycle > requires confirmation before the first Windows hide and remembers it
TypeError: Cannot read properties of undefined (reading 'getItem')
 ❯ src/test/desktopLifecycle.test.ts:69:32
```

`useDesktopLifecycle` persists the tray-visibility confirmation through `window.localStorage`, and the environment this file runs under does not provide one. So the file has been reporting 10 failures instead of exercising the behaviour it was written for.

Current `dev` (`492321dd`), full frontend suite:

```
 Test Files  1 failed | 103 passed (104)
      Tests  10 failed | 1040 passed (1050)
```

The single failing file is this one.

### Fix

Install a small in-memory `Storage` in `beforeEach`, through both `Object.defineProperty(window, 'localStorage', …)` and `vi.stubGlobal('localStorage', …)` so `window.localStorage` and the bare `localStorage` global resolve to the same object.

A fresh instance per test means the persistence assertions read what the test itself wrote, rather than leaking state between cases — which matters here, since several of these tests are specifically about *remembering* a confirmation across a second `useDesktopLifecycle` call.

### Result

No production code touched. The full suite goes green:

```
 Test Files  104 passed (104)
      Tests  1050 passed (1050)
```

`vue-tsc --noEmit` clean, `prettier --check` clean, and `eslint src/` is unchanged from the base (`580 problems, 4 errors, 576 warnings` before and after).
