### PR TITLE
chore: bump version to 0.23.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1615,7 +1615,7 @@ dependencies = [
 
 [[package]]
 name = "dinotty-desktop"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
@@ -1654,7 +1654,7 @@ dependencies = [
 
 [[package]]
 name = "dinotty-server"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "arboard",
  "axum 0.7.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["src-tauri"]
 
 [workspace.package]
-version = "0.23.0"
+version = "0.23.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/xichan96/dinotty"


### PR DESCRIPTION
## Summary
- 版本号 0.23.0 -> 0.23.1（Cargo.toml + Cargo.lock），对齐已发布的 v0.23.1 tag

## Test plan
- [ ] `cargo build` 通过（仅版本号变更，无代码逻辑改动）