### PR TITLE
fix: Windows CI build failures

### DIFF
--- a/frontend/src/keyboard/builtin-keyboard/vite.config.ts
+++ b/frontend/src/keyboard/builtin-keyboard/vite.config.ts
@@ -54,9 +54,12 @@ export default defineConfig({
       // Fallback for @/ specifiers pointing to source files that are bundled
       // as-is (pure helpers, local SFC leaves, icons). Must come after the
       // host-composable aliases so those take precedence.
+      // fileURLToPath yields backslashes on Windows; vite only normalizes
+      // trailing slashes when BOTH find and replacement end with '/', so keep
+      // forward slashes or the '@/' prefix match silently breaks on Windows.
       {
         find: '@/',
-        replacement: fileURLToPath(new URL('../../../src/', import.meta.url)),
+        replacement: fileURLToPath(new URL('../../../src/', import.meta.url)).replace(/\\/g, '/'),
       },
     ],
   },

--- a/src-tauri/src/autostart.rs
+++ b/src-tauri/src/autostart.rs
@@ -563,8 +563,10 @@ mod platform {
             return None;
         }
         let mut units = bytes
-            .chunks_exact(2)
-            .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|pair| u16::from_le_bytes(*pair))
             .collect::<Vec<_>>();
         if units.last() == Some(&0) {
             units.pop();

--- a/src/platform/shell_probe.rs
+++ b/src/platform/shell_probe.rs
@@ -411,7 +411,7 @@ fn decode_wsl_text(bytes: &[u8]) -> Result<String, ()> {
         if body.len() % 2 != 0 {
             return Err(());
         }
-        let units = body.chunks_exact(2).map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]));
+        let units = body.as_chunks::<2>().0.iter().map(|chunk| u16::from_le_bytes(*chunk));
         return std::char::decode_utf16(units).collect::<Result<String, _>>().map_err(|_| ());
     }
     std::str::from_utf8(body).map(str::to_string).map_err(|_| ())

--- a/src/token.rs
+++ b/src/token.rs
@@ -732,11 +732,13 @@ mod tests {
             scoped.with_file_name(format!("{}2", scoped.file_name().unwrap().to_string_lossy()));
         assert!(!info.check_path_scope("workspace:read", &sibling));
 
-        // `~` expansion
+        // `~` expansion. Windows temp_dir() lives under the home directory,
+        // so use a sibling of home to get a path guaranteed outside it.
         let home = dirs::home_dir().unwrap().canonicalize().unwrap();
         let info = path_info(vec!["~/".into()]);
         assert!(info.check_path_scope("workspace:read", &home));
-        assert!(!info.check_path_scope("workspace:read", &tmp.join("definitely-not-home")));
+        let outside_home = home.parent().unwrap().join("definitely-not-home");
+        assert!(!info.check_path_scope("workspace:read", &outside_home));
 
         // Nonexistent scope entries are skipped
         let info = path_info(vec!["/nonexistent/dinotty-scope-dir".into()]);


### PR DESCRIPTION
## Summary
- fix(keyboard): make builtin-keyboard `@/` alias resolve on Windows (vite alias trailing-slash normalization)
- fix(ci): replace `chunks_exact` with `as_chunks` for clippy 1.98 (`chunks_exact_to_as_chunks`)
- fix(test): use path outside home for `~/` scope assertion (Windows temp_dir lives under home)

## Test plan
- [x] Windows CI (self-hosted) green on dev @ 5b291ac
- [x] Linux CI green on dev @ 5b291ac
- [x] Local: `npm run build:builtin-kb` output unchanged; `cargo clippy` clean; `cargo test token::tests::test_path_scope_check` passes