### PR TITLE
chore: bump version to 0.23.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1615,7 +1615,7 @@ dependencies = [
 
 [[package]]
 name = "dinotty-desktop"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
@@ -1654,7 +1654,7 @@ dependencies = [
 
 [[package]]
 name = "dinotty-server"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "arboard",
  "axum 0.7.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["src-tauri"]
 
 [workspace.package]
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/xichan96/dinotty"


### PR DESCRIPTION
## Summary

- Bump workspace version to 0.23.0 to match release tag (Package workflow version validation)

## Test plan

- [x] Cargo.lock workspace member versions refreshed