### PR TITLE
fix(mobile): stabilize builtin IME first paint

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -758,6 +758,7 @@ const { isLandscape, dispose: disposeViewport } = useViewportResize({
   activePaneId,
   tabs,
   termRefs,
+  builtinTextareaFocused: kbTyping,
   onSystemKeyboardClose: onSystemKeyboardClosed,
 })
 

--- a/frontend/src/components/keyboard/MobileKeyboard.vue
+++ b/frontend/src/components/keyboard/MobileKeyboard.vue
@@ -865,7 +865,6 @@ function onViewportChange() {
   if (!window.visualViewport) return
   const vh = window.visualViewport.height
   if (vh > naturalVH) naturalVH = vh
-  const off = window.innerHeight - (window.visualViewport.offsetTop + vh)
   const wasSysKbOpen = sysKbOpen
   sysKbOpen = naturalVH - vh > 120
   if (sysKbOpen && !wasSysKbOpen) sysKbArmed = textInputFocused.value
@@ -876,12 +875,10 @@ function onViewportChange() {
     } else if (sysKbOpen && textInputFocused.value) {
       // System keyboard open with our input focused: show bar, hide panels via v-show
       barRef.value.style.display = ''
-      barRef.value.style.bottom = `${Math.max(0, off)}px`
     } else if (sysKbOpen) {
       barRef.value.style.display = 'none'
     } else {
       barRef.value.style.display = ''
-      barRef.value.style.bottom = `${Math.max(0, off)}px`
     }
   }
   if (textInputFocused.value) resizeTextInput()

--- a/frontend/src/composables/useViewportResize.ts
+++ b/frontend/src/composables/useViewportResize.ts
@@ -1,6 +1,9 @@
 import { computed, ref, watch, onMounted, onBeforeUnmount, type Ref } from 'vue'
 import type { Tab } from '../types/pane'
 import { getAllLeaves } from '../types/pane'
+import { isIPhoneClient } from '../utils/clientPlatform'
+
+const MAX_PAN_RESETS = 3
 
 export interface ViewportResizeOptions {
   kbVisible: Ref<boolean>
@@ -8,6 +11,7 @@ export interface ViewportResizeOptions {
   tabs: Ref<Tab[]>
   termRefs: Record<string, { fit: () => void }>
   terminalImeFocused?: Ref<boolean>
+  builtinTextareaFocused: Ref<boolean>
   onSystemKeyboardClose?: () => void
 }
 
@@ -38,7 +42,9 @@ export function useViewportResize(opts: ViewportResizeOptions): ViewportResizeSt
   )
   let viewportRefitTimer = 0
   let orientationRevalidateFrame = 0
+  let earlyPanReleaseFrame = 0
   let naturalVH = 0
+  let panResetAttempts = 0
   let lastSampledKeyboardOpen = false
   let awaitingPostOrientationBaseline = false
   let postOrientationOccludedVH = 0
@@ -47,6 +53,7 @@ export function useViewportResize(opts: ViewportResizeOptions): ViewportResizeSt
   function sampleViewport(allowBaselineReset = false) {
     const viewport = window.visualViewport
     if (!viewport) {
+      panResetAttempts = 0
       imeOccluding.value = false
       systemKeyboardOpen.value = false
       systemKeyboardHeight.value = 0
@@ -54,7 +61,10 @@ export function useViewportResize(opts: ViewportResizeOptions): ViewportResizeSt
     }
 
     const vh = viewport.height
-    const off = Math.max(0, window.innerHeight - (viewport.offsetTop + vh))
+    // offsetTop is WebKit's temporary caret pan, not keyboard occlusion. Keeping
+    // the inset pan-invariant prevents the keyboard bar from painting short and
+    // then jumping down after the visual viewport returns to zero.
+    const off = Math.max(0, window.innerHeight - vh)
     let preserveKeyboardWithoutBaseline = false
     // Layout-resize browsers report off=0 even with the IME open. After a
     // rotation, retain the known-open state until the viewport expands again.
@@ -97,7 +107,40 @@ export function useViewportResize(opts: ViewportResizeOptions): ViewportResizeSt
       '--kb-open',
       sysKbOpen || kbVisible.value ? '1' : '0'
     )
