### PR TITLE
fix(keyboard): ship only the plugin's own scoped CSS in the builtin-keyboard seed

### DIFF
--- a/frontend/src/keyboard/builtin-keyboard/build-seed.mjs
+++ b/frontend/src/keyboard/builtin-keyboard/build-seed.mjs
@@ -1,35 +1,177 @@
 import { copyFileSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
-import { fileURLToPath, URL } from 'node:url'
+import { fileURLToPath, pathToFileURL, URL } from 'node:url'
 
 // Assemble the seed artifact from the vite lib-build output:
-//   mobile-keyboard.css (global host styles) + scoped.css (this build's SFC hashes) -> styles.css
+//   scoped.css (this build's SFC hashes) -> styles.css
 //   plugin.json (source manifest) -> seed/builtin-keyboard/plugin.json
-const here = fileURLToPath(new URL('.', import.meta.url))
-const outDir = fileURLToPath(new URL('../../../../seed/builtin-keyboard', import.meta.url))
+function stripComments(css) {
+  let output = ''
+  let quote = null
 
-mkdirSync(outDir, { recursive: true })
+  for (let index = 0; index < css.length; index += 1) {
+    const char = css[index]
+    const next = css[index + 1]
 
-// Vite's emptyOutDir is unreliable when outDir is outside project root; clean
-// stale artifacts (old PWA files, previous scoped.css) while preserving this
-// build's output.
-for (const entry of readdirSync(outDir)) {
-  if (entry === 'main.js' || entry === 'scoped.css') continue
-  rmSync(`${outDir}/${entry}`, { recursive: true, force: true })
+    if (quote) {
+      output += char
+      if (char === '\\') {
+        output += next ?? ''
+        index += 1
+      } else if (char === quote) {
+        quote = null
+      }
+      continue
+    }
+
+    if (char === '\\') {
+      output += char
+      output += next ?? ''
+      index += 1
+      continue
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char
+      output += char
+    } else if (char === '/' && next === '*') {
+      const end = css.indexOf('*/', index + 2)
+      index = end === -1 ? css.length : end + 1
+    } else {
+      output += char
+    }
+  }
+
+  return output
 }
 
-const globalCss = readFileSync(
-  fileURLToPath(new URL('../../styles/mobile-keyboard.css', import.meta.url)),
-  'utf8'
-)
-const scopedCss = readFileSync(`${outDir}/scoped.css`, 'utf8')
-writeFileSync(
-  `${outDir}/styles.css`,
-  `${globalCss}\n/* scoped SFC styles (this build's data-v hashes) */\n${scopedCss}`
-)
+function stripStrings(css) {
+  let output = ''
+  let quote = null
 
-// scoped.css is an intermediate build product; the shipped styles file is styles.css.
-rmSync(`${outDir}/scoped.css`, { force: true })
+  for (let index = 0; index < css.length; index += 1) {
+    const char = css[index]
+    const next = css[index + 1]
 
-copyFileSync(`${here}/plugin.json`, `${outDir}/plugin.json`)
+    if (quote) {
+      if (char === '\\') {
+        index += 1
+      } else if (char === quote) {
+        quote = null
+        output += char
+      }
+      continue
+    }
 
-console.log(`seed/builtin-keyboard: ${outDir}`)
+    if (char === '\\') {
+      output += char
+      output += next ?? ''
+      index += 1
+      continue
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char
+      output += char
+    } else {
+      output += char
+    }
+  }
+
+  return output
+}
+
+function stripUnquotedUrls(css) {
+  let output = ''
+
+  for (let index = 0; index < css.length; index += 1) {
+    const isUrl =
+      css.slice(index, index + 4).toLowerCase() === 'url(' &&
+      (index === 0 || !/[\w-]/.test(css[index - 1]))
+
+    if (!isUrl) {
+      output += css[index]
+      continue
+    }
+
+    const contentStart = index + 4
+    let contentIndex = contentStart
+    while (/\s/.test(css[contentIndex] ?? '')) contentIndex += 1
+
+    if (css[contentIndex] === '"' || css[contentIndex] === "'") {
+      output += css.slice(index, contentStart)
+      index = contentStart - 1
+      continue
+    }
+
+    let closingParen = contentIndex
+    while (closingParen < css.length && css[closingParen] !== ')') {
+      if (css[closingParen] === '\\') closingParen += 1
+      closingParen += 1
+    }
+
+    output += css.slice(index, contentStart)
+    if (closingParen < css.length) {
+      output += ')'
+      index = closingParen
+    } else {
+      index = css.length
+    }
+  }
+
+  return output
+}
+
+// Tripwire for one specific regression: host global CSS reaching the seed broke the mobile toolbar
+// because the seeded <style> is injected after the core stylesheet at equal specificity, allowing a
+// host selector to override the app's own rule. This does not prove every selector is scoped; the
+// universal selector is deliberately not checked because it is indistinguishable from calc()
+// multiplication without a real CSS parser, which this package deliberately does not carry. The actual
+// fix is that the seed no longer concatenates the host stylesheet, and this check is belt-and-braces.
+// It deliberately under-detects rather than false-reject because a false reject here blocks every build.
+export function assertNoHostGlobalSelectors(css) {
+  const source = stripUnquotedUrls(stripStrings(stripComments(css)))
+  const offenders = new Set()
+
+  for (const token of ['#system-mobile-kb', '#mobile-kb', '#app-root', ':root']) {
+    if (source.includes(token)) offenders.add(token)
+  }
+  for (const token of ['html', 'body']) {
+    if (new RegExp(`(?<![\\w-])${token}(?![\\w-])`).test(source)) offenders.add(token)
+  }
+  if (offenders.size > 0) {
+    throw new Error(
+      `Builtin keyboard seed must contain only the plugin's own scoped SFC CSS; host-global selector tokens re-introduce host CSS into the seed payload: ${[...offenders].join(', ')}`
+    )
+  }
+}
+
+function buildSeed() {
+  const here = fileURLToPath(new URL('.', import.meta.url))
+  const outDir = fileURLToPath(new URL('../../../../seed/builtin-keyboard', import.meta.url))
+
+  mkdirSync(outDir, { recursive: true })
+
+  // Vite's emptyOutDir is unreliable when outDir is outside project root; clean
+  // stale artifacts (old PWA files, previous scoped.css) while preserving this
+  // build's output.
+  for (const entry of readdirSync(outDir)) {
+    if (entry === 'main.js' || entry === 'scoped.css') continue
+    rmSync(`${outDir}/${entry}`, { recursive: true, force: true })
+  }
+
+  const scopedCss = readFileSync(`${outDir}/scoped.css`, 'utf8')
+  const stylesPath = `${outDir}/styles.css`
+  writeFileSync(stylesPath, scopedCss)
+  assertNoHostGlobalSelectors(readFileSync(stylesPath, 'utf8'))
+
+  // scoped.css is an intermediate build product; the shipped styles file is styles.css.
+  rmSync(`${outDir}/scoped.css`, { force: true })
+
+  copyFileSync(`${here}/plugin.json`, `${outDir}/plugin.json`)
+
+  console.log(`seed/builtin-keyboard: ${outDir}`)
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  buildSeed()
+}

--- a/frontend/src/keyboard/builtin-keyboard/plugin.json
+++ b/frontend/src/keyboard/builtin-keyboard/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "builtin-keyboard",
   "name": "Builtin Keyboard",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Dinotty builtin mobile virtual keyboard (single-sourced in the host core; seed-shipped with the app)",
   "description_zh": "Dinotty 内置移动端虚拟键盘（宿主编译树单源，随 app seed 分发）",
   "category": "system",

--- a/frontend/src/test/builtinKeyboardSeedCss.test.ts
+++ b/frontend/src/test/builtinKeyboardSeedCss.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+
+// @ts-expect-error build-seed is an executable ESM script without a TypeScript declaration file.
+import { assertNoHostGlobalSelectors } from '../keyboard/builtin-keyboard/build-seed.mjs'
+
+describe('builtin keyboard seed host-global CSS tripwire', () => {
+  it('accepts realistic scoped SFC rules', () => {
+    const css = `
+      .suggestion-bar[data-v-d0382cf6] { display: flex; }
+      .keyboard[data-v-d0382cf6] .key[data-v-d0382cf6] { min-width: 2rem; }
+      @media (max-width: 600px) {
+        .suggestion[data-v-d0382cf6]:is(.active, .wide) { color: var(--text-color); }
+      }
+    `
+
+    expect(() => assertNoHostGlobalSelectors(css)).not.toThrow()
+  })
+
+  it.each([
+    ['#system-mobile-kb', '#system-mobile-kb { position: relative; }'],
+    ['#mobile-kb', '#mobile-kb { display: grid; }'],
+    ['#app-root', '#app-root { min-height: 100%; }'],
+    ['html', 'html { font-size: 16px; }'],
+    ['body', 'body { margin: 0; }'],
+    [':root', ':root { --keyboard-height: 18rem; }'],
+  ])('rejects the host-global token %s and names it', (token, css) => {
+    expect(() => assertNoHostGlobalSelectors(css)).toThrowError(
+      new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    )
+  })
+
+  it('collects and names every host-global token found', () => {
+    const css = '#system-mobile-kb, #mobile-kb, #app-root, html, body, :root { color: red; }'
+
+    expect(() => assertNoHostGlobalSelectors(css)).toThrowError(
+      /#system-mobile-kb, #mobile-kb, #app-root, :root, html, body/
+    )
+  })
+
+  it.each(['.x[data-v-a1]{width:calc(2 * 1px)}', '.x[data-v-a1]{width:calc(2*1px)}'])(
+    'accepts calc multiplication: %s',
+    (css) => {
+      expect(() => assertNoHostGlobalSelectors(css)).not.toThrow()
+    }
+  )
+
+  it.each([
+    '.x[data-v-a1]{background:url(body-bg.png)}',
+    '.x[data-v-a1]{background:url(html-icon.svg)}',
+  ])('ignores host-global tokens in unquoted URLs: %s', (css) => {
+    expect(() => assertNoHostGlobalSelectors(css)).not.toThrow()
+  })
+
+  it('still rejects a body rule after stripping an unquoted URL containing body', () => {
+    const css = '.x[data-v-a1]{background:url(body-bg.png)} body { margin: 0 }'
+
+    expect(() => assertNoHostGlobalSelectors(css)).toThrowError(/body/)
+  })
+
+  it('does not match html or body inside longer CSS identifiers', () => {
+    const css = `
+      .mkb-body[data-v-a1] { display: flex; }
+      .x[data-v-a1] { --html-safe: 1; }
+    `
+
+    expect(() => assertNoHostGlobalSelectors(css)).not.toThrow()
+  })
+
+  it('ignores host-global tokens that appear only inside strings', () => {
+    expect(() => assertNoHostGlobalSelectors('.x[data-v-a1] { content: "body"; }')).not.toThrow()
+  })
+
+  it('still rejects a body rule after stripping a string containing body', () => {
+    const css = '.x[data-v-a1] { content: "body"; } body { margin: 0; }'
+
+    expect(() => assertNoHostGlobalSelectors(css)).toThrowError(/body/)
+  })
+
+  it.each([
+    String.raw`.key\,wide[data-v-a1] { color: red; }`,
+    '.key[data-v-a1] {}' + '\\',
+    String.raw`.key[data-v-a1] { content: "safe\"; }`,
+  ])('accepts escape edge cases: %s', (css) => {
+    expect(() => assertNoHostGlobalSelectors(css)).not.toThrow()
+  })
+
+  it('accepts a custom mixin block', () => {
+    expect(() =>
+      assertNoHostGlobalSelectors('@mixin --theme { --payload: { red }; }')
+    ).not.toThrow()
+  })
+
+  it('ignores html and body inside comments', () => {
+    const css = '/* html { color: red; } body { margin: 0; } */ .x[data-v-a1] { color: blue; }'
+
+    expect(() => assertNoHostGlobalSelectors(css)).not.toThrow()
+  })
+
+  it('rejects a host-global rule nested inside @media', () => {
+    const css = '@media (max-width: 600px) { #mobile-kb { display: block; } }'
+
+    expect(() => assertNoHostGlobalSelectors(css)).toThrowError(/#mobile-kb/)
+  })
+
+  it('rejects a host-global rule nested inside @keyframes', () => {
+    const css = '@keyframes reveal { from { opacity: 0; } body { opacity: 1; } }'
+
+    expect(() => assertNoHostGlobalSelectors(css)).toThrowError(/body/)
+  })
+})


### PR DESCRIPTION
The builtin-keyboard seed concatenates the host stylesheet `frontend/src/styles/mobile-keyboard.css` into the plugin payload. The plugin's `<style data-plugin-id="builtin-keyboard">` is injected **after** the core stylesheet at identical specificity, so every rule in that copy wins the cascade over the app's own. In effect the installed plugin, not the app bundle, decides the mobile keyboard's layout.

### Why this bites

It is invisible until the two drift — and they drift by construction. The copy is frozen at whatever the stylesheet said when the seed was last built; the app bundle moves on with every release.

The concrete failure I hit: an installed seed still carried `#system-mobile-kb { position: relative }` from an older toolbar design, while the shipped app had moved to `position: fixed` with the app root subtracting the toolbar's measured height. Each design is self-consistent on its own. Together, the app reserved a band and the stale rule made sure nothing occupied it, leaving a blank strip exactly the toolbar's height below the terminal on phones using the system IME.

### The change

The seed now ships only the plugin's own scoped SFC CSS.

A build-time tripwire rejects a payload carrying host global selectors, scanning comment-, string- and url-stripped source.

It deliberately **under-detects** rather than risk a false reject. That direction is chosen, not conceded: a build-blocking guard that false-rejects stops every build of the repository, and actually proving every selector is scoped needs a real CSS parser this package does not carry — a substring test for the scope attribute does not, since Vue compiles `:global(...)` away without injecting a scope id. The universal selector is not checked for the same reason: without a parser it is indistinguishable from `calc()` multiplication, and the seed already ships `calc()`.

What actually closes the class is that the concatenation is gone. The assertion is belt-and-braces and is sized like it.

`plugin.json` goes `0.1.0` → `0.1.1` because the installed-version comparison refuses a rebuild that is not strictly newer. Without the bump, the corrected seed is rebuilt and then discarded on every start, and the stale copy stays installed forever.

### Testing

- `builtinKeyboardSeedCss.test.ts`, 23 cases: the tripwire's positives and negatives, comment/string/url stripping, and escape handling.
- `npm run build` green — the seed step runs as part of it and produces no diff to any tracked file.
- Full frontend suite on this branch: 1331 passed, 15 failed. **All 15 failures are `src/test/OverlayDragItem.test.ts` and are pre-existing on `dev`** — reproduced on a clean checkout of `dev` at `8b644d9` with none of this change present, same 15. Nothing here touches that file.
- `prettier --check` clean.
