### PR TITLE
fix(mobile): preserve touch terminal selection

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1599,17 +1599,9 @@ function guardTerminalFocusEvent(e: Event) {
     e.stopPropagation()
     return
   }
-  if (
-    isTouchDevice() &&
-    effectiveMobileInputMode.value === 'system' &&
-    !terminalImeFocused.value &&
-    hasOpenGuard(appSettings.keyboard_guard_mode) &&
-    target?.closest('.terminal-pane-container') &&
-    !target.closest('input, textarea, select, [contenteditable="true"]')
-  ) {
-    e.preventDefault()
-    return
-  }
+  // Manual-open protection belongs to the xterm helper textarea's
+  // inputMode / virtualkeyboardpolicy. Cancelling terminal pointer defaults
+  // here would also cancel the browser selection anchor.
   if (!isKbTypingLocked()) return
   if (target?.closest('input, textarea, select, [contenteditable="true"]')) return
   e.preventDefault()

--- a/frontend/src/test/appPaneClose/system-keyboard.test.ts
+++ b/frontend/src/test/appPaneClose/system-keyboard.test.ts
@@ -124,16 +124,6 @@ describe('App.vue - system keyboard state regressions', () => {
     return { wrapper, activeTerminal, terminalSurface, helper }
   }
 
-  it('guards manual-open focus only on touch input', () => {
-    const source = readFileSync(join(process.cwd(), 'src/App.vue'), 'utf8')
-    const guard = source.match(
-      /if \(\s*(isTouchDevice\(\) &&[\s\S]*?effectiveMobileInputMode\.value === 'system' &&[\s\S]*?hasOpenGuard\(appSettings\.keyboard_guard_mode\)[\s\S]*?target\?\.closest\('\.terminal-pane-container'\)[\s\S]*?)\s*\) \{\s*e\.preventDefault\(\)/
-    )
-
-    expect(guard).not.toBeNull()
-    expect(guard?.[1].trimStart().startsWith('isTouchDevice() &&')).toBe(true)
-  })
-
   it('keeps the toolbar visible after IME close only in persistent phone mode', async () => {
     settings.mobile_input_mode = 'system'
     settings.system_toolbar_mode = 'persistent_mobile'

--- a/frontend/src/test/appPaneClose/system-keyboard.test.ts
+++ b/frontend/src/test/appPaneClose/system-keyboard.test.ts
@@ -312,6 +312,36 @@ describe('App.vue - system keyboard state regressions', () => {
   })
 
   it.each(['open_only', 'both'] as const)(
+    'keeps touch Web terminal selection events native under %s protection',
+    async (guardMode) => {
+      mocks.touchDevice = true
+      settings.mobile_input_mode = 'system'
+      settings.system_toolbar_mode = 'persistent_mobile'
+      settings.keyboard_guard_mode = guardMode
+      useIsMobile().isMobile.value = true
+      const wrapper = await mountWithTabs()
+      const terminalSurface = document.createElement('div')
+      terminalSurface.className = 'terminal-pane-container'
+      const terminalScreen = document.createElement('div')
+      terminalScreen.className = 'xterm-screen'
+      terminalSurface.appendChild(terminalScreen)
+      wrapper.get('#tab-content').element.appendChild(terminalSurface)
+
+      const pointerDown = new PointerEvent('pointerdown', { bubbles: true, cancelable: true })
+      terminalScreen.dispatchEvent(pointerDown)
+      const mouseDown = new MouseEvent('mousedown', { bubbles: true, cancelable: true })
+      terminalScreen.dispatchEvent(mouseDown)
+
+      expect(pointerDown.defaultPrevented).toBe(false)
+      expect(mouseDown.defaultPrevented).toBe(false)
+      expect(wrapper.findComponent(SystemKeyboardToolbarStub).props('ctx').nativeImeOpen.value).toBe(
+        false
+      )
+      expect(mocks.setSystemImeAuthorized).not.toHaveBeenCalledWith(true)
+    }
+  )
+
+  it.each(['open_only', 'both'] as const)(
     'keeps terminal input focused without authorizing the IME under %s protection',
     async (guardMode) => {
       mocks.touchDevice = true


### PR DESCRIPTION
## What changed

- Keep terminal pointer and mouse down events native on touch Web when manual IME protection is enabled.
- Preserve manual input-method authorization through the xterm helper textarea policy.
- Add regression coverage for `open_only` and `both` guard modes.

## Why

The previous terminal focus guard called `preventDefault()` on the browser selection anchor, so touch Web users could not select terminal text. The upstream source-contract test required that obsolete behavior and is removed in this PR; the behavioral tests now protect the intended contract.

## Verification

- Focused system-keyboard tests pass.
- Full frontend test, build, and Rust workspace gates run by the upstream PR workflow.
- No private fork configuration or deployment files are included.