-    if (keyboardClosed) opts.onSystemKeyboardClose?.()
+    if (keyboardClosed) {
+      panResetAttempts = 0
+      opts.onSystemKeyboardClose?.()
+    }
+  }
+
+  function scheduleBuiltinPanRelease() {
+    cancelAnimationFrame(earlyPanReleaseFrame)
+    earlyPanReleaseFrame = 0
+    const viewport = window.visualViewport
+    if (
+      !viewport ||
+      !isIPhoneClient() ||
+      !opts.builtinTextareaFocused.value ||
+      !systemKeyboardOpen.value ||
+      viewport.offsetTop <= 0 ||
+      panResetAttempts >= MAX_PAN_RESETS
+    )
+      return
+    earlyPanReleaseFrame = requestAnimationFrame(() => {
+      earlyPanReleaseFrame = 0
+      const current = window.visualViewport
+      if (disposed || !current) return
+      sampleViewport()
+      if (
+        !opts.builtinTextareaFocused.value ||
+        !systemKeyboardOpen.value ||
+        current.offsetTop <= 0 ||
+        panResetAttempts >= MAX_PAN_RESETS
+      )
+        return
+      panResetAttempts += 1
+      window.scrollTo(0, 0)
+    })
   }
 
   function onViewportResize() {
@@ -107,8 +150,12 @@ export function useViewportResize(opts: ViewportResizeOptions): ViewportResizeSt
     }
     if (!window.visualViewport) return
     sampleViewport()
+    scheduleBuiltinPanRelease()
 
     clearTimeout(viewportRefitTimer)
