### PR TITLE
fix(mobile): put toasts in a readable top-center strip instead of a 33vw corner sliver

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -424,7 +424,7 @@ import { pickSuccessorTab } from './utils/tabSuccessor'
 import { workspaceIdFromPaneId } from './utils/pluginPaneId'
 import { initMonitorHistory } from './composables/useMonitor'
 import NotificationPanel from './components/notification/NotificationPanel.vue'
-import { POSITION, useToast } from 'vue-toastification'
+import { useToast } from 'vue-toastification'
 import {
   useNotification,
   pushNotification,
@@ -487,6 +487,7 @@ import { readHostClipboard } from './utils/clipboard'
 import { hasCollapseGuard, hasOpenGuard } from './utils/keyboardGuardMode'
 import type { AppActionOptions } from './components/keyboard/mkbTypes'
 import { canFixShellErrorInSettings, shellErrorMessage } from './utils/shellError'
+import { resolveResponsiveToastPosition } from './utils/toastPosition'
 
 // ── Stores ──────────────────────────────────────────────────────
 const session = useSessionStore()
@@ -579,11 +580,12 @@ const hostClipboardPaste = createHostClipboardPasteController({
     getActiveTerminalRef()?.pasteFromClipboard(text, autoEnter, !systemActionKeyboardOpen.value)
   },
   clipboardEmpty: () =>
-    toast.info(t('mobileKb.clipboardEmpty'), { position: POSITION.BOTTOM_CENTER }),
-  pasteFailed: () => toast.error(t('mobileKb.pasteFailed'), { position: POSITION.BOTTOM_CENTER }),
+    toast.info(t('mobileKb.clipboardEmpty'), { position: resolveResponsiveToastPosition() }),
+  pasteFailed: () =>
+    toast.error(t('mobileKb.pasteFailed'), { position: resolveResponsiveToastPosition() }),
   confirmMultiline: (lines) =>
     toast.info(t('mobileKb.confirmMultiline', { n: lines }), {
-      position: POSITION.BOTTOM_CENTER,
+      position: resolveResponsiveToastPosition(),
     }),
 })
 const cursorPicker = useCursorPicker({

--- a/frontend/src/components/keyboard/MobileKeyboard.vue
+++ b/frontend/src/components/keyboard/MobileKeyboard.vue
@@ -351,7 +351,7 @@ import { shellEscapePath, trailingPathDeleteLen } from '../../utils/shell'
 import { isTauri } from '../../composables/useTransport'
 import { formatMB, useUpload, type UploadProgress } from '../../composables/useUpload'
 import type { UploadResponse } from '../../types/uploads'
-import { POSITION, useToast } from 'vue-toastification'
+import { useToast } from 'vue-toastification'
 import { useTextareaMetrics } from '../../composables/useTextareaMetrics'
 import {
   observeSwipePanelHeightTargets,
@@ -362,6 +362,7 @@ import { useKeyboardLayout } from '../../composables/useKeyboardLayout'
 import type { SendDataFn } from '../../utils/frozenSend'
 import { hasCollapseGuard } from '../../utils/keyboardGuardMode'
 import { isTouchDevice } from '../../utils/terminalInput'
+import { resolveResponsiveToastPosition } from '../../utils/toastPosition'
 
 const props = defineProps<{
   visible: boolean
@@ -745,9 +746,9 @@ async function onPhoneFileInputChange(ev: Event) {
     const paths = data.saved ?? []
     if (paths.length) insertTextAtCaret(paths.map(shellEscapePath).join(' '))
     window.dispatchEvent(new CustomEvent('dinotty-upload-status', { detail: data }))
-    toast.success(t('mobileKb.uploadDone'), { position: POSITION.BOTTOM_CENTER })
+    toast.success(t('mobileKb.uploadDone'), { position: resolveResponsiveToastPosition() })
   } catch (err) {
-    toast.error(uploadErrorMessage(err), { position: POSITION.BOTTOM_CENTER })
+    toast.error(uploadErrorMessage(err), { position: resolveResponsiveToastPosition() })
   } finally {
     phoneUploading.value = false
     phoneUploadProgress.value = 0

--- a/frontend/src/components/terminal/TerminalPane.vue
+++ b/frontend/src/components/terminal/TerminalPane.vue
@@ -100,7 +100,8 @@ import SearchBar from './SearchBar.vue'
 import TerminalContextMenu from './TerminalContextMenu.vue'
 import SelectionHandles from './SelectionHandles.vue'
 import { shellEscapePath } from '../../utils/shell'
-import { POSITION, useToast } from 'vue-toastification'
+import { resolveResponsiveToastPosition } from '../../utils/toastPosition'
+import { useToast } from 'vue-toastification'
 import { useI18n } from '../../composables/useI18n'
 import { useUpload } from '../../composables/useUpload'
 import { useScrollPosition, type ScrollPositionHandle } from '../../composables/useScrollPosition'
@@ -360,11 +361,11 @@ async function onMenuPaste() {
   }
 
   if (text === null) {
-    toast.error(t('mobileKb.pasteFailed'), { position: POSITION.BOTTOM_CENTER })
+    toast.error(t('mobileKb.pasteFailed'), { position: resolveResponsiveToastPosition() })
     return
   }
   if (text === '') {
-    toast.info(t('mobileKb.clipboardEmpty'), { position: POSITION.BOTTOM_CENTER })
+    toast.info(t('mobileKb.clipboardEmpty'), { position: resolveResponsiveToastPosition() })
     return
   }
   pasteFromClipboard(text, false)
@@ -1020,10 +1021,10 @@ onMounted(() => {
         const saved = data.saved ?? []
         if (saved.length) self.sendData(saved.map(shellEscapePath).join(' ') + ' ', true)
         window.dispatchEvent(new CustomEvent('dinotty-upload-status', { detail: data }))
-        toast.success(t('mobileKb.uploadDone'), { position: POSITION.BOTTOM_CENTER })
+        toast.success(t('mobileKb.uploadDone'), { position: resolveResponsiveToastPosition() })
       } catch (err) {
         if (!paneAlive) return
-        toast.error(uploadErrorMessage(err), { position: POSITION.BOTTOM_CENTER })
+        toast.error(uploadErrorMessage(err), { position: resolveResponsiveToastPosition() })
       }
     }
     const insertTurn = insertQueue.then(() => doInsert()).catch(() => undefined)

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -169,27 +169,36 @@ input {
   cursor: pointer;
 }
 
-@media (max-width: 480px) and (orientation: portrait) {
+@media (max-width: 768px) {
   .Vue-Toastification__container {
-    width: 33.33vw !important;
+    top: max(12px, env(safe-area-inset-top)) !important;
+    bottom: auto !important;
+    left: 50% !important;
+    right: auto !important;
+    width: min(420px, calc(100vw - 24px)) !important;
     min-width: 0 !important;
-    right: 8px !important;
-    left: auto !important;
     padding: 0 !important;
+    transform: translateX(-50%);
+    pointer-events: none;
   }
   .Vue-Toastification__toast {
+    width: 100% !important;
+    max-width: 100% !important;
     min-height: 0 !important;
-    padding: 6px 8px !important;
-    font-size: 10px !important;
+    margin-bottom: 8px !important;
+    padding: 8px 10px !important;
+    font-size: 12px !important;
+    overflow-wrap: anywhere;
+    pointer-events: auto;
   }
   .notif-toast-title {
-    font-size: 10px;
+    font-size: 12px;
   }
   .notif-toast-body {
-    font-size: 9px;
+    font-size: 11px;
   }
   .notif-toast-btn {
-    font-size: 9px;
-    padding: 2px 6px;
+    font-size: 11px;
+    padding: 3px 8px;
   }
 }

--- a/frontend/src/test/mobileToastLayout.test.ts
+++ b/frontend/src/test/mobileToastLayout.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { POSITION } from 'vue-toastification'
+import { resolveResponsiveToastPosition } from '../utils/toastPosition'
+
+describe('mobile toast layout', () => {
+  it('pins every mobile toast container to a safe top-center viewport slot', () => {
+    const css = readFileSync(join(process.cwd(), 'src/styles/base.css'), 'utf8')
+    const mobileRule = css.slice(css.indexOf('@media (max-width: 768px)'))
+
+    expect(mobileRule).toContain('top: max(12px, env(safe-area-inset-top)) !important')
+    expect(mobileRule).toContain('bottom: auto !important')
+    expect(mobileRule).toContain('left: 50% !important')
+    expect(mobileRule).toContain('transform: translateX(-50%)')
+    expect(mobileRule).toContain('width: min(420px, calc(100vw - 24px)) !important')
+    expect(mobileRule).toContain('overflow-wrap: anywhere')
+    expect(mobileRule).not.toContain('width: 33.33vw')
+  })
+
+  it('routes explicit mobile positions into the default container without changing desktop', () => {
+    expect(resolveResponsiveToastPosition(POSITION.BOTTOM_CENTER, 390)).toBe(POSITION.TOP_RIGHT)
+    expect(resolveResponsiveToastPosition(POSITION.BOTTOM_CENTER, 1024)).toBe(
+      POSITION.BOTTOM_CENTER
+    )
+  })
+})

--- a/frontend/src/utils/toastPosition.ts
+++ b/frontend/src/utils/toastPosition.ts
@@ -1,0 +1,8 @@
+import { POSITION } from 'vue-toastification'
+
+export function resolveResponsiveToastPosition(
+  desktopPosition: POSITION = POSITION.BOTTOM_CENTER,
+  viewportWidth = typeof window === 'undefined' ? Number.POSITIVE_INFINITY : window.innerWidth
+): POSITION {
+  return viewportWidth <= 768 ? POSITION.TOP_RIGHT : desktopPosition
+}


### PR DESCRIPTION
### Problem

On a phone, toasts render into a `33.33vw` container pinned to the bottom-right corner at 9–10px type.

Two things go wrong with that:

- A third of a phone's width is roughly 130px. Anything longer than a few words wraps into a tall, narrow column, and paths — which several of these toasts carry — overflow it.
- The bottom-right corner is where the on-screen keyboard and the mobile keyboard bar sit. The toast is frequently covered at the exact moment it appears.

The breakpoint is also `(max-width: 480px) and (orientation: portrait)`, so landscape phones and small tablets have been getting desktop toast geometry while the rest of the mobile CSS already switches at 768px.

### Fix

Move the mobile toast container to a top-center strip:

- `min(420px, calc(100vw - 24px))` wide, centered, offset by `max(12px, env(safe-area-inset-top))`
- 11–12px type instead of 9–10px, and `overflow-wrap: anywhere` so long paths break rather than overflow
- container is `pointer-events: none` with the toast itself `pointer-events: auto`, so the strip does not swallow taps on the terminal underneath
- breakpoint moves to `max-width: 768px`, matching the rest of the mobile CSS

Call sites passed `POSITION.BOTTOM_CENTER` explicitly, and an explicit position overrides the container CSS — so the CSS alone would not have taken effect. They now go through a small helper:

```ts
export function resolveResponsiveToastPosition(
  desktopPosition: POSITION = POSITION.BOTTOM_CENTER,
  viewportWidth = typeof window === 'undefined' ? Number.POSITIVE_INFINITY : window.innerWidth
): POSITION {
  return viewportWidth <= 768 ? POSITION.TOP_RIGHT : desktopPosition
}
```

Under 768px it returns `TOP_RIGHT` — the default container the CSS above styles — and above it passes the desktop position through untouched. **Desktop behaviour is unchanged.**

### Verification

Full frontend suite, this branch vs. its base, compared set for set:

```
base (492321dd)   Test Files  1 failed | 103 passed (104)
                       Tests  10 failed | 1040 passed (1050)

this branch       Test Files  1 failed | 104 passed (105)
                       Tests  10 failed | 1042 passed (1052)
```

The failing file is `desktopLifecycle.test.ts` in both — a pre-existing failure on `dev`, unrelated to this change (fixed separately in #252). The delta here is exactly +1 file / +2 tests, both passing.

`vue-tsc --noEmit` clean. `eslint src/` identical to base (`580 problems, 4 errors, 576 warnings` before and after).
