### PR TITLE
fix(mobile): stabilize native terminal input

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -4,7 +4,13 @@
   <div v-else-if="!authenticated" class="auth-probe-screen">
     <RefreshCw :size="20" class="auth-probe-spinner" />
   </div>
-  <div v-else id="app-root">
+  <div
+    v-else
+    id="app-root"
+    @mousedown.capture="onAppMouseReplayCapture"
+    @click.capture="onAppMouseReplayCapture"
+    @touchstart.capture="onAppTouchStartCapture"
+  >
     <TabBar
       ref="tabBarRef"
       :tabs="visibleTabList"
@@ -119,7 +125,9 @@
       id="tab-content"
       @mousedown.capture="onTabContentMouseDownCapture"
       @pointerdown.capture="onTabContentPointerDownCapture"
+      @touchstart.capture="onTabContentTouchStartCapture"
       @touchend="onTerminalTouch"
+      @touchcancel.capture="onTabContentTouchCancelCapture"
     >
       <div
         v-for="tab in tabs"
@@ -522,6 +530,12 @@ const previewMenuOpen = ref(false)
 let linkJustActivated = false
 let scrollGestureDetected = false
 let scrollGestureTimer = 0
+const TERMINAL_LONG_PRESS_MS = 500
+const TERMINAL_MOUSE_REPLAY_MS = 500
+let terminalTouchOpenPending = false
+let terminalTouchOpenStartedAt = 0
+let terminalTouchMouseReplayUntil = 0
+let terminalTouchFocusBlockUntil = 0
 // Sticky typing mode: true while the mobile keyboard's text input is focused.
 const kbTyping = ref(false)
 const terminalImeFocused = ref(false)
@@ -1398,6 +1412,15 @@ function onTerminalRunCode(e: Event) {
 }
 
 function onLinkActivate() {
+  if (
+    effectiveMobileInputMode.value === 'system' &&
+    terminalTouchMouseReplayUntil > 0
+  ) {
+    const withinReplayWindow = performance.now() < terminalTouchMouseReplayUntil
+    terminalTouchMouseReplayUntil = 0
+    if (withinReplayWindow) closeSystemIme()
+    return
+  }
   linkJustActivated = true
 }
 