+    // The terminal ResizeObserver already owns the iPhone frame resize. A
+    // second delayed fit repaints the upper frame during the IME animation.
+    if (isIPhoneClient()) return
     viewportRefitTimer = window.setTimeout(() => {
       if (!activePaneId.value) return
       const tab = tabs.value.find((t) => t.paneId === activePaneId.value)
@@ -125,7 +172,10 @@ export function useViewportResize(opts: ViewportResizeOptions): ViewportResizeSt
 
   function clearViewportState(discardBaseline = false) {
     clearTimeout(viewportRefitTimer)
+    cancelAnimationFrame(earlyPanReleaseFrame)
+    earlyPanReleaseFrame = 0
     if (discardBaseline) naturalVH = 0
+    panResetAttempts = 0
     imeOccluding.value = false
     systemKeyboardOpen.value = false
     systemKeyboardHeight.value = 0
@@ -147,7 +197,7 @@ export function useViewportResize(opts: ViewportResizeOptions): ViewportResizeSt
     // Reset a stale baseline only from a confirmed-unoccluded sample. If this
     // is the first sample after rotation and it is still occluded, sampleViewport
     // derives the new orientation's baseline from the layout viewport instead.
-    const off = Math.max(0, window.innerHeight - (viewport.offsetTop + viewport.height))
+    const off = Math.max(0, window.innerHeight - viewport.height)
     const preservedDelta = Math.max(0, naturalVH - viewport.height)
     const confirmedUnoccluded =
       off === 0 &&
@@ -198,7 +248,9 @@ export function useViewportResize(opts: ViewportResizeOptions): ViewportResizeSt
     disposed = true
     clearTimeout(viewportRefitTimer)
     cancelAnimationFrame(orientationRevalidateFrame)
+    cancelAnimationFrame(earlyPanReleaseFrame)
     naturalVH = 0
+    panResetAttempts = 0
     lastSampledKeyboardOpen = false
     awaitingPostOrientationBaseline = false
     postOrientationOccludedVH = 0

--- a/frontend/src/styles/mobile-keyboard.css
+++ b/frontend/src/styles/mobile-keyboard.css
@@ -4,7 +4,7 @@
   position: fixed;
   left: 0;
   right: 0;
-  bottom: 0;
+  bottom: var(--sys-kb-height, 0px);
   z-index: 500;
   background: var(--bg-surface);
   border-top: 1px solid var(--border);

--- a/frontend/src/test/useViewportResize.test.ts
+++ b/frontend/src/test/useViewportResize.test.ts
@@ -1,8 +1,11 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { defineComponent, h, ref } from 'vue'
 import { mount, type VueWrapper } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useViewportResize, type ViewportResizeState } from '../composables/useViewportResize'
 import type { Tab } from '../types/pane'
+import { isIPhoneClient } from '../utils/clientPlatform'
 
 class FakeVisualViewport extends EventTarget {
   height = 800
@@ -17,6 +20,8 @@ describe('useViewportResize system keyboard lifecycle', () => {
   let originalInnerHeight: PropertyDescriptor | undefined
   let originalInnerWidth: PropertyDescriptor | undefined
   let originalVisibilityState: PropertyDescriptor | undefined
+  let originalUserAgent: PropertyDescriptor | undefined
+  let builtinTextareaFocused = ref(false)
 
   beforeEach(() => {
     vi.useFakeTimers()
@@ -26,6 +31,8 @@ describe('useViewportResize system keyboard lifecycle', () => {
     originalInnerHeight = Object.getOwnPropertyDescriptor(window, 'innerHeight')
     originalInnerWidth = Object.getOwnPropertyDescriptor(window, 'innerWidth')
     originalVisibilityState = Object.getOwnPropertyDescriptor(document, 'visibilityState')
+    originalUserAgent = Object.getOwnPropertyDescriptor(navigator, 'userAgent')
+    builtinTextareaFocused = ref(false)
     Object.defineProperty(window, 'visualViewport', {
       configurable: true,
       value: viewport,
@@ -43,6 +50,7 @@ describe('useViewportResize system keyboard lifecycle', () => {
     restoreProperty(window, 'innerHeight', originalInnerHeight)
     restoreProperty(window, 'innerWidth', originalInnerWidth)
     restoreProperty(document, 'visibilityState', originalVisibilityState)
+    restoreProperty(navigator, 'userAgent', originalUserAgent)
     vi.useRealTimers()
   })
 
@@ -52,7 +60,7 @@ describe('useViewportResize system keyboard lifecycle', () => {
   }
 
   function restoreProperty(
-    target: Window | Document,
+    target: Window | Document | Navigator,
     key: string,
     descriptor: PropertyDescriptor | undefined
   ) {
@@ -69,6 +77,7 @@ describe('useViewportResize system keyboard lifecycle', () => {
           tabs: ref<Tab[]>([]),
           termRefs: {},
           terminalImeFocused: ref(true),
+          builtinTextareaFocused,
           onSystemKeyboardClose,
         })
         return () => h('div')
@@ -76,6 +85,36 @@ describe('useViewportResize system keyboard lifecycle', () => {
     })
     wrapper = mount(Host)
     return onSystemKeyboardClose
+  }
+
+  function mountViewportWithTerminal() {
+    const fit = vi.fn()
+    const terminalTab = {
+      type: 'terminal',
+      paneId: 'tab-1',
+      activePaneId: 'pane-1',
+      layout: {
+        type: 'leaf',
+        kind: 'terminal',
+        paneId: 'pane-1',
+        title: 'Terminal',
+      },
+    } as Tab
+    const Host = defineComponent({
+      setup() {
+        state = useViewportResize({
+          kbVisible: ref(true),
+          activePaneId: ref('tab-1'),
+          tabs: ref<Tab[]>([terminalTab]),
+          termRefs: { 'pane-1': { fit } },
+          terminalImeFocused: ref(false),
+          builtinTextareaFocused,
+        })
+        return () => h('div')
+      },
+    })
+    wrapper = mount(Host)
+    return fit
   }
 
   function openKeyboard(height = 500) {
@@ -178,5 +217,140 @@ describe('useViewportResize system keyboard lifecycle', () => {
     window.dispatchEvent(new Event('focus'))
 
     expect(onSystemKeyboardClose).toHaveBeenCalledOnce()
+  })
+
+  it('keeps the published keyboard inset stable across a transient visual-viewport pan', () => {
+    mountViewport()
+    viewport.height = 500
+    viewport.offsetTop = 0
+    state.onViewportResize()
+    expect(state.systemKeyboardHeight.value).toBe(300)
+
+    viewport.offsetTop = 35
+    state.onViewportResize()
+
+    expect(state.systemKeyboardHeight.value).toBe(300)
+    expect(document.documentElement.style.getPropertyValue('--sys-kb-height')).toBe('300px')
+  })
+
+  it('releases an iPhone builtin-input pan on the first safe paint', async () => {
+    Object.defineProperty(navigator, 'userAgent', {
+      configurable: true,
+      value: 'Mozilla/5.0 (iPhone) CriOS/140.0 Mobile',
+    })
+    builtinTextareaFocused.value = true
+    const scrollTo = vi.spyOn(window, 'scrollTo').mockImplementation(() => {})
+    let nextPaint: FrameRequestCallback | undefined
+    const requestFrame = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback) => {
+        nextPaint = callback
+        return 1
+      })
+    mountViewport()
+    openKeyboard()
+    viewport.offsetTop = 35
+    expect(isIPhoneClient()).toBe(true)
+    expect(builtinTextareaFocused.value).toBe(true)
+    expect(state.systemKeyboardOpen.value).toBe(true)
+
+    state.onViewportResize()
+    expect(nextPaint).toBeTypeOf('function')
+    nextPaint?.(16)
+
+    expect(scrollTo).toHaveBeenCalledOnce()
+    expect(scrollTo).toHaveBeenCalledWith(0, 0)
+    requestFrame.mockRestore()
+    scrollTo.mockRestore()
+  })
+
+  it('does not release a pan owned by an unrelated native input', async () => {
+    Object.defineProperty(navigator, 'userAgent', {
+      configurable: true,
+      value: 'Mozilla/5.0 (iPhone) CriOS/140.0 Mobile',
+    })
+    const scrollTo = vi.spyOn(window, 'scrollTo').mockImplementation(() => {})
+    mountViewport()
+    openKeyboard()
+    viewport.offsetTop = 35
+
+    state.onViewportResize()
+    await vi.runOnlyPendingTimersAsync()
+
+    expect(scrollTo).not.toHaveBeenCalled()
+    scrollTo.mockRestore()
+  })
+
+  it('caps pan releases per open episode and rearms after keyboard close', () => {
+    Object.defineProperty(navigator, 'userAgent', {
+      configurable: true,
+      value: 'Mozilla/5.0 (iPhone) CriOS/140.0 Mobile',
+    })
+    builtinTextareaFocused.value = true
+    const scrollTo = vi.spyOn(window, 'scrollTo').mockImplementation(() => {})
+    const paints: FrameRequestCallback[] = []
+    const requestFrame = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback) => {
+        paints.push(callback)
+        return paints.length
+      })
+    mountViewport()
+    openKeyboard()
+
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      viewport.offsetTop = 35
+      state.onViewportResize()
+      paints.shift()?.(attempt * 16)
+    }
+    expect(scrollTo).toHaveBeenCalledTimes(3)
+
+    viewport.offsetTop = 0
+    viewport.height = 800
+    state.onViewportResize()
+    viewport.height = 500
+    state.onViewportResize()
+    viewport.offsetTop = 35
+    state.onViewportResize()
+    paints.shift()?.(80)
+
+    expect(scrollTo).toHaveBeenCalledTimes(4)
+    requestFrame.mockRestore()
+    scrollTo.mockRestore()
+  })
+
+  it('leaves iPhone terminal refits to the ResizeObserver during IME opening', async () => {
+    Object.defineProperty(navigator, 'userAgent', {
+      configurable: true,
+      value: 'Mozilla/5.0 (iPhone) CriOS/140.0 Mobile',
+    })
+    const fit = mountViewportWithTerminal()
+    viewport.height = 500
+
+    state.onViewportResize()
+    await vi.advanceTimersByTimeAsync(200)
+
+    expect(fit).not.toHaveBeenCalled()
+  })
+
+  it('retains the existing viewport refit on non-iPhone clients', async () => {
+    const fit = mountViewportWithTerminal()
+    viewport.height = 500
+
+    state.onViewportResize()
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(fit).toHaveBeenCalledOnce()
+  })
+
+  it('gives the shared inset sole ownership of focused builtin-keyboard positioning', () => {
+    const css = readFileSync(join(process.cwd(), 'src/styles/mobile-keyboard.css'), 'utf8')
+    const component = readFileSync(
+      join(process.cwd(), 'src/components/keyboard/MobileKeyboard.vue'),
+      'utf8'
+    )
+
+    expect(css).toMatch(/#mobile-kb\s*\{[^}]*bottom:\s*var\(--sys-kb-height,\s*0px\)/s)
+    expect(component).not.toContain('barRef.value.style.bottom =')
   })
 })

--- a/frontend/src/utils/clientPlatform.ts
+++ b/frontend/src/utils/clientPlatform.ts
@@ -5,6 +5,10 @@ export const isWindowsClient: boolean =
       navigator.platform,
   )
 
+export function isIPhoneClient(): boolean {
+  return typeof navigator !== 'undefined' && /iPhone|iPod/i.test(navigator.userAgent)
+}
+
 /**
  * Returns the current client's host target string, matching the backend
  * `HostTarget::as_str()` vocabulary. Returns `null` when the platform


### PR DESCRIPTION
## Summary

- derive native-keyboard occlusion from `innerHeight - visualViewport.height` so WebKit's transient caret pan cannot shorten the first rendered inset
- give `--sys-kb-height` sole ownership of the builtin keyboard bar's bottom position
- release an iPhone pan owned by Dinotty's focused builtin textarea on the next safe paint, with a three-attempt per-open-episode cap
- leave iPhone terminal resizing to the existing ResizeObserver while retaining the upstream delayed refit on non-iPhone clients

## Verification

- `npm run test` — 115 files, 1147 tests passed
- `npm run build` — passed (existing Rollup warnings only)
- `cargo check` — passed
- `cargo fmt --check` — passed
- changed-file ESLint (`--quiet`) — passed
- focused viewport/mobile/App suites — 47 tests passed before full QA
- independent complete code review — passed; the only coverage note was closed with a direct 3-release/reset regression test

## Scope and platform boundary

The scroll release and delayed-refit suppression are narrowly gated to iPhone. Android, Windows, Linux, desktop, and the system-IME toolbar retain their existing paths. This PR intentionally does not include the fork's wider viewport/layout stack or prior height experiments.

The same behavior was physically exercised in the integration build that motivated this extraction; this PR is the minimal upstream-owned adaptation, so automated proof above applies to this exact six-file branch.
