### PR TITLE
fix(plugin): resolve the plugin store from the instance root so a suffixed build is isolated

### DIFF
--- a/src/plugin/manager.rs
+++ b/src/plugin/manager.rs
@@ -102,13 +102,21 @@ pub struct PluginManager {
 
 pub type PluginManagerState = Arc<PluginManager>;
 
+fn instance_root(home: &Path, suffix: &str) -> PathBuf {
+    home.join(format!(".dinotty{suffix}"))
+}
+
 impl PluginManager {
     #[must_use]
     pub fn new(host_origin: String, host_mode: String) -> Self {
         let home = dirs::home_dir().unwrap_or_default();
+        let root = instance_root(&home, &crate::settings::instance_suffix());
+        let plugin_dir = root.join("plugins");
+        let data_dir = root.join("plugin-data");
+        tracing::info!(plugin_dir = %plugin_dir.display(), "Resolved plugin directory");
         Self {
-            plugin_dir: home.join(".dinotty/plugins"),
-            data_dir: home.join(".dinotty/plugin-data"),
+            plugin_dir,
+            data_dir,
             registry: DashMap::new(),
             processes: DashMap::new(),
             operation_locks: DashMap::new(),
@@ -817,5 +825,103 @@ impl PluginManager {
 
         self.registry.remove(id);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{instance_root, PluginManager};
+    use std::ffi::OsString;
+    use std::path::Path;
+    use std::sync::Mutex;
+
+    const COMPILE_TIME_SUFFIX: Option<&str> = option_env!("DINOTTY_CONFIG_SUFFIX");
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvVarGuard {
+        name: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(name: &'static str, value: &str) -> Self {
+            let previous = std::env::var_os(name);
+            std::env::set_var(name, value);
+            Self { name, previous }
+        }
+
+        fn unset(name: &'static str) -> Self {
+            let previous = std::env::var_os(name);
+            std::env::remove_var(name);
+            Self { name, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(previous) = &self.previous {
+                std::env::set_var(self.name, previous);
+            } else {
+                std::env::remove_var(self.name);
+            }
+        }
+    }
+
+    #[test]
+    fn empty_suffix_keeps_default_plugin_directories() {
+        let home = Path::new("/home/example");
+        let root = instance_root(home, "");
+
+        assert_eq!(root.join("plugins"), home.join(".dinotty/plugins"));
+        assert_eq!(root.join("plugin-data"), home.join(".dinotty/plugin-data"));
+    }
+
+    #[test]
+    fn non_empty_suffix_moves_both_plugin_directories() {
+        let home = Path::new("/home/example");
+        let root = instance_root(home, "-test");
+
+        assert_eq!(root.join("plugins"), home.join(".dinotty-test/plugins"));
+        assert_eq!(root.join("plugin-data"), home.join(".dinotty-test/plugin-data"));
+    }
+
+    #[test]
+    fn new_resolves_both_directories_through_the_instance_suffix() {
+        let _env_lock = ENV_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        // This env var is process-global, so its directory must not be used by any live instance.
+        let _suffix = EnvVarGuard::set("DINOTTY_CONFIG_SUFFIX", "-plugin-manager-wiring-test");
+
+        let manager = PluginManager::new("http://localhost:8998".into(), "test".into());
+        let suffix = crate::settings::instance_suffix();
+
+        assert!(manager.plugin_dir.ends_with(format!(".dinotty{suffix}/plugins")));
+        assert!(manager.data_dir.ends_with(format!(".dinotty{suffix}/plugin-data")));
+    }
+
+    #[test]
+    fn instance_suffix_uses_runtime_environment_value() {
+        // The runtime fallback is unreachable when this value was embedded at compile time.
+        if COMPILE_TIME_SUFFIX.is_some() {
+            return;
+        }
+
+        let _env_lock = ENV_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _suffix = EnvVarGuard::set("DINOTTY_CONFIG_SUFFIX", "-plugin-manager-wiring-test");
+
+        assert_eq!(crate::settings::instance_suffix(), "-plugin-manager-wiring-test");
+    }
+
+    #[test]
+    fn instance_suffix_defaults_to_empty_when_runtime_environment_is_absent() {
+        // The runtime fallback is unreachable when this value was embedded at compile time.
+        if COMPILE_TIME_SUFFIX.is_some() {
+            return;
+        }
+
+        let _env_lock = ENV_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _suffix = EnvVarGuard::unset("DINOTTY_CONFIG_SUFFIX");
+
+        assert_eq!(crate::settings::instance_suffix(), "");
     }
 }

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -38,14 +38,19 @@ pub(crate) use normalize::{
 pub(crate) use types::default_scroll_acceleration;
 
 #[must_use]
-pub fn config_dir() -> PathBuf {
+pub fn instance_suffix() -> String {
     // Compile-time suffix (set via build script / `DINOTTY_CONFIG_SUFFIX` at
     // build) takes precedence; otherwise fall back to the runtime env var
     // (used by integration tests to isolate each server's config dir).
-    let suffix = option_env!("DINOTTY_CONFIG_SUFFIX")
+    option_env!("DINOTTY_CONFIG_SUFFIX")
         .map(str::to_string)
         .or_else(|| std::env::var("DINOTTY_CONFIG_SUFFIX").ok())
-        .unwrap_or_default();
+        .unwrap_or_default()
+}
+
+#[must_use]
+pub fn config_dir() -> PathBuf {
+    let suffix = instance_suffix();
     dirs::config_dir().unwrap_or_else(|| PathBuf::from(".")).join(format!("dinotty{suffix}"))
 }
 


### PR DESCRIPTION
`DINOTTY_CONFIG_SUFFIX` already isolates the **configuration** directory per instance, so two builds of Dinotty on one machine get their own settings. The **plugin store** does not follow: `PluginManager` hardcodes `home/.dinotty/plugins` and `home/.dinotty/plugin-data` regardless of the suffix, so every instance on the machine shares one plugin directory.

### Why that is not benign

The plugin directory is watched, and a change broadcasts `plugin_changed` to connected clients, which hot-swap the plugin's `<style>` element after a short debounce — no page reload.

So installing or reseeding a plugin from a suffixed build reaches into an unsuffixed one and mutates its running UI within about a second. There is no signal that anything crossed instances. I hit this while trying to verify a keyboard change on a test build without disturbing the one I use daily; the test build's reseed changed the daily build's UI while I was looking at it.

### The change

- The suffix lookup moves into `settings::instance_suffix()`.
- `config_dir()` and the new `instance_root()` both read from that one function, so the two cannot drift apart again.
- `PluginManager::new` derives both plugin paths from `instance_root()`.

With no suffix set, `instance_root()` resolves to `home/.dinotty` and every path is byte-identical to today. This is a no-op for anyone not using the suffix.

### Testing

- Two tests drive `PluginManager::new` itself rather than the pure helper, so removing `instance_suffix()` from the call site — the exact regression this exists to prevent — fails them. An earlier revision tested only the helper and stayed green under that mutation.
- They use a suffix that names no real instance directory, so a concurrently scheduled test resolving `config_dir()` can never touch a live instance's store.
- The runtime-fallback assertions are gated on `option_env!` being `None`, because a compile-time suffix takes precedence over the runtime lookup and would otherwise make one of them fail deterministically and the other pass without exercising the fallback at all.
- `cargo test` 618 passed / 0 failed, `cargo fmt --check` clean, `cargo clippy --all-targets` clean.
