### PR TITLE
fix(mobile): keep manual IME guards input-safe

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -407,6 +407,7 @@ import {
   configureAllMobileInputTextareas,
   setActivePaneId,
   setKbTypingLock,
+  setSystemImeAuthorized,
 } from './composables/useTerminal'
 import { useI18n } from './composables/useI18n'
 import { keyEventMatchesBinding, useKeybindings } from './composables/useKeybindings'
@@ -875,6 +876,19 @@ watch(
   { immediate: true }
 )
 
+// Manual-open protection controls only the touch software IME. Keep xterm's
+// textarea focusable for hardware input, but expose inputMode=text only after
+// the explicit keyboard action authorizes it. Synchronous updates preserve the
+// browser user-gesture stack required to open mobile keyboards.
+watch(
+  [terminalImeFocused, () => appSettings.keyboard_guard_mode],
+  ([open]) => {
+    setSystemImeAuthorized(open)
+    if (effectiveMobileInputMode.value === 'system') configureAllMobileInputTextareas('system')
+  },
+  { immediate: true, flush: 'sync' }
+)
+
 watch(
   () => appSettings.mobile_input_mode,
   (mode, previousMode) => {
@@ -1216,6 +1230,7 @@ function getActiveTerminalRef() {
 
 function canRestoreSystemInputFocus() {
   return !(
+    isTouchDevice() &&
     effectiveMobileInputMode.value === 'system' &&
     hasOpenGuard(appSettings.keyboard_guard_mode) &&
     !terminalImeFocused.value
@@ -1230,9 +1245,8 @@ function focusSystemInput(authorizeOpen = false) {
     (!authorizeOpen && !canRestoreSystemInputFocus())
   )
     return
-  configureAllMobileInputTextareas('system')
-  setKbTypingLock(false)
   terminalImeFocused.value = true
+  setKbTypingLock(false)
   getActiveTerminalRef()?.focus()
 }
 
@@ -2064,17 +2078,25 @@ function onDocumentFocusIn(event: FocusEvent) {
   const target = event.target as HTMLElement | null
   if (!target) return
   if (target.classList.contains('xterm-helper-textarea')) {
+    // Reject only a touch gesture already classified as scroll/long-press/cancelled.
+    // Manual-open protection uses inputMode=none instead of blur so hardware input
+    // keeps working while the touch software keyboard remains closed.
     if (
       isTouchDevice() &&
       effectiveMobileInputMode.value === 'system' &&
-      (hasOpenGuard(appSettings.keyboard_guard_mode) ||
-        terminalTouchOpenPending ||
-        performance.now() < terminalTouchFocusBlockUntil) &&
+      (terminalTouchOpenPending || performance.now() < terminalTouchFocusBlockUntil) &&
       !terminalImeFocused.value
     ) {
       target.blur()
       return
     }
+    if (
+      isTouchDevice() &&
+      effectiveMobileInputMode.value === 'system' &&
+      hasOpenGuard(appSettings.keyboard_guard_mode) &&
+      !terminalImeFocused.value
+    )
+      return
     terminalImeFocused.value = effectiveMobileInputMode.value === 'system'
     return
   }

--- a/frontend/src/components/settings/KeyboardTab.vue
+++ b/frontend/src/components/settings/KeyboardTab.vue
@@ -1153,7 +1153,11 @@
       </div>
     </CollapsibleSection>
 
-    <CollapsibleSection :title="t('settings.advancedText')" level="group">
+    <CollapsibleSection
+      class="system-keyboard-advanced-gap"
+      :title="t('settings.advancedText')"
+      level="group"
+    >
       <div class="settings-row">
         <label>{{ t('settings.keyboard.quickSendThreshold') }}</label>
         <input
@@ -2154,6 +2158,9 @@ onBeforeUnmount(() => {
 </script>
 
 <style scoped>
+.system-keyboard-advanced-gap {
+  margin-top: 16px;
+}
 .system-editor-head {
   margin-top: 14px;
   margin-bottom: 6px;

--- a/frontend/src/composables/useTerminal.ts
+++ b/frontend/src/composables/useTerminal.ts
@@ -38,6 +38,7 @@ import { createTerminalWheel, type TerminalWheel } from './useTerminalWheel'
 import { setupTerminalDrop } from './useTerminalDrop'
 import { createTerminalOverlay } from './useTerminalOverlay'
 import { t } from './useI18n'
+import { hasOpenGuard } from '../utils/keyboardGuardMode'
 
 // Re-export pure helpers so existing callers (App.vue, useTabLifecycle,
 // useSplitPane, tests) don't need to update their import paths.
@@ -79,6 +80,12 @@ function resolveTerminalFontFamily(configuredFamily: string, cssFallback: string
 // fact. The query covers hidden split panes too.
 // Deliberately sweep on every call so late-created or re-enabled helpers are reconciled.
 let _kbTypingLock = false
+let _systemImeAuthorized = false
+
+export function setSystemImeAuthorized(open: boolean) {
+  _systemImeAuthorized = open
+}
+
 export function setKbTypingLock(active: boolean) {
   _kbTypingLock = active
   document.querySelectorAll('.xterm-helper-textarea').forEach((el) => {
@@ -97,7 +104,10 @@ export function configureMobileInputTextarea(
   textarea: HTMLTextAreaElement,
   mode: MobileInputMode | null | undefined = settings.mobile_input_mode
 ) {
-  if (mode === 'system') {
+  const allowSoftwareKeyboard =
+    mode === 'system' &&
+    (!isTouchDevice() || !hasOpenGuard(settings.keyboard_guard_mode) || _systemImeAuthorized)
+  if (allowSoftwareKeyboard) {
     textarea.inputMode = 'text'
     textarea.setAttribute('virtualkeyboardpolicy', 'auto')
     textarea.enterKeyHint = 'enter'

--- a/frontend/src/test/KeyboardTab.systemEditor.test.ts
+++ b/frontend/src/test/KeyboardTab.systemEditor.test.ts
@@ -86,6 +86,18 @@ describe('KeyboardTab system IME editor', () => {
     )
   })
 
+  it('separates the system preset actions from the following Advanced section', () => {
+    wrapper = mount(KeyboardTab)
+
+    expect(wrapper.find('.system-keyboard-advanced-gap').exists()).toBe(true)
+
+    const source = readFileSync(
+      join(process.cwd(), 'src/components/settings/KeyboardTab.vue'),
+      'utf8'
+    )
+    expect(source).toMatch(/\.system-keyboard-advanced-gap\s*\{[^}]*margin-top:\s*16px;/s)
+  })
+
   it('uses the whole key body as the edit target and marks the fixed IME key by color', async () => {
     wrapper = mount(KeyboardTab)
 

--- a/frontend/src/test/appPaneClose/_setup.ts
+++ b/frontend/src/test/appPaneClose/_setup.ts
@@ -61,6 +61,7 @@ const mocks = vi.hoisted(() => {
     apiActivateWorkspace: vi.fn<(id: string) => Promise<void>>(async () => {}),
     apiDeactivateWorkspace: vi.fn<() => Promise<void>>(async () => {}),
     onSystemKeyboardClose: undefined as undefined | (() => void),
+    setSystemImeAuthorized: vi.fn(),
     apiCreateTab: vi.fn(async () => ({
       tab_id: 't-new',
       pane_id: 'p-new',
@@ -123,6 +124,7 @@ vi.mock('../../composables/useTerminal', () => ({
   isTouchDevice: () => mocks.touchDevice,
   setActivePaneId: () => {},
   setKbTypingLock: () => {},
+  setSystemImeAuthorized: (open: boolean) => mocks.setSystemImeAuthorized(open),
 }))
 vi.mock('../../composables/useViewportResize', async () => {
   const { ref } = await vi.importActual<typeof import('vue')>('vue')
@@ -498,6 +500,7 @@ afterEach(() => {
   mocks.apiDeactivateWorkspace.mockReset()
   mocks.apiDeactivateWorkspace.mockResolvedValue(undefined)
   mocks.onSystemKeyboardClose = undefined
+  mocks.setSystemImeAuthorized.mockReset()
   mocks.mintNotificationRequestId.mockClear()
   mocks.resetNotificationRequestIds()
   mocks.touchDevice = false

--- a/frontend/src/test/appPaneClose/system-keyboard.test.ts
+++ b/frontend/src/test/appPaneClose/system-keyboard.test.ts
@@ -178,6 +178,38 @@ describe('App.vue - system keyboard state regressions', () => {
     textarea.remove()
   })
 
+  it.each(['open_only', 'both'] as const)(
+    'keeps terminal input focused without authorizing the IME under %s protection',
+    async (guardMode) => {
+      mocks.touchDevice = true
+      settings.mobile_input_mode = 'system'
+      settings.system_toolbar_mode = 'persistent_mobile'
+      settings.keyboard_guard_mode = guardMode
+      useIsMobile().isMobile.value = true
+      const wrapper = await mountWithTabs()
+
+      const helper = document.createElement('textarea')
+      helper.className = 'xterm-helper-textarea'
+      helper.inputMode = 'none'
+      document.body.appendChild(helper)
+      helper.focus()
+      await nextTick()
+
+      expect(document.activeElement).toBe(helper)
+      const toolbar = wrapper.findComponent(SystemKeyboardToolbarStub)
+      expect(toolbar.props('imeOpen')).toBe(false)
+      expect(mocks.setSystemImeAuthorized).toHaveBeenLastCalledWith(false)
+
+      const activeTerminal = { setOutputListener: vi.fn(), focus: vi.fn() }
+      await wrapper.findComponent(SplitContainerStub).vm.$emit('register', 'pane-1', activeTerminal)
+      await toolbar.vm.$emit('toggle-ime')
+      expect(mocks.setSystemImeAuthorized).toHaveBeenLastCalledWith(true)
+      expect(activeTerminal.focus).toHaveBeenCalledOnce()
+      expect(toolbar.props('imeOpen')).toBe(true)
+      helper.remove()
+    }
+  )
+
   it('serializes an unguarded terminal touch until touchend', async () => {
     const { wrapper, activeTerminal, terminalSurface, helper } =
       await mountUnguardedTouchTerminal()

--- a/frontend/src/test/systemMobileInput.test.ts
+++ b/frontend/src/test/systemMobileInput.test.ts
@@ -5,11 +5,20 @@ import {
   configureMobileInputTextarea,
   normalizeTerminalTextareaSelection,
   setKbTypingLock,
+  setSystemImeAuthorized,
   terminalTextareaEdit,
 } from '../composables/useTerminal'
+import { settings } from '../composables/useSettings'
+
+const originalMaxTouchPoints = Object.getOwnPropertyDescriptor(navigator, 'maxTouchPoints')
 
 afterEach(() => {
   setKbTypingLock(false)
+  setSystemImeAuthorized(false)
+  settings.keyboard_guard_mode = 'off'
+  if (originalMaxTouchPoints)
+    Object.defineProperty(navigator, 'maxTouchPoints', originalMaxTouchPoints)
+  else Reflect.deleteProperty(navigator, 'maxTouchPoints')
   document.body.replaceChildren()
 })
 
@@ -35,6 +44,50 @@ describe('system mobile input', () => {
     configureMobileInputTextarea(textarea, 'system')
 
     expect(textarea.disabled).toBe(true)
+  })
+
+  it.each(['open_only', 'both'] as const)(
+    'keeps terminal focus available while %s suppresses the touch software keyboard',
+    (guardMode) => {
+      Object.defineProperty(navigator, 'maxTouchPoints', { configurable: true, value: 1 })
+      settings.keyboard_guard_mode = guardMode
+      const textarea = document.createElement('textarea')
+
+      configureMobileInputTextarea(textarea, 'system')
+
+      expect(textarea.inputMode).toBe('none')
+      expect(textarea.getAttribute('virtualkeyboardpolicy')).toBe('manual')
+      expect(textarea.disabled).toBe(false)
+
+      setSystemImeAuthorized(true)
+      configureMobileInputTextarea(textarea, 'system')
+      expect(textarea.inputMode).toBe('text')
+      expect(textarea.getAttribute('virtualkeyboardpolicy')).toBe('auto')
+    }
+  )
+
+  it.each(['off', 'collapse_only'] as const)(
+    'keeps touch system input unchanged under %s protection',
+    (guardMode) => {
+      Object.defineProperty(navigator, 'maxTouchPoints', { configurable: true, value: 1 })
+      settings.keyboard_guard_mode = guardMode
+      const textarea = document.createElement('textarea')
+
+      configureMobileInputTextarea(textarea, 'system')
+
+      expect(textarea.inputMode).toBe('text')
+      expect(textarea.getAttribute('virtualkeyboardpolicy')).toBe('auto')
+    }
+  )
+
+  it('does not suppress a non-touch system input under manual-open protection', () => {
+    Object.defineProperty(navigator, 'maxTouchPoints', { configurable: true, value: 0 })
+    settings.keyboard_guard_mode = 'both'
+    const textarea = document.createElement('textarea')
+
+    configureMobileInputTextarea(textarea, 'system')
+
+    expect(textarea.inputMode).toBe('text')
   })
 
   it('defers a mode application until the active xterm composition ends', () => {


### PR DESCRIPTION
## Summary

- keep xterm helper textareas focusable for hardware keyboards while manual-open protection suppresses only the touch software IME
- authorize and configure the native IME synchronously from the fixed keyboard control before focusing the terminal
- preserve rejected touch gesture handling and existing behavior for unprotected, builtin, and non-touch clients
- add a scoped 16px gap between the system-keyboard preset actions and Advanced settings

## Verification

- `npm run test` — 115 files, 1148 tests passed
- `npm run build` — passed (existing Rollup warnings only)
- `cargo check` — passed
- `cargo fmt --check` — passed
- changed-file ESLint (`--quiet`) — passed
- focused TDD suites — 53 tests passed

The repository-wide lint command still reports the existing upstream baseline (4 errors and 582 warnings); none are introduced by the seven changed files.

## Platforms

The input gate is touch-capability based rather than OS-name based. Non-touch Web/Tauri behavior is explicitly covered, so Windows and Linux hardware-input paths remain enabled while touch clients receive the same manual-open protection.
