### PR TITLE
fix(mobile): cancel the visual-viewport pan on non-scrollable chrome

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -7,6 +7,7 @@
   <div
     v-else
     id="app-root"
+    ref="appRootRef"
     :class="{
       'system-toolbar-docked': effectiveMobileInputMode === 'system' && systemToolbarVisible,
       'system-ime-open': effectiveMobileInputMode === 'system' && systemKeyboardOpen,
@@ -441,6 +442,7 @@ const windowCloseConfirmVisible = ref(false)
 const trayVisibilityDialogVisible = ref(false)
 const previewMenuOpen = ref(false)
 const lastTabCloseShortcutAt = ref(0)
+const appRootRef = ref<HTMLElement | null>(null)
 const tabBarRef = ref<InstanceType<typeof TabBar> | null>(null)
 const paletteRef = ref<InstanceType<typeof CommandPalette>>()
 const bookmarksRef = ref<InstanceType<typeof CommandBookmarks>>()
@@ -468,7 +470,7 @@ const actions = useAppActions({
   lastTabCloseShortcutAt,
   toast,
 })
-const keyboard = useAppKeyboard({ core, actions, settingsStore, bookmarksRef })
+const keyboard = useAppKeyboard({ core, actions, settingsStore, bookmarksRef, appRootRef })
 const connectivity = useAppConnectivity({ core, sshPanelRef, persist })
 const tauri = useAppTauri({
   desktopLifecycle,
@@ -581,6 +583,7 @@ const {
   systemKeyboardOpen,
   keyboardCtx,
   disposeViewport,
+  disposePanLock,
   toggleTerminalKeyboard,
   onSystemActionKeyboardChange,
   onMobileInputGuideChoose,
@@ -757,6 +760,7 @@ onBeforeUnmount(() => {
   window.removeEventListener('pane-drag-hover-switch', onPaneDragHoverSwitch)
   window.removeEventListener('hashchange', syncKbDebugFlag)
   disposeViewport()
+  disposePanLock()
   syncWs.closeWs()
 })
 </script>

--- a/frontend/src/composables/useAppKeyboard.ts
+++ b/frontend/src/composables/useAppKeyboard.ts
@@ -3,6 +3,7 @@ import { createKeyboardContext } from '../keyboard/createKeyboardContext'
 import { useKeyboardBand } from '../keyboard/useKeyboardBand'
 import type { KeyboardHostEventMap } from '../../../plugin-api/index'
 import { useViewportResize } from './useViewportResize'
+import { useViewportPanLock } from './useViewportPanLock'
 import { useOverlayKeyboardBroadcast } from './useOverlayKeyboardBroadcast'
 import { useKeyboardOverlap } from './useKeyboardOverlap'
 import { imeKeyboardOverlapPx, type MobileInputMode } from './useSettings'
@@ -28,10 +29,11 @@ export interface AppKeyboardOptions {
   actions: ReturnType<typeof useAppActions>
   settingsStore: ReturnType<typeof useSettingsStore>
   bookmarksRef: Ref<{ open(): void } | undefined>
+  appRootRef: Ref<HTMLElement | null>
 }
 
 export function useAppKeyboard(options: AppKeyboardOptions) {
-  const { core, actions, settingsStore, bookmarksRef } = options
+  const { core, actions, settingsStore, bookmarksRef, appRootRef } = options
   const { dispatchAppAction } = actions
   const {
     kbTyping,
@@ -193,6 +195,13 @@ export function useAppKeyboard(options: AppKeyboardOptions) {
     termRefs,
     terminalImeFocused,
     onSystemKeyboardClose: onSystemKeyboardClosed,
+  })
+
+  const { dispose: disposePanLock } = useViewportPanLock(appRootRef, {
+    isActive: () =>
+      effectiveMobileInputMode.value === 'system' &&
+      terminalImeFocused.value &&
+      systemKeyboardOpen.value,
   })
 
   useOverlayKeyboardBroadcast({ systemKeyboardOpen, kbVisible })
@@ -607,6 +616,7 @@ export function useAppKeyboard(options: AppKeyboardOptions) {
     systemKeyboardOpen,
     isLandscape,
     disposeViewport,
+    disposePanLock,
     dismissTerminalKeyboard,
     closeSystemIme,
     requestTerminalKeyboard,

--- a/frontend/src/composables/useViewportPanLock.ts
+++ b/frontend/src/composables/useViewportPanLock.ts
@@ -1,0 +1,102 @@
+import { onBeforeUnmount, onMounted, watch, type Ref } from 'vue'
+
+export interface PanLockDeps {
+  isActive: () => boolean
+}
+
+export function findScrollableAncestor(
+  target: Element | null,
+  root: Element,
+  deltaY: number
+): Element | null {
+  if (typeof window === 'undefined') return null
+
+  let current = target
+  while (current) {
+    const overflowY = window.getComputedStyle(current).overflowY
+    const isScrollable =
+      (overflowY === 'auto' || overflowY === 'scroll') &&
+      current.scrollHeight - current.clientHeight > 1
+    if (isScrollable) {
+      const canMove =
+        (deltaY > 0 && current.scrollTop > 0) ||
+        (deltaY < 0 && current.scrollTop + current.clientHeight < current.scrollHeight - 1)
+      // An exact boundary is intentionally not a match, so rubber-band overscroll is cancelled.
+      if (canMove) return current
+    }
+    if (current === root) break
+    current = current.parentElement
+  }
+  return null
+}
+
+export function useViewportPanLock(
+  root: Ref<HTMLElement | null>,
+  deps: PanLockDeps
+): { dispose: () => void } {
+  let attachedRoot: HTMLElement | null = null
+  let eligible = false
+  let startX = 0
+  let startY = 0
+  let stopWatching: (() => void) | null = null
+
+  const touchMoveOptions: AddEventListenerOptions = { passive: false }
+
+  function onTouchStart(event: TouchEvent) {
+    eligible = event.touches.length === 1
+    if (!eligible) return
+    startX = event.touches[0].clientX
+    startY = event.touches[0].clientY
+  }
+
+  function onTouchMove(event: TouchEvent) {
+    if (!eligible || event.touches.length !== 1 || !event.cancelable || !deps.isActive()) return
+    const deltaX = event.touches[0].clientX - startX
+    const deltaY = event.touches[0].clientY - startY
+    if (Math.abs(deltaY) <= Math.abs(deltaX)) return
+    const target = event.target instanceof Element ? event.target : null
+    if (attachedRoot && findScrollableAncestor(target, attachedRoot, deltaY) === null) {
+      event.preventDefault()
+    }
+  }
+
+  function clearGesture() {
+    eligible = false
+  }
+
+  function detach() {
+    if (!attachedRoot) return
+    attachedRoot.removeEventListener('touchstart', onTouchStart)
+    attachedRoot.removeEventListener('touchmove', onTouchMove, touchMoveOptions)
+    attachedRoot.removeEventListener('touchend', clearGesture)
+    attachedRoot.removeEventListener('touchcancel', clearGesture)
+    attachedRoot = null
+    clearGesture()
+  }
+
+  function attach(nextRoot: HTMLElement | null) {
+    if (nextRoot === attachedRoot) return
+    detach()
+    if (!nextRoot) return
+    attachedRoot = nextRoot
+    attachedRoot.addEventListener('touchstart', onTouchStart, { passive: true })
+    attachedRoot.addEventListener('touchmove', onTouchMove, touchMoveOptions)
+    attachedRoot.addEventListener('touchend', clearGesture)
+    attachedRoot.addEventListener('touchcancel', clearGesture)
+  }
+
+  function dispose() {
+    stopWatching?.()
+    stopWatching = null
+    detach()
+  }
+
+  if (typeof window !== 'undefined') {
+    onMounted(() => {
+      stopWatching = watch(root, attach, { immediate: true, flush: 'post' })
+    })
+    onBeforeUnmount(dispose)
+  }
+
+  return { dispose }
+}

--- a/frontend/src/test/useViewportPanLock.test.ts
+++ b/frontend/src/test/useViewportPanLock.test.ts
@@ -1,0 +1,145 @@
+import { defineComponent, h, ref } from 'vue'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { useViewportPanLock } from '../composables/useViewportPanLock'
+
+type Fixture = VueWrapper & { vm: { dispose: () => void } }
+
+function mountFixture(isActive = true): Fixture {
+  const component = defineComponent({
+    setup(_, { expose }) {
+      const root = ref<HTMLElement | null>(null)
+      const { dispose } = useViewportPanLock(root, { isActive: () => isActive })
+      expose({ dispose })
+      return () =>
+        h('div', { ref: root }, [h('div', { class: 'chrome' }), h('div', { class: 'terminal' })])
+    },
+  })
+  return mount(component, { attachTo: document.body }) as Fixture
+}
+
+function dispatchTouch(
+  target: Element,
+  type: string,
+  touches: Array<{ clientX: number; clientY: number }>,
+  cancelable = true
+) {
+  const event = new Event(type, { bubbles: true, cancelable }) as TouchEvent
+  Object.defineProperty(event, 'touches', { value: touches })
+  const preventDefault = vi.spyOn(event, 'preventDefault')
+  target.dispatchEvent(event)
+  return preventDefault
+}
+
+function start(target: Element, touches = [{ clientX: 10, clientY: 10 }]) {
+  dispatchTouch(target, 'touchstart', touches)
+}
+
+function makeScrollable(element: HTMLElement, scrollTop: number) {
+  Object.defineProperties(element, {
+    scrollHeight: { configurable: true, value: 300 },
+    clientHeight: { configurable: true, value: 100 },
+    scrollTop: { configurable: true, value: scrollTop },
+  })
+  vi.spyOn(window, 'getComputedStyle').mockImplementation(
+    (candidate) =>
+      ({ overflowY: candidate === element ? 'auto' : 'visible' }) as CSSStyleDeclaration
+  )
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  document.body.replaceChildren()
+})
+
+describe('useViewportPanLock', () => {
+  it('prevents a vertical drag on non-scrollable chrome while the keyboard is open', () => {
+    const wrapper = mountFixture()
+    const chrome = wrapper.get('.chrome').element
+    start(chrome)
+    expect(
+      dispatchTouch(chrome, 'touchmove', [{ clientX: 10, clientY: 30 }])
+    ).toHaveBeenCalledOnce()
+    wrapper.unmount()
+  })
+
+  it('does not prevent the same drag when inactive', () => {
+    const wrapper = mountFixture(false)
+    const chrome = wrapper.get('.chrome').element
+    start(chrome)
+    expect(
+      dispatchTouch(chrome, 'touchmove', [{ clientX: 10, clientY: 30 }])
+    ).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('does not prevent terminal scrollback that can still scroll in the gesture direction', () => {
+    const wrapper = mountFixture()
+    const terminal = wrapper.get('.terminal').element as HTMLElement
+    makeScrollable(terminal, 50)
+    start(terminal)
+    expect(
+      dispatchTouch(terminal, 'touchmove', [{ clientX: 10, clientY: 30 }])
+    ).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('prevents terminal scrollback at the boundary in the gesture direction', () => {
+    const wrapper = mountFixture()
+    const terminal = wrapper.get('.terminal').element as HTMLElement
+    makeScrollable(terminal, 0)
+    start(terminal)
+    expect(
+      dispatchTouch(terminal, 'touchmove', [{ clientX: 10, clientY: 30 }])
+    ).toHaveBeenCalledOnce()
+    wrapper.unmount()
+  })
+
+  it('leaves predominantly horizontal drags alone', () => {
+    const wrapper = mountFixture()
+    const chrome = wrapper.get('.chrome').element
+    start(chrome)
+    expect(
+      dispatchTouch(chrome, 'touchmove', [{ clientX: 40, clientY: 20 }])
+    ).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('leaves two-finger gestures alone', () => {
+    const wrapper = mountFixture()
+    const chrome = wrapper.get('.chrome').element
+    start(chrome, [
+      { clientX: 10, clientY: 10 },
+      { clientX: 20, clientY: 20 },
+    ])
+    expect(
+      dispatchTouch(chrome, 'touchmove', [
+        { clientX: 10, clientY: 30 },
+        { clientX: 20, clientY: 40 },
+      ])
+    ).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('does not prevent a non-cancelable event', () => {
+    const wrapper = mountFixture()
+    const chrome = wrapper.get('.chrome').element
+    start(chrome)
+    expect(
+      dispatchTouch(chrome, 'touchmove', [{ clientX: 10, clientY: 30 }], false)
+    ).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('does not prevent touchmove after disposal', () => {
+    const wrapper = mountFixture()
+    const chrome = wrapper.get('.chrome').element
+    start(chrome)
+    wrapper.vm.dispose()
+    expect(
+      dispatchTouch(chrome, 'touchmove', [{ clientX: 10, clientY: 30 }])
+    ).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
On iOS, a touch drag that starts anywhere non-scrollable pans the **visual viewport**: the whole page slides underneath the fixed chrome, and the terminal ends up somewhere the layout never put it. It does not scroll back on its own — you have to tap around until WebKit decides to restore it.

The two surfaces users actually hit this on are the system-keyboard toolbar and the status bar, because those are the parts of the UI you are most likely to press and drag while the native IME is up.

### What this does

Adds `useViewportPanLock`, which cancels such a `touchmove` unless a genuine scrollable ancestor can absorb it.

`findScrollableAncestor` walks `target → root` looking for `overflow-y: auto | scroll` with real scrollable content **and** room left to move in the requested direction:

- dragging down (`deltaY > 0`) requires `scrollTop > 0`
- dragging up requires `scrollTop + clientHeight < scrollHeight - 1`

The exact boundary deliberately does **not** match. That asymmetry is the point: a container already scrolled to its top still lets an upward drag through to the page, while a downward one is cancelled, so rubber-band overscroll is suppressed without breaking ordinary scrolling anywhere inside the app.

### Guards

In order, before anything is cancelled:

- single touch only (a pinch is never a pan)
- the event must be cancelable
- vertical movement must dominate horizontal (`|deltaY| > |deltaX|`)
- the caller's `isActive()` must hold

`App.vue` wires `isActive` to system input mode **and** terminal IME focus **and** keyboard open, so the listener is inert on desktop and whenever the keyboard is down.

`touchstart` is registered passive; only `touchmove` is non-passive, and only `touchmove` can `preventDefault`. `touchend` / `touchcancel` clear the gesture. `dispose()` removes every listener.

### Testing

- `useViewportPanLock.test.ts`, 8 cases covering the direction asymmetry, the multi-touch and non-cancelable bail-outs, the horizontal-dominance bail-out, and the `isActive` gate.
- `vue-tsc --noEmit` clean, `prettier --check` clean.
- Full frontend suite on this branch: 1316 passed, 15 failed. **All 15 failures are `src/test/OverlayDragItem.test.ts` and are pre-existing on `dev`** — I reproduced them on a clean checkout of `dev` at `8b644d9` with none of this change present, same 15. Nothing here touches that file or anything it imports.
- Behaviour verified on a physical iPhone, both in mobile Safari and in an installed home-screen web app.
