### PR TITLE
fix(terminal): reconcile iOS dictation tail replacements

### DIFF
--- a/frontend/src/composables/useTerminal.ts
+++ b/frontend/src/composables/useTerminal.ts
@@ -158,6 +158,10 @@ export class TerminalInstance {
   private _ime229Baseline: TerminalTextareaSnapshot | null = null
   private _ime229InputData: string | null = null
   private _ime229Timer: ReturnType<typeof setTimeout> | null = null
+  // The same textarea snapshot/diff owner handles keyCode 229 and mobile
+  // dictation tail replacements, but their event lifecycles must not overlap.
+  private _ime229Owner: 'key' | 'tail-replacement' | null = null
+  private _imeTailReplacement: { data: string; value: string; sawRaw: boolean } | null = null
   // IME composition state. Tracked via compositionstart/compositionend on the
   // xterm textarea so focusActive() can avoid .focus()/.blur()/.fit() during
   // composition - those calls interrupt the IME session and cause xterm's
@@ -328,7 +332,11 @@ export class TerminalInstance {
         !this._composing &&
         (e.keyCode === 229 || e.key === 'Process')
       const ownsTextarea229 =
-        isTextarea229 || (acceptsTextarea229 && this._ime229Baseline != null && e.type === 'keyup')
+        isTextarea229 ||
+        (acceptsTextarea229 &&
+          this._ime229Owner === 'key' &&
+          this._ime229Baseline != null &&
+          e.type === 'keyup')
       if (ownsTextarea229) {
         if (e.type === 'keydown' && !this._composing) this._startIme229()
         else if (e.type === 'keyup') this._flushIme229(false)
@@ -507,6 +515,29 @@ export class TerminalInstance {
       let _trackedTextareaValue = ''
       textarea.addEventListener('input', ((e: Event) => {
         const ie = e as InputEvent
+        const tailReplacement = this._imeTailReplacement
+        if (tailReplacement) {
+          const matches =
+            !ie.isComposing &&
+            ie.inputType === 'insertText' &&
+            ie.data === tailReplacement.data &&
+            textarea.value === tailReplacement.value
+          this._imeTailReplacement = null
+          if (tailReplacement.sawRaw && matches) {
+            this._ime229InputData = ie.data
+            this._armIme229Fallback()
+            return
+          }
+          if (tailReplacement.sawRaw) {
+            // The DOM is the authoritative result. Reconcile from the original
+            // chain baseline so a later prediction mismatch cannot discard the
+            // earlier raw candidates that were already suppressed.
+            this._ime229InputData = ie.data
+            this._flushIme229(true)
+            return
+          }
+          this._clearIme229()
+        }
         if (this._ime229Baseline != null && !ie.isComposing) {
           this._ime229InputData = ie.data
           this._armIme229Fallback()
@@ -517,6 +548,42 @@ export class TerminalInstance {
       }) as EventListener)
       textarea.addEventListener('beforeinput', ((e: Event) => {
         const ie = e as InputEvent
+        // iOS dictation revises its current hypothesis by selecting a textarea
+        // tail and emitting the whole replacement as insertText. xterm treats
+        // that data as a fresh append, so arm our existing snapshot/diff path
+        // before xterm's input listener sees it. All unmatched events continue
+        // through the existing replacement-text handling below.
+        if (
+          isTouchDevice() &&
+          !isTauri() &&
+          settings.mobile_input_mode === 'system' &&
+          !this._composing &&
+          !ie.isComposing &&
+          !this.xterm?.options.screenReaderMode &&
+          ie.inputType === 'insertText' &&
+          typeof ie.data === 'string' &&
+          ie.data
+        ) {
+          const start = textarea.selectionStart
+          const end = textarea.selectionEnd
+          if (
+            start != null &&
+            end != null &&
+            start !== end &&
+            end === textarea.value.length &&
+            this._ime229Owner !== 'key'
+          ) {
+            if (this._ime229Baseline == null) this._startIme229('tail-replacement')
+            if (this._ime229Owner === 'tail-replacement') {
+              this._imeTailReplacement = {
+                data: ie.data,
+                value: `${textarea.value.slice(0, start)}${ie.data}`,
+                sawRaw: false,
+              }
+              return
+            }
+          }
+        }
         if (this._composing) return
         // Only intercept insertReplacementText (macOS text replacement);
         // insertText is normal typing and must not send backspaces.
@@ -774,8 +841,9 @@ export class TerminalInstance {
     }
   }
 
-  private _startIme229() {
+  private _startIme229(owner: 'key' | 'tail-replacement' = 'key') {
     if (!this._inputTextarea || this._ime229Baseline != null) return
+    this._ime229Owner = owner
     this._ime229Baseline = {
       value: this._inputTextarea.value,
       selectionStart: this._inputTextarea.selectionStart,
@@ -826,6 +894,8 @@ export class TerminalInstance {
     this._ime229Timer = null
     this._ime229Baseline = null
     this._ime229InputData = null
+    this._ime229Owner = null
+    this._imeTailReplacement = null
   }
 
   private _resolveSym(data: string, src: 0 | 1, now: number): boolean {
@@ -846,6 +916,16 @@ export class TerminalInstance {
     // key-replay dedup below must not eat them.
     if (this._wheel?.isBypassActive()) {
       this._emitInput(rawData)
+      return
+    }
+    const tailReplacement = this._imeTailReplacement
+    if (
+      !fromIme229 &&
+      this._ime229Owner === 'tail-replacement' &&
+      tailReplacement &&
+      rawData === tailReplacement.data
+    ) {
+      tailReplacement.sawRaw = true
       return
     }
     // The non-composition 229 cycle owns the final textarea diff. xterm can

--- a/frontend/src/test/useTerminalDeviceText.test.ts
+++ b/frontend/src/test/useTerminalDeviceText.test.ts
@@ -95,6 +95,39 @@ function lastXterm() {
   return mocks.instances[mocks.instances.length - 1]
 }
 
+function dispatchTextareaInsert(
+  textarea: HTMLTextAreaElement,
+  before: string,
+  selectionStart: number,
+  data: string,
+  after: string,
+  emitRaw = true
+) {
+  textarea.value = before
+  textarea.setSelectionRange(selectionStart, before.length)
+  textarea.dispatchEvent(
+    new InputEvent('beforeinput', {
+      bubbles: true,
+      composed: true,
+      data,
+      inputType: 'insertText',
+      isComposing: false,
+    })
+  )
+  textarea.value = after
+  textarea.setSelectionRange(after.length, after.length)
+  if (emitRaw) lastXterm().dataHandler!(data)
+  textarea.dispatchEvent(
+    new InputEvent('input', {
+      bubbles: true,
+      composed: true,
+      data,
+      inputType: 'insertText',
+      isComposing: false,
+    })
+  )
+}
+
 describe('useTerminal device text integration', () => {
   beforeEach(() => {
     mocks.instances.length = 0
@@ -296,6 +329,173 @@ describe('useTerminal device text integration', () => {
     lastXterm().dataHandler!('！')
 
     expect(input.mock.calls.map(([data]) => data)).toEqual(['！'])
+    term.destroy()
+  })
+
+  it('reconciles iOS dictation tail replacements instead of appending interim transcripts', async () => {
+    vi.useFakeTimers()
+    mocks.isTauri.mockReturnValue(false)
+    Object.defineProperty(navigator, 'maxTouchPoints', { configurable: true, value: 1 })
+    settings.mobile_input_mode = 'system'
+    const term = attach('p1')
+    const input = vi.fn()
+    term.onInput = input
+    const textarea = (term as any)._wrapper.querySelector(
+      '.xterm-helper-textarea'
+    ) as HTMLTextAreaElement
+
+    dispatchTextareaInsert(textarea, '', 0, '我', '我')
+    dispatchTextareaInsert(textarea, '我', 0, '我说一句', '我说一句')
+    dispatchTextareaInsert(textarea, '我说一句', 0, '我说一句话', '我说一句话')
+    dispatchTextareaInsert(
+      textarea,
+      '我说一句话',
+      0,
+      '我说一句话，你来理解我',
+      '我说一句话，你来理解我'
+    )
+    dispatchTextareaInsert(
+      textarea,
+      '我说一句话，你来理解我',
+      0,
+      '我说一句话，你来理解我的意思',
+      '我说一句话，你来理解我的意思'
+    )
+    await vi.advanceTimersByTimeAsync(80)
+
+    expect(input.mock.calls.map(([data]) => data)).toEqual(['我', '说一句话，你来理解我的意思'])
+
+    dispatchTextareaInsert(
+      textarea,
+      '我说一句话，你来理解我的意思',
+      12,
+      '意图',
+      '我说一句话，你来理解我的意图'
+    )
+    await vi.advanceTimersByTimeAsync(80)
+    expect(input.mock.calls.map(([data]) => data)).toEqual([
+      '我',
+      '说一句话，你来理解我的意思',
+      '\x7f图',
+    ])
+    term.destroy()
+    vi.useRealTimers()
+  })
+
+  it('reconciles the full observed dictation chain when a later DOM edit does not match', () => {
+    mocks.isTauri.mockReturnValue(false)
+    Object.defineProperty(navigator, 'maxTouchPoints', { configurable: true, value: 1 })
+    settings.mobile_input_mode = 'system'
+    const term = attach('p1')
+    const input = vi.fn()
+    term.onInput = input
+    const textarea = (term as any)._wrapper.querySelector(
+      '.xterm-helper-textarea'
+    ) as HTMLTextAreaElement
+
+    dispatchTextareaInsert(textarea, '', 0, '我', '我')
+    dispatchTextareaInsert(textarea, '我', 0, '我说一句', '我说一句')
+    dispatchTextareaInsert(textarea, '我说一句', 0, '我说一句话', '我说一句呢')
+
+    expect(input.mock.calls.map(([data]) => data)).toEqual(['我', '说一句呢'])
+    expect((term as any)._ime229Baseline).toBeNull()
+    term.destroy()
+  })
+
+  it('does not let an unrelated keyup flush a dictation-owned snapshot', async () => {
+    vi.useFakeTimers()
+    mocks.isTauri.mockReturnValue(false)
+    Object.defineProperty(navigator, 'maxTouchPoints', { configurable: true, value: 1 })
+    settings.mobile_input_mode = 'system'
+    const term = attach('p1')
+    const input = vi.fn()
+    term.onInput = input
+    const textarea = (term as any)._wrapper.querySelector(
+      '.xterm-helper-textarea'
+    ) as HTMLTextAreaElement
+
+    dispatchTextareaInsert(textarea, '', 0, '我', '我')
+    dispatchTextareaInsert(textarea, '我', 0, '我说一句', '我说一句')
+    expect(lastXterm().keyHandler!(new KeyboardEvent('keyup', { key: 'Shift' }))).toBe(true)
+    expect(input.mock.calls.map(([data]) => data)).toEqual(['我'])
+
+    await vi.advanceTimersByTimeAsync(80)
+    expect(input.mock.calls.map(([data]) => data)).toEqual(['我', '说一句'])
+    term.destroy()
+    vi.useRealTimers()
+  })
+
+  it('does not synthesize a dictation edit unless xterm emitted the matching raw input', async () => {
+    vi.useFakeTimers()
+    mocks.isTauri.mockReturnValue(false)
+    Object.defineProperty(navigator, 'maxTouchPoints', { configurable: true, value: 1 })
+    settings.mobile_input_mode = 'system'
+    const term = attach('p1')
+    const input = vi.fn()
+    term.onInput = input
+    const textarea = (term as any)._wrapper.querySelector(
+      '.xterm-helper-textarea'
+    ) as HTMLTextAreaElement
+
+    dispatchTextareaInsert(textarea, '旧候选', 0, '新候选', '新候选', false)
+    await vi.advanceTimersByTimeAsync(80)
+
+    expect(input).not.toHaveBeenCalled()
+    expect((term as any)._ime229Baseline).toBeNull()
+    term.destroy()
+    vi.useRealTimers()
+  })
+
+  it.each([
+    ['builtin input', 'builtin', false, false],
+    ['screen reader mode', 'system', true, false],
+    ['Tauri touch input', 'system', false, true],
+  ] as const)(
+    'leaves dictation-like tail input on xterm in %s',
+    (_case, mode, screenReaderMode, tauri) => {
+      mocks.isTauri.mockReturnValue(tauri)
+      Object.defineProperty(navigator, 'maxTouchPoints', { configurable: true, value: 1 })
+      settings.mobile_input_mode = mode
+      const term = attach('p1')
+      const input = vi.fn()
+      term.onInput = input
+      term.xterm!.options.screenReaderMode = screenReaderMode
+      const textarea = (term as any)._wrapper.querySelector(
+        '.xterm-helper-textarea'
+      ) as HTMLTextAreaElement
+
+      dispatchTextareaInsert(textarea, '旧候选', 0, '新候选', '新候选')
+
+      expect(input.mock.calls.map(([data]) => data)).toEqual(['新候选'])
+      expect((term as any)._ime229Baseline).toBeNull()
+      term.destroy()
+    }
+  )
+
+  it('preserves the desktop replacement-text workaround on Tauri touch input', () => {
+    mocks.isTauri.mockReturnValue(true)
+    Object.defineProperty(navigator, 'maxTouchPoints', { configurable: true, value: 1 })
+    settings.mobile_input_mode = 'system'
+    const term = attach('p1')
+    const sendData = vi.spyOn(term, 'sendData')
+    const textarea = (term as any)._wrapper.querySelector(
+      '.xterm-helper-textarea'
+    ) as HTMLTextAreaElement
+    textarea.value = 'ni'
+    textarea.dispatchEvent(
+      new InputEvent('input', { inputType: 'insertText', data: 'ni', isComposing: false })
+    )
+
+    textarea.dispatchEvent(
+      new InputEvent('beforeinput', {
+        inputType: 'insertReplacementText',
+        data: '你',
+        isComposing: false,
+      })
+    )
+
+    expect(sendData).toHaveBeenCalledOnce()
+    expect(sendData).toHaveBeenCalledWith('\x7f\x7f')
     term.destroy()
   })
 })


### PR DESCRIPTION
## Summary

- Prevent iOS system dictation's cumulative hypotheses from being appended as duplicate terminal input.

## Changes

- Detect non-composing `insertText` events that replace the current textarea tail on touch web clients using system input.
- Suppress only the matching xterm raw candidate, then reconcile the original textarea snapshot against the browser's authoritative final DOM value.
- Keep dictation snapshots isolated from keyCode 229 keyup handling and clear all pending state/timers on composition or teardown.
- Leave built-in input, screen-reader mode, Tauri/native input, and the existing desktop `insertReplacementText` workaround on their original paths.
- Add regression coverage for cumulative hypotheses, final-tail revisions, DOM prediction mismatches, missing raw events, unrelated keyup, and platform/mode guards.

## Test Plan

- [x] Tested locally
- [x] Frontend type-check passes (`pnpm build`, which runs `vue-tsc -b`)
- [x] No regressions on desktop browser
- [x] No regressions on mobile browser (if applicable)
- [x] Full frontend suite: 115 files / 1163 tests passed
- [x] Target ESLint: 0 errors
- [x] Full macOS Tauri test build and 8998 deployment completed from this branch
- [x] Real Chromium/xterm/WebSocket E2E on 8998:
  - cumulative hypotheses emitted only `我` + `说一句话，你来理解我的意思`
  - `意思` → `意图` emitted one DEL + `图`
  - a later DOM mismatch reconciled as `我` + `说一句呢`
- [x] Reporter confirmed the original phrase on iPhone after the fix

## Platform coverage

- Windows/Linux and Tauri are excluded by the web-only guard and retain the existing xterm/desktop replacement flow.
- Regression tests cover built-in input, screen-reader mode, Tauri touch pass-through, and the Tauri desktop replacement-text workaround.

## Visual Checklist

- [x] Not applicable — this PR has no visual or palette changes.