@@ -1430,6 +1453,21 @@ function onOpenSettingsRequest() {
 // default does not cancel the subsequent click.
 function guardTerminalFocusEvent(e: Event) {
   const target = e.target as HTMLElement | null
+  // Rejected touches can still synthesize a mousedown. Stop it before xterm's
+  // bubble listener focuses the helper textarea; normal pointerdown is untouched.
+  if (
+    e.type === 'mousedown' &&
+    isTouchDevice() &&
+    effectiveMobileInputMode.value === 'system' &&
+    !terminalImeFocused.value &&
+    performance.now() < terminalTouchFocusBlockUntil &&
+    target?.closest('.terminal-pane-container') &&
+    !target.closest('input, textarea, select, [contenteditable="true"]')
+  ) {
+    e.preventDefault()
+    e.stopPropagation()
+    return
+  }
   if (
     isTouchDevice() &&
     effectiveMobileInputMode.value === 'system' &&
@@ -1454,10 +1492,57 @@ function onTabContentPointerDownCapture(e: PointerEvent) {
   guardTerminalFocusEvent(e)
 }
 
+function onAppMouseReplayCapture(e: MouseEvent) {
+  if (performance.now() >= terminalTouchMouseReplayUntil) {
+    terminalTouchMouseReplayUntil = 0
+    return
+  }
+  const target = e.target as HTMLElement | null
+  if (!target?.closest('#system-mobile-kb')) return
+  e.preventDefault()
+  e.stopPropagation()
+  if (e.type === 'click') terminalTouchMouseReplayUntil = 0
+}
+
+function onAppTouchStartCapture(e: TouchEvent) {
+  const target = e.target as HTMLElement | null
+  if (target?.closest('#system-mobile-kb')) terminalTouchMouseReplayUntil = 0
+}
+
+function armTerminalTouchOpen(e: Event) {
+  const target = e.target as HTMLElement | null
+  if (
+    isTouchDevice() &&
+    effectiveMobileInputMode.value === 'system' &&
+    !terminalImeFocused.value &&
+    target?.closest('.terminal-pane-container') &&
+    !target.closest('input, textarea, select, [contenteditable="true"]')
+  ) {
+    terminalTouchFocusBlockUntil = 0
+    terminalTouchOpenPending = true
+    terminalTouchOpenStartedAt = performance.now()
+  }
+}
+
+function onTabContentTouchStartCapture(e: TouchEvent) {
+  armTerminalTouchOpen(e)
+}
+
+function onTabContentTouchCancelCapture() {
+  terminalTouchOpenPending = false
+  terminalTouchFocusBlockUntil = performance.now() + TERMINAL_MOUSE_REPLAY_MS
+}
+
 function onTerminalTouch(e: TouchEvent) {
   if (!isTouchDevice()) return
+  const openPending = terminalTouchOpenPending
+  const endedAt = performance.now()
+  const heldFor = endedAt - terminalTouchOpenStartedAt
+  terminalTouchOpenPending = false
   const target = e.target as HTMLElement
   if (target.closest('.terminal-pane-container')) {
+    if (effectiveMobileInputMode.value === 'system' && openPending)
+      terminalTouchFocusBlockUntil = endedAt + TERMINAL_MOUSE_REPLAY_MS
     // Don't show keyboard when tapping a link (file path or URL)
     if (linkJustActivated) {
       linkJustActivated = false
@@ -1479,7 +1564,18 @@ function onTerminalTouch(e: TouchEvent) {
         effectiveMobileInputMode.value === 'system' ? closeSystemIme() : (kbVisible.value = false)
       return
     }
-    if (!hasOpenGuard(appSettings.keyboard_guard_mode)) requestTerminalKeyboard()
+    if (
+      effectiveMobileInputMode.value === 'system' &&
+      (!openPending || heldFor >= TERMINAL_LONG_PRESS_MS)
+    )
+      return
+    if (!hasOpenGuard(appSettings.keyboard_guard_mode)) {
+      if (effectiveMobileInputMode.value === 'system') {
+        terminalTouchFocusBlockUntil = 0
+        terminalTouchMouseReplayUntil = endedAt + TERMINAL_MOUSE_REPLAY_MS
+      }
+      requestTerminalKeyboard()
+    }
   }
 }
 
@@ -1971,7 +2067,9 @@ function onDocumentFocusIn(event: FocusEvent) {
     if (
       isTouchDevice() &&
       effectiveMobileInputMode.value === 'system' &&
-      hasOpenGuard(appSettings.keyboard_guard_mode) &&
+      (hasOpenGuard(appSettings.keyboard_guard_mode) ||
+        terminalTouchOpenPending ||
+        performance.now() < terminalTouchFocusBlockUntil) &&
       !terminalImeFocused.value
     ) {
       target.blur()

--- a/frontend/src/components/keyboard/MkbKey.vue
+++ b/frontend/src/components/keyboard/MkbKey.vue
@@ -77,7 +77,9 @@ const isModifier = computed(() => Boolean(parsedSpecial.value?.entry.modifier))
 const isModActive = computed(() => {
   if (!isModifier.value) return false
   const modifier = parsedSpecial.value?.entry.modifier
-  return modifier ? props.state[modifier] : false
+  if (!modifier || !props.state[modifier]) return false
+  const owner = props.state.activeSpecial?.[modifier]
+  return !owner || owner === parsedSpecial.value?.id
 })
 const isModLocked = computed(() => {
   const modifier = parsedSpecial.value?.entry.modifier

--- a/frontend/src/components/keyboard/MobileKeyboard.vue
+++ b/frontend/src/components/keyboard/MobileKeyboard.vue
@@ -368,8 +368,12 @@ import {
   mobileTerminalModifierActive,
   type MobileTerminalModifiers,
 } from '../../utils/terminalInput'
-import { parseKeyboardSpecial } from '../../utils/keyboardSpecialKeys'
-import { resolveResponsiveToastPosition } from '../../utils/toastPosition' 
+import {
+  parseKeyboardSpecial,
+  type KeyboardModifierFamily,
+  type KeyboardSpecialId,
+} from '../../utils/keyboardSpecialKeys'
+import { resolveResponsiveToastPosition } from '../../utils/toastPosition'
 
 const props = defineProps<{
   visible: boolean
@@ -457,6 +461,9 @@ const {
 })
 
 const modifierModes = reactive<MobileTerminalModifiers>(emptyMobileTerminalModifiers())
+const activeModifierSpecial = reactive<Partial<Record<KeyboardModifierFamily, KeyboardSpecialId>>>(
+  {}
+)
 const modState = computed<ModState>(() => ({
   ctrl: mobileTerminalModifierActive(modifierModes.ctrl),
   shift: mobileTerminalModifierActive(modifierModes.shift),
@@ -468,6 +475,7 @@ const modState = computed<ModState>(() => ({
     alt: modifierModes.alt === 'locked',
     meta: modifierModes.meta === 'locked',
   },
+  activeSpecial: activeModifierSpecial,
 }))
 
 const {
@@ -641,6 +649,7 @@ function onSpecial(sp: string) {
     const family = parsed.entry.modifier
     modifierModes[family] =
       modifierModes[family] === 'off' ? (parsed.behavior === 'lock' ? 'locked' : 'once') : 'off'
+    if (modifierModes[family] !== 'off') activeModifierSpecial[family] = parsed.id
   }
   if (sp === 'kbswitch') {
     switchMode(kbMode.value === 'action' ? 'default' : 'action')

--- a/frontend/src/components/keyboard/SystemKeyboardToolbar.vue
+++ b/frontend/src/components/keyboard/SystemKeyboardToolbar.vue
@@ -275,7 +275,11 @@ import {
   systemKeyboardLayoutStatus,
   systemKeyUnits,
 } from '../../utils/systemKeyboardLayout'
-import { parseKeyboardSpecial } from '../../utils/keyboardSpecialKeys'
+import {
+  parseKeyboardSpecial,
+  type KeyboardModifierFamily,
+  type KeyboardSpecialId,
+} from '../../utils/keyboardSpecialKeys'
 
 const props = defineProps<{
   visible: boolean
@@ -309,6 +313,9 @@ const historyItems = ref<SuggestionItem[]>([])
 const kbMode = ref<'default' | 'action'>('action')
 const expandedPanel = ref<'termius' | 'shortcuts'>('termius')
 const modifierModes = reactive<MobileTerminalModifiers>(emptyMobileTerminalModifiers())
+const activeModifierSpecial = reactive<Partial<Record<KeyboardModifierFamily, KeyboardSpecialId>>>(
+  {}
+)
 const modState = computed<ModState>(() => ({
   ctrl: mobileTerminalModifierActive(modifierModes.ctrl),
   shift: mobileTerminalModifierActive(modifierModes.shift),
@@ -320,6 +327,7 @@ const modState = computed<ModState>(() => ({
     alt: modifierModes.alt === 'locked',
     meta: modifierModes.meta === 'locked',
   },
+  activeSpecial: activeModifierSpecial,
 }))
 
 const { actionFirstRow, actionFollowingRows, actionBottom, actionBottomRows, actionEnter } =
@@ -525,6 +533,7 @@ function onSpecial(special: string) {
     const family = parsed.entry.modifier
     modifierModes[family] =
       modifierModes[family] === 'off' ? (parsed.behavior === 'lock' ? 'locked' : 'once') : 'off'
+    if (modifierModes[family] !== 'off') activeModifierSpecial[family] = parsed.id
   }
   if (special === 'bookmarks') emit('bookmarks')
   if (special === 'kbswitch') closeActionKeyboard()

--- a/frontend/src/components/keyboard/mkbTypes.ts
+++ b/frontend/src/components/keyboard/mkbTypes.ts
@@ -1,3 +1,5 @@
+import type { KeyboardModifierFamily, KeyboardSpecialId } from '../../utils/keyboardSpecialKeys'
+
 export interface KeyDef {
   l: string // label
   s?: string // send character
@@ -23,5 +25,6 @@ export interface ModState {
   ctrl: boolean
   alt: boolean
   meta: boolean
-  locked?: Partial<Record<keyof Omit<ModState, 'locked'>, boolean>>
+  locked?: Partial<Record<KeyboardModifierFamily, boolean>>
+  activeSpecial?: Partial<Record<KeyboardModifierFamily, KeyboardSpecialId>>
 }

--- a/frontend/src/composables/useTerminal.ts
+++ b/frontend/src/composables/useTerminal.ts
@@ -28,7 +28,10 @@ import {
   isShiftSymbolChar,
   isTouchDevice,
   mobileTerminalModifierActive,
+  normalizeTerminalTextareaSelection,
   stripImeConfirmSpace,
+  terminalTextareaEdit,
+  type TerminalTextareaSnapshot,
   type MobileTerminalModifiers,
 } from '../utils/terminalInput'
 import { createTerminalWheel, type TerminalWheel } from './useTerminalWheel'
@@ -48,7 +51,9 @@ export {
   isSinglePrintableAscii,
   isSinglePrintableGrapheme,
   isTouchDevice,
+  normalizeTerminalTextareaSelection,
   stripImeConfirmSpace,
+  terminalTextareaEdit,
   terminalKeybindingMatches,
 } from '../utils/terminalInput'
 
@@ -139,6 +144,10 @@ export class TerminalInstance {
   private _lastInputData = ''
   private _lastInputTime = 0
   private _symCredits: Array<{ data: string; src: 0 | 1; at: number }> = []
+  private _inputTextarea: HTMLTextAreaElement | null = null
+  private _ime229Baseline: TerminalTextareaSnapshot | null = null
+  private _ime229InputData: string | null = null
+  private _ime229Timer: ReturnType<typeof setTimeout> | null = null
   // IME composition state. Tracked via compositionstart/compositionend on the
   // xterm textarea so focusActive() can avoid .focus()/.blur()/.fit() during
   // composition - those calls interrupt the IME session and cause xterm's
@@ -301,6 +310,21 @@ export class TerminalInstance {
     const xt = this.xterm
     const { isAppShortcut } = useKeybindings()
     xt.attachCustomKeyEventHandler((e: KeyboardEvent) => {
+      const acceptsTextarea229 =
+        isTauri() || !isTouchDevice() || settings.mobile_input_mode === 'system'
+      const isTextarea229 =
+        acceptsTextarea229 &&
+        !e.isComposing &&
+        !this._composing &&
+        (e.keyCode === 229 || e.key === 'Process')
+      const ownsTextarea229 =
+        isTextarea229 || (acceptsTextarea229 && this._ime229Baseline != null && e.type === 'keyup')
+      if (ownsTextarea229) {
+        if (e.type === 'keydown' && !this._composing) this._startIme229()
+        else if (e.type === 'keyup') this._flushIme229(false)
+        return false
+      }
+      if (e.type === 'keydown' && this._ime229Baseline != null) this._flushIme229(true)
       if (e.type === 'keydown') {
         if (e.isComposing || (e as any).keyCode === 229 || e.key === 'Process') return true
 
@@ -437,6 +461,7 @@ export class TerminalInstance {
     this.xterm.loadAddon(this.searchAddon)
 
     const textarea = wrapper.querySelector('.xterm-helper-textarea') as HTMLTextAreaElement | null
+    this._inputTextarea = textarea
     if (textarea && isTouchDevice()) configureMobileInputTextarea(textarea)
     // Track IME composition state on all platforms so focusActive() can
     // defer .focus()/.blur()/.fit() during composition. Interrupting an
@@ -444,6 +469,7 @@ export class TerminalInstance {
     // text as raw input (P3).
     if (textarea) {
       const onStart = () => {
+        this._clearIme229()
         this._composing = true
         textarea.dataset.dinottyComposing = 'true'
       }
@@ -471,6 +497,11 @@ export class TerminalInstance {
       let _trackedTextareaValue = ''
       textarea.addEventListener('input', ((e: Event) => {
         const ie = e as InputEvent
+        if (this._ime229Baseline != null && !ie.isComposing) {
+          this._ime229InputData = ie.data
+          this._armIme229Fallback()
+          return
+        }
         if (ie.isComposing) return
         _trackedTextareaValue = textarea.value
       }) as EventListener)
@@ -494,6 +525,7 @@ export class TerminalInstance {
     }
     if (textarea && isTauri()) {
       const onImeInput = (e: InputEvent) => {
+        if (this._ime229Baseline != null) return
         if (e.inputType !== 'insertText') return
         const data = stripImeConfirmSpace(e.data || '')
         if (!isShiftSymbolChar(data)) return
@@ -732,6 +764,60 @@ export class TerminalInstance {
     }
   }
 
+  private _startIme229() {
+    if (!this._inputTextarea || this._ime229Baseline != null) return
+    this._ime229Baseline = {
+      value: this._inputTextarea.value,
+      selectionStart: this._inputTextarea.selectionStart,
+      selectionEnd: this._inputTextarea.selectionEnd,
+    }
+    this._armIme229Fallback()
+  }
+
+  private _armIme229Fallback() {
+    if (this._ime229Timer) clearTimeout(this._ime229Timer)
+    this._ime229Timer = setTimeout(() => {
+      this._ime229Timer = null
+      this._flushIme229(true)
+    }, 80)
+  }
+
+  private _flushIme229(clearEmpty: boolean) {
+    const before = this._ime229Baseline
+    const textarea = this._inputTextarea
+    if (!before || !textarea || this._composing) {
+      this._clearIme229()
+      return
+    }
+    const observed = {
+      value: textarea.value,
+      selectionStart: textarea.selectionStart,
+      selectionEnd: textarea.selectionEnd,
+    }
+    const after = normalizeTerminalTextareaSelection(before, observed, this._ime229InputData)
+    const data = terminalTextareaEdit(
+      before,
+      after,
+      this.xterm?.modes.applicationCursorKeysMode ?? false
+    )
+    if (!data && !clearEmpty) return
+    if (
+      after.selectionStart !== observed.selectionStart ||
+      after.selectionEnd !== observed.selectionEnd
+    ) {
+      textarea.setSelectionRange(after.selectionStart, after.selectionEnd)
+    }
+    this._clearIme229()
+    if (data) this._handleXtermData(data, true)
+  }
+
+  private _clearIme229() {
+    if (this._ime229Timer) clearTimeout(this._ime229Timer)
+    this._ime229Timer = null
+    this._ime229Baseline = null
+    this._ime229InputData = null
+  }
+
   private _resolveSym(data: string, src: 0 | 1, now: number): boolean {
     if (this._symCredits.length)
       this._symCredits = this._symCredits.filter((c) => now - c.at < IME_SYM_PAIR_MS)
@@ -744,7 +830,7 @@ export class TerminalInstance {
     return true
   }
 
-  private _handleXtermData(rawData: string) {
+  private _handleXtermData(rawData: string, fromIme229 = false) {
     // Mouse reports produced synchronously by our synthetic wheel dispatches
     // (wheel.sendWheelEvent) are legitimate identical repeats; the WKWebView
     // key-replay dedup below must not eat them.
@@ -752,6 +838,9 @@ export class TerminalInstance {
       this._emitInput(rawData)
       return
     }
+    // The non-composition 229 cycle owns the final textarea diff. xterm can
+    // also surface the same input through onData; accepting both duplicates it.
+    if (this._ime229Baseline != null) return
     const tauri = isTauri()
     let data = tauri ? stripImeConfirmSpace(rawData) : rawData
     if (!data) return
@@ -766,6 +855,10 @@ export class TerminalInstance {
     this._lastInputTime = now
     if (tauri && isShiftSymbolChar(data)) {
       if (!this._resolveSym(data, 1, now)) return
+    }
+    if (fromIme229 && (data.includes('\x1b') || data.includes('\x7f'))) {
+      this._emitInput(data)
+      return
     }
     const modified = applyMobileTerminalModifiers(data, this._mobileModifiers)
     data = modified.data
@@ -836,6 +929,8 @@ export class TerminalInstance {
     this._wheel = null
     this._touchCleanup?.()
     this._compositionCleanup?.()
+    this._clearIme229()
+    this._inputTextarea = null
     this._dropCleanup?.()
     this._dropCleanup = null
     this._overlayCtl?.cleanup()

--- a/frontend/src/composables/useTerminal.ts
+++ b/frontend/src/composables/useTerminal.ts
@@ -523,7 +523,7 @@ export class TerminalInstance {
         }
       }) as EventListener)
     }
-    if (textarea && isTauri()) {
+    if (textarea && (isTauri() || isTouchDevice())) {
       const onImeInput = (e: InputEvent) => {
         if (this._ime229Baseline != null) return
         if (e.inputType !== 'insertText') return
@@ -842,7 +842,8 @@ export class TerminalInstance {
     // also surface the same input through onData; accepting both duplicates it.
     if (this._ime229Baseline != null) return
     const tauri = isTauri()
-    let data = tauri ? stripImeConfirmSpace(rawData) : rawData
+    const rescueImeSymbols = tauri || isTouchDevice()
+    let data = rescueImeSymbols ? stripImeConfirmSpace(rawData) : rawData
     if (!data) return
     const now = performance.now()
     // Gate the WKWebView replay dedup to Tauri only. On web, browsers don't
@@ -853,7 +854,7 @@ export class TerminalInstance {
     if (tauri && isDuplicateOnData(data, this._lastInputData, this._lastInputTime, now)) return
     this._lastInputData = data
     this._lastInputTime = now
-    if (tauri && isShiftSymbolChar(data)) {
+    if (rescueImeSymbols && isShiftSymbolChar(data)) {
       if (!this._resolveSym(data, 1, now)) return
     }
     if (fromIme229 && (data.includes('\x1b') || data.includes('\x7f'))) {

--- a/frontend/src/test/MobileKeyboard.modifiers.test.ts
+++ b/frontend/src/test/MobileKeyboard.modifiers.test.ts
@@ -96,4 +96,38 @@ describe('MobileKeyboard modifier buttons', () => {
     await shiftHold.trigger('mousedown')
     expect(shiftHold.classes()).not.toContain('mkb-active')
   })
+
+  it('highlights the chosen Cmd/Win alias without activating its sibling', async () => {
+    settings.action_keyboard = {
+      rows: [
+        [
+          { label: 'Cmd', kind: 'send', special: 'cmd:lock', display: 'text' },
+          { label: 'Win', kind: 'send', special: 'win:lock', display: 'text' },
+        ],
+      ],
+      bottom: { rows: [], enter: { label: 'Enter', kind: 'send', send: '\r' } },
+    }
+    wrapper = mount(MobileKeyboard, {
+      props: { visible: true, paneId: 'p1', getSendFn: () => vi.fn() },
+      global: {
+        stubs: {
+          SuggestionBar: true,
+          HistoryPanel: true,
+          FilePickerModal: true,
+        },
+      },
+    })
+    const buttons = wrapper.findAll('#mkb-action-panel .mkb-btn')
+    const cmd = buttons.find((button) => button.text() === 'Cmd')!
+    const win = buttons.find((button) => button.text() === 'Win')!
+
+    await cmd.trigger('mousedown')
+    expect(cmd.classes()).toContain('mkb-active')
+    expect(win.classes()).not.toContain('mkb-active')
+
+    await cmd.trigger('mousedown')
+    await win.trigger('mousedown')
+    expect(cmd.classes()).not.toContain('mkb-active')
+    expect(win.classes()).toContain('mkb-active')
+  })
 })

--- a/frontend/src/test/SystemKeyboardToolbar.test.ts
+++ b/frontend/src/test/SystemKeyboardToolbar.test.ts
@@ -330,12 +330,46 @@ describe('SystemKeyboardToolbar', () => {
     wrapper.unmount()
   })
 
+  it('highlights only the selected alias for a shared modifier family', async () => {
+    settings.system_keyboard = {
+      upper: [],
+      pages: [
+        [
+          { label: 'Cmd', kind: 'send', special: 'cmd:lock', display: 'text' },
+          { label: 'Win', kind: 'send', special: 'win:lock', display: 'text' },
+          { label: 'Alt', kind: 'send', special: 'alt:lock', display: 'text' },
+          { label: 'Opt', kind: 'send', special: 'opt:lock', display: 'text' },
+        ],
+      ],
+      lower_enabled: true,
+      upper_pinned: 0,
+    }
+    const wrapper = mountToolbar()
+    const [cmd, win, alt, opt] = wrapper.findAll('.system-kb-lower-page .mkb-btn')
+
+    await cmd.trigger('mousedown')
+    expect(cmd.classes()).toContain('mkb-active')
+    expect(win.classes()).not.toContain('mkb-active')
+
+    await cmd.trigger('mousedown')
+    await win.trigger('mousedown')
+    expect(cmd.classes()).not.toContain('mkb-active')
+    expect(win.classes()).toContain('mkb-active')
+
+    await alt.trigger('mousedown')
+    expect(alt.classes()).toContain('mkb-active')
+    expect(opt.classes()).not.toContain('mkb-active')
+    wrapper.unmount()
+  })
+
   it('uses an unsuffixed modifier once and releases it after the next key', async () => {
     settings.system_keyboard = {
       upper: [],
       pages: [
         [
           { label: 'Legacy Ctrl', kind: 'send', special: 'ctrl', display: 'text' },
+          { label: 'Cmd once', kind: 'send', special: 'cmd', display: 'text' },
+          { label: 'Win sibling', kind: 'send', special: 'win', display: 'text' },
           { label: 'c', kind: 'send', send: 'c' },
         ],
       ],
@@ -345,7 +379,7 @@ describe('SystemKeyboardToolbar', () => {
     const send = vi.fn()
     const wrapper = mountToolbar(false, send)
 
-    const [ctrl, c] = wrapper.findAll('.system-kb-lower-page .mkb-btn')
+    const [ctrl, cmd, win, c] = wrapper.findAll('.system-kb-lower-page .mkb-btn')
     await ctrl.trigger('mousedown')
     expect(ctrl.classes()).toContain('mkb-active')
     expect(ctrl.classes()).not.toContain('mkb-locked')
@@ -358,6 +392,13 @@ describe('SystemKeyboardToolbar', () => {
     expect(wrapper.emitted('modifier-change')).toContainEqual([
       { ctrl: 'off', shift: 'off', alt: 'off', meta: 'off' },
     ])
+
+    await cmd.trigger('mousedown')
+    expect(cmd.classes()).toContain('mkb-active')
+    expect(win.classes()).not.toContain('mkb-active')
+    await c.trigger('mousedown')
+    expect(cmd.classes()).not.toContain('mkb-active')
+    expect(win.classes()).not.toContain('mkb-active')
     wrapper.unmount()
   })
 

--- a/frontend/src/test/appPaneClose/_setup.ts
+++ b/frontend/src/test/appPaneClose/_setup.ts
@@ -42,6 +42,7 @@ export const localStorageMock = {
 const mocks = vi.hoisted(() => {
   let notificationRequestIdCounter = 0
   return {
+    touchDevice: false,
     closePane: vi.fn<(paneId: string) => Promise<boolean>>(),
     splitPane: vi.fn(),
     insertNonTerminalPane: vi.fn<() => Promise<void>>(async () => {}),
@@ -119,7 +120,7 @@ vi.mock('../../composables/useTerminal', () => ({
   },
   configureAllMobileInputTextareas: () => {},
   isKbTypingLocked: () => false,
-  isTouchDevice: () => false,
+  isTouchDevice: () => mocks.touchDevice,
   setActivePaneId: () => {},
   setKbTypingLock: () => {},
 }))
@@ -499,6 +500,7 @@ afterEach(() => {
   mocks.onSystemKeyboardClose = undefined
   mocks.mintNotificationRequestId.mockClear()
   mocks.resetNotificationRequestIds()
+  mocks.touchDevice = false
   settings.mobile_input_mode = null
 })
 

--- a/frontend/src/test/appPaneClose/system-keyboard.test.ts
+++ b/frontend/src/test/appPaneClose/system-keyboard.test.ts
@@ -97,6 +97,30 @@ describe('App.vue - system keyboard dismissal', () => {
 })
 
 describe('App.vue - system keyboard state regressions', () => {
+  async function mountUnguardedTouchTerminal() {
+    mocks.touchDevice = true
+    settings.mobile_input_mode = 'system'
+    settings.system_toolbar_mode = 'persistent_mobile'
+    settings.keyboard_guard_mode = 'off'
+    useIsMobile().isMobile.value = true
+    const wrapper = await mountWithTabs()
+    const activeTerminal = {
+      setOutputListener: vi.fn(),
+      setVirtualModifiers: vi.fn(),
+      getTerminal: vi.fn(() => ({ touchMoved: false })),
+      focus: vi.fn(),
+      blur: vi.fn(),
+    }
+    await wrapper.findComponent(SplitContainerStub).vm.$emit('register', 'pane-1', activeTerminal)
+    const terminalSurface = document.createElement('div')
+    terminalSurface.className = 'terminal-pane-container'
+    const helper = document.createElement('textarea')
+    helper.className = 'xterm-helper-textarea'
+    document.body.appendChild(helper)
+    wrapper.get('#tab-content').element.appendChild(terminalSurface)
+    return { wrapper, activeTerminal, terminalSurface, helper }
+  }
+
   it('guards manual-open focus only on touch input', () => {
     const source = readFileSync(join(process.cwd(), 'src/App.vue'), 'utf8')
     const guard = source.match(
@@ -152,6 +176,116 @@ describe('App.vue - system keyboard state regressions', () => {
     expect(activeTerminal.focus).toHaveBeenCalledOnce()
     expect(toolbar.props('imeOpen')).toBe(true)
     textarea.remove()
+  })
+
+  it('serializes an unguarded terminal touch until touchend', async () => {
+    const { wrapper, activeTerminal, terminalSurface, helper } =
+      await mountUnguardedTouchTerminal()
+
+    terminalSurface.dispatchEvent(new TouchEvent('touchstart', { bubbles: true }))
+    helper.focus()
+    await nextTick()
+    expect(document.activeElement).not.toBe(helper)
+    expect(activeTerminal.focus).not.toHaveBeenCalled()
+
+    const touchEnd = new TouchEvent('touchend', { bubbles: true, cancelable: true })
+    terminalSurface.dispatchEvent(touchEnd)
+    await nextTick()
+    expect(touchEnd.defaultPrevented).toBe(false)
+    expect(activeTerminal.focus).toHaveBeenCalledOnce()
+    expect(wrapper.findComponent(SystemKeyboardToolbarStub).props('imeOpen')).toBe(true)
+    helper.remove()
+  })
+
+  it('keeps rejected terminal gestures from opening the system IME', async () => {
+    const { wrapper, activeTerminal, terminalSurface, helper } =
+      await mountUnguardedTouchTerminal()
+
+    terminalSurface.dispatchEvent(new TouchEvent('touchstart', { bubbles: true }))
+    helper.focus()
+    document.dispatchEvent(new Event('terminal-scroll'))
+    terminalSurface.dispatchEvent(new TouchEvent('touchend', { bubbles: true, cancelable: true }))
+    await nextTick()
+    expect(activeTerminal.focus).not.toHaveBeenCalled()
+    expect(document.activeElement).not.toBe(helper)
+    expect(wrapper.findComponent(SystemKeyboardToolbarStub).props('imeOpen')).toBe(false)
+
+    terminalSurface.dispatchEvent(new TouchEvent('touchstart', { bubbles: true }))
+    terminalSurface.dispatchEvent(new TouchEvent('touchcancel', { bubbles: true }))
+    await nextTick()
+    expect(activeTerminal.focus).not.toHaveBeenCalled()
+    expect(wrapper.findComponent(SystemKeyboardToolbarStub).props('imeOpen')).toBe(false)
+    helper.remove()
+  })
+
+  it('blocks only the compatibility mousedown after a long press', async () => {
+    const { wrapper, activeTerminal, terminalSurface, helper } =
+      await mountUnguardedTouchTerminal()
+    const now = vi.spyOn(performance, 'now').mockReturnValue(100)
+
+    terminalSurface.dispatchEvent(new TouchEvent('touchstart', { bubbles: true }))
+    now.mockReturnValue(600)
+    terminalSurface.dispatchEvent(new TouchEvent('touchend', { bubbles: true, cancelable: true }))
+    await nextTick()
+    expect(activeTerminal.focus).not.toHaveBeenCalled()
+
+    const pointerDown = new PointerEvent('pointerdown', { bubbles: true, cancelable: true })
+    terminalSurface.dispatchEvent(pointerDown)
+    expect(pointerDown.defaultPrevented).toBe(false)
+
+    const xtermFocus = vi.fn(() => helper.focus())
+    terminalSurface.addEventListener('mousedown', xtermFocus)
+    const mouseDown = new MouseEvent('mousedown', { bubbles: true, cancelable: true })
+    terminalSurface.dispatchEvent(mouseDown)
+    await nextTick()
+    expect(xtermFocus).not.toHaveBeenCalled()
+    expect(mouseDown.defaultPrevented).toBe(true)
+    expect(document.activeElement).not.toBe(helper)
+    expect(wrapper.findComponent(SystemKeyboardToolbarStub).props('imeOpen')).toBe(false)
+    helper.remove()
+  })
+
+  it('blocks mouse replay only on the newly shown toolbar', async () => {
+    const { wrapper, terminalSurface, helper } = await mountUnguardedTouchTerminal()
+    const toolbar = document.createElement('div')
+    toolbar.id = 'system-mobile-kb'
+    const toolbarButton = document.createElement('button')
+    toolbar.appendChild(toolbarButton)
+    wrapper.get('#app-root').element.appendChild(toolbar)
+    const onClick = vi.fn()
+    toolbarButton.addEventListener('click', onClick)
+
+    terminalSurface.dispatchEvent(new TouchEvent('touchstart', { bubbles: true }))
+    terminalSurface.dispatchEvent(new TouchEvent('touchend', { bubbles: true, cancelable: true }))
+    await nextTick()
+
+    const replay = new MouseEvent('click', { bubbles: true, cancelable: true })
+    toolbarButton.dispatchEvent(replay)
+    expect(replay.defaultPrevented).toBe(true)
+    expect(onClick).not.toHaveBeenCalled()
+
+    terminalSurface.dispatchEvent(new TouchEvent('touchstart', { bubbles: true }))
+    terminalSurface.dispatchEvent(new TouchEvent('touchend', { bubbles: true, cancelable: true }))
+    toolbarButton.dispatchEvent(new TouchEvent('touchstart', { bubbles: true }))
+    const realFollowUp = new MouseEvent('click', { bubbles: true, cancelable: true })
+    toolbarButton.dispatchEvent(realFollowUp)
+    expect(realFollowUp.defaultPrevented).toBe(false)
+    expect(onClick).toHaveBeenCalledOnce()
+    helper.remove()
+  })
+
+  it('does not open the system IME after terminal link activation', async () => {
+    const { wrapper, activeTerminal, terminalSurface, helper } =
+      await mountUnguardedTouchTerminal()
+
+    terminalSurface.dispatchEvent(new TouchEvent('touchstart', { bubbles: true }))
+    await wrapper.findComponent(SplitContainerStub).vm.$emit('link-activate')
+    const touchEnd = new TouchEvent('touchend', { bubbles: true, cancelable: true })
+    terminalSurface.dispatchEvent(touchEnd)
+    await nextTick()
+    expect(activeTerminal.focus).not.toHaveBeenCalled()
+    expect(touchEnd.defaultPrevented).toBe(false)
+    helper.remove()
   })
 
   it('dismisses the toolbar when VisualViewport reports a native keyboard close', async () => {

--- a/frontend/src/test/systemMobileInput.test.ts
+++ b/frontend/src/test/systemMobileInput.test.ts
@@ -3,7 +3,9 @@ import {
   applyAfterTerminalComposition,
   applyMobileTerminalModifiers,
   configureMobileInputTextarea,
+  normalizeTerminalTextareaSelection,
   setKbTypingLock,
+  terminalTextareaEdit,
 } from '../composables/useTerminal'
 
 afterEach(() => {
@@ -50,6 +52,63 @@ describe('system mobile input', () => {
     textarea.dispatchEvent(new CompositionEvent('compositionend'))
     expect(apply).toHaveBeenCalledOnce()
   })
+
+  it.each([
+    [
+      { value: '', selectionStart: 0, selectionEnd: 0 },
+      { value: '()', selectionStart: 1, selectionEnd: 1 },
+      '()\x1b[D',
+      null,
+    ],
+    [
+      { value: '()', selectionStart: 1, selectionEnd: 1 },
+      { value: '())', selectionStart: 2, selectionEnd: 2 },
+      '\x1b[C)',
+      ')',
+    ],
+    [
+      { value: 'abXYcd', selectionStart: 4, selectionEnd: 4 },
+      { value: 'abZcd', selectionStart: 3, selectionEnd: 3 },
+      '\x7f\x7fZ',
+      null,
+    ],
+    [
+      { value: '😀', selectionStart: 2, selectionEnd: 2 },
+      { value: '😀()', selectionStart: 3, selectionEnd: 3 },
+      '()\x1b[D',
+      null,
+    ],
+  ])('derives a caret-aware terminal edit from %j to %j', (before, after, expected, data) => {
+    expect(
+      terminalTextareaEdit(before, normalizeTerminalTextareaSelection(before, after, data))
+    ).toBe(expected)
+  })
+
+  it.each([
+    ['(abc)', '(abc))', 4, 5, ')', '\x1b[C)'],
+    ['[abc]', '[abc]]', 4, 5, ']', '\x1b[C]'],
+    ['（中文）', '（中文））', 3, 4, '）', '\x1b[C）'],
+    ['“中文”', '“中文””', 3, 4, '”', '\x1b[C”'],
+  ])(
+    'places a standalone closer after prior auto-pair content: %s -> %s',
+    (beforeValue, afterValue, beforeCaret, afterCaret, data, expected) => {
+      const before = {
+        value: beforeValue,
+        selectionStart: beforeCaret,
+        selectionEnd: beforeCaret,
+      }
+      expect(
+        terminalTextareaEdit(
+          before,
+          normalizeTerminalTextareaSelection(
+            before,
+            { value: afterValue, selectionStart: afterCaret, selectionEnd: afterCaret },
+            data
+          )
+        )
+      ).toBe(expected)
+    }
+  )
 
   it('keeps a held Ctrl active across multiple combinations until the button releases it', () => {
     const held = { ctrl: 'locked', shift: 'off', alt: 'off', meta: 'off' } as const

--- a/frontend/src/test/useTerminalDeviceText.test.ts
+++ b/frontend/src/test/useTerminalDeviceText.test.ts
@@ -12,6 +12,9 @@ vi.mock('@xterm/xterm', () => ({
     unicode = { activeVersion: '' }
     parser = { registerOscHandler() {} }
     buffer = { active: { getLine: () => null, cursorY: 0, cursorX: 0 } }
+    keyHandler: ((event: KeyboardEvent) => boolean) | null = null
+    dataHandler: ((data: string) => void) | null = null
+    modes = { applicationCursorKeysMode: false }
     constructor(options: Record<string, any>) {
       this.options = { ...options }
       mocks.instances.push(this)
@@ -21,11 +24,16 @@ vi.mock('@xterm/xterm', () => ({
       const el = document.createElement('div')
       el.className = 'xterm'
       wrapper.appendChild(el)
+      const textarea = document.createElement('textarea')
+      textarea.className = 'xterm-helper-textarea'
+      wrapper.appendChild(textarea)
     }
-    attachCustomKeyEventHandler() {}
+    attachCustomKeyEventHandler(handler: (event: KeyboardEvent) => boolean) {
+      this.keyHandler = handler
+    }
     registerLinkProvider() {}
     onTitleChange() {}
-    onData() {}
+    onData(handler: (data: string) => void) { this.dataHandler = handler }
     hasSelection() { return false }
     dispose() {}
     focus() {}
@@ -81,6 +89,10 @@ function attach(id: string) {
   vi.spyOn(term as any, '_refit').mockImplementation(() => {})
   term.attach(document.createElement('div'))
   return term
+}
+
+function lastXterm() {
+  return mocks.instances[mocks.instances.length - 1]
 }
 
 describe('useTerminal device text integration', () => {
@@ -200,6 +212,70 @@ describe('useTerminal device text integration', () => {
     notifyTextChange()
     expect(term.xterm?.options.scrollback).toBe(20000)
     expect(refit).toHaveBeenCalledTimes(1)
+    term.destroy()
+  })
+
+  it.each([
+    ['touch system input', false, 1, 'system', 'ios'],
+    ['Windows Tauri touch input', true, 1, 'builtin', 'windows-x86_64'],
+    ['Linux Tauri desktop input', true, 0, 'builtin', 'linux-x86_64'],
+  ] as const)(
+    'reconciles an auto-pair and later closer on %s',
+    (_surface, tauri, touchPoints, inputMode, target) => {
+      mocks.isTauri.mockReturnValue(tauri)
+      mocks.hostTarget.mockReturnValue(target)
+      Object.defineProperty(navigator, 'maxTouchPoints', {
+        configurable: true,
+        value: touchPoints,
+      })
+      settings.mobile_input_mode = inputMode
+      const term = attach('p1')
+      const input = vi.fn()
+      term.onInput = input
+      const textarea = (term as any)._wrapper.querySelector(
+        '.xterm-helper-textarea',
+      ) as HTMLTextAreaElement
+      const keyHandler = lastXterm().keyHandler!
+      const edit = (value: string, caret: number, data: string) => {
+        keyHandler(new KeyboardEvent('keydown', { keyCode: 229, key: 'Process' }))
+        textarea.value = value
+        textarea.setSelectionRange(caret, caret)
+        textarea.dispatchEvent(
+          new InputEvent('input', { inputType: 'insertText', data, isComposing: false }),
+        )
+        keyHandler(new KeyboardEvent('keyup', { keyCode: 229, key: 'Process' }))
+      }
+
+      edit('()', 1, '(')
+      edit('())', 2, ')')
+
+      expect(input.mock.calls.map(([data]) => data)).toEqual(['()\x1b[D', '\x1b[C)'])
+      expect([textarea.selectionStart, textarea.selectionEnd]).toEqual([3, 3])
+      term.destroy()
+    },
+  )
+
+  it('does not duplicate a Tauri 229 symbol through the input rescue path', () => {
+    mocks.isTauri.mockReturnValue(true)
+    Object.defineProperty(navigator, 'maxTouchPoints', { configurable: true, value: 0 })
+    const term = attach('p1')
+    const input = vi.fn()
+    term.onInput = input
+    const textarea = (term as any)._wrapper.querySelector(
+      '.xterm-helper-textarea',
+    ) as HTMLTextAreaElement
+    const keyHandler = lastXterm().keyHandler!
+
+    keyHandler(new KeyboardEvent('keydown', { keyCode: 229, key: 'Process' }))
+    textarea.value = '!'
+    textarea.setSelectionRange(1, 1)
+    textarea.dispatchEvent(
+      new InputEvent('input', { inputType: 'insertText', data: '!', isComposing: false }),
+    )
+    lastXterm().dataHandler!('!')
+    keyHandler(new KeyboardEvent('keyup', { keyCode: 229, key: 'Process' }))
+
+    expect(input.mock.calls.map(([data]) => data)).toEqual(['!'])
     term.destroy()
   })
 })

--- a/frontend/src/test/useTerminalDeviceText.test.ts
+++ b/frontend/src/test/useTerminalDeviceText.test.ts
@@ -278,4 +278,24 @@ describe('useTerminal device text integration', () => {
     expect(input.mock.calls.map(([data]) => data)).toEqual(['!'])
     term.destroy()
   })
+
+  it('rescues a touch-web punctuation input when the IME emits no 229 event', () => {
+    mocks.isTauri.mockReturnValue(false)
+    Object.defineProperty(navigator, 'maxTouchPoints', { configurable: true, value: 1 })
+    settings.mobile_input_mode = 'system'
+    const term = attach('p1')
+    const input = vi.fn()
+    term.onInput = input
+    const textarea = (term as any)._wrapper.querySelector(
+      '.xterm-helper-textarea',
+    ) as HTMLTextAreaElement
+
+    textarea.dispatchEvent(
+      new InputEvent('input', { inputType: 'insertText', data: '！', isComposing: false }),
+    )
+    lastXterm().dataHandler!('！')
+
+    expect(input.mock.calls.map(([data]) => data)).toEqual(['！'])
+    term.destroy()
+  })
 })

--- a/frontend/src/utils/terminalInput.ts
+++ b/frontend/src/utils/terminalInput.ts
@@ -110,6 +110,75 @@ export const DEDUP_WINDOW_MS = 2
 
 export const IME_SYM_PAIR_MS = 400
 
+export interface TerminalTextareaSnapshot {
+  value: string
+  selectionStart: number
+  selectionEnd: number
+}
+
+function codePointOffset(value: string, utf16Offset: number): number {
+  return Array.from(value.slice(0, Math.max(0, utf16Offset))).length
+}
+
+function moveTerminalCursor(from: number, to: number, applicationCursor: boolean): string {
+  if (from === to) return ''
+  const final = to < from ? 'D' : 'C'
+  return `\x1b${applicationCursor ? 'O' : '['}${final}`.repeat(Math.abs(to - from))
+}
+
+export function normalizeTerminalTextareaSelection(
+  before: TerminalTextareaSnapshot,
+  after: TerminalTextareaSnapshot,
+  inputData: string | null
+): TerminalTextareaSnapshot {
+  if (!inputData || after.selectionStart !== after.selectionEnd) return after
+  const start = after.selectionEnd
+  const end = start + inputData.length
+  return after.value.slice(start, end) === inputData &&
+    after.value.slice(0, start) + after.value.slice(end) === before.value
+    ? { ...after, selectionStart: end, selectionEnd: end }
+    : after
+}
+
+export function terminalTextareaEdit(
+  before: TerminalTextareaSnapshot,
+  after: TerminalTextareaSnapshot,
+  applicationCursor = false
+): string {
+  const cursorBefore = codePointOffset(before.value, before.selectionEnd)
+  const desiredCursor = codePointOffset(after.value, after.selectionEnd)
+  if (before.value === after.value) {
+    return moveTerminalCursor(cursorBefore, desiredCursor, applicationCursor)
+  }
+
+  const oldText = Array.from(before.value)
+  const newText = Array.from(after.value)
+  let prefix = 0
+  while (
+    prefix < oldText.length &&
+    prefix < newText.length &&
+    oldText[prefix] === newText[prefix]
+  ) {
+    prefix++
+  }
+  let suffix = 0
+  while (
+    suffix < oldText.length - prefix &&
+    suffix < newText.length - prefix &&
+    oldText[oldText.length - 1 - suffix] === newText[newText.length - 1 - suffix]
+  ) {
+    suffix++
+  }
+
+  const oldEditEnd = oldText.length - suffix
+  const inserted = newText.slice(prefix, newText.length - suffix).join('')
+  const cursorAfterEdit = prefix + Array.from(inserted).length
+
+  return `${moveTerminalCursor(cursorBefore, oldEditEnd, applicationCursor)}${'\x7f'.repeat(
+    oldEditEnd - prefix
+  )}${inserted}${moveTerminalCursor(cursorAfterEdit, desiredCursor, applicationCursor)}`
+}
+
 /**
  * Determine whether an incoming onData payload should be dropped because
  * it is a WKWebView multi-focus replay of the previous event. Exported


### PR DESCRIPTION
## Summary

- prevent rejected mobile terminal gestures and compatibility mouse replay from opening the native IME or activating controls that appear underneath the touch
- keep Cmd/Win and Alt/Opt aliases on one modifier family while highlighting only the selected owner
- reconcile non-composition keyCode 229 textarea values and selections across mobile web and Tauri macOS/Windows/Linux, including spaces, Chinese punctuation, auto-pairs, replacements, and caret movement

## Verification

- `npm test -- --run` — 115 files, 1140 tests passed
- `npm run build`
- changed-file ESLint (`--quiet`)
- `git diff --check upstream/dev...HEAD`
- focused fixtures cover iOS system input, touchscreen Windows Tauri builtin input, Linux desktop Tauri input, missing-keyup fallback, composition cancellation, punctuation rescue, and duplicate suppression

Physical iPhone E2E is accepted by the reporter. Physical Windows/Linux IME verification remains a follow-up device check; the implementation uses the shared Tauri path and includes platform fixtures for both.

This branch starts from current `upstream/dev` and excludes local ledgers, deployment scripts, build output, and prior failed viewport experiments.
