### PR TITLE
fix(mobile): stop reserving the bottom inset while the keyboard covers it

### DIFF
--- a/frontend/src/styles/mobile-keyboard.css
+++ b/frontend/src/styles/mobile-keyboard.css
@@ -590,7 +590,14 @@
   flex-direction: column;
   box-sizing: border-box;
   gap: 4px;
-  padding: 5px max(5px, env(safe-area-inset-right)) max(8px, env(safe-area-inset-bottom))
+  /* The bottom inset is reserved only while it is actually exposed. This toolbar is fixed to
+   * the keyboard edge, so once the keyboard is up it covers the home indicator and reserving
+   * its inset costs terminal height for space nothing can occupy. --sys-kb-height is the
+   * measured occlusion, 0px whenever nothing occludes, so with the keyboard down the
+   * expression is identical to max(8px, env(safe-area-inset-bottom)). The var() fallback
+   * matters because useViewportResize's teardown removes the property rather than zeroing it. */
+  padding: 5px max(5px, env(safe-area-inset-right))
+    max(8px, calc(env(safe-area-inset-bottom, 0px) - var(--sys-kb-height, 0px)))
     max(5px, env(safe-area-inset-left));
   border-top: 1px solid color-mix(in srgb, var(--border), white 7%);
   background: color-mix(in srgb, var(--bg-surface), black 4%);

--- a/frontend/src/test/SystemKeyboardToolbar.test.ts
+++ b/frontend/src/test/SystemKeyboardToolbar.test.ts
@@ -86,6 +86,8 @@ describe('SystemKeyboardToolbar', () => {
     expect(toolbarRule).toMatch(/bottom:\s*var\(--system-toolbar-bottom,\s*0px\)/)
     expect(toolbarPadding).toContain('8px')
     expect(toolbarPadding).toContain('safe-area-inset-bottom')
+    // Reserving the inset under an open keyboard costs height for covered space.
+    expect(toolbarPadding).toContain('--sys-kb-height')
     // The frozen toolbar must not own geometry: the host owns both the height
     // band (--mkb-height via useKeyboardBand 'auto') and passes the terminal
     // IME focus into the viewport composable that writes the bottom offset.


### PR DESCRIPTION
With `viewport-fit=cover` set in `index.html`, `env(safe-area-inset-bottom)` resolves to the home-indicator height on iPhone. `#system-mobile-kb` reserves it unconditionally as its bottom padding.

But this toolbar is fixed to the **keyboard edge**, not to the screen. While the native IME is up, `--system-toolbar-bottom` lifts the toolbar so its bottom sits at the top of the keyboard — and the home indicator is underneath the keyboard, not underneath the toolbar. The reserved strip ends up behind the keyboard, where nothing can occupy it.

It is not free space, either. The toolbar's measured height is published as `--mkb-height` (via `getBoundingClientRect().height`, which includes its own padding) and `#app-root` subtracts that from its height. Every pixel reserved there is a pixel of terminal.

### The change

The bottom component subtracts the measured occlusion:

```css
max(8px, calc(env(safe-area-inset-bottom, 0px) - var(--sys-kb-height, 0px)))
```

`--sys-kb-height` is written by `useViewportResize` and is `0px` whenever nothing occludes, so:

| state | resolves to | vs today |
|---|---|---|
| keyboard down, iPhone | `max(8px, inset - 0px)` | identical |
| keyboard down, inset 0 (desktop, most browsers) | `8px` | identical |
| external keyboard / mid-dismissal (`.ime-open` true, occlusion 0) | `max(8px, inset)` | identical — the inset is genuinely exposed here, and is kept |
| keyboard up, iPhone | `8px` | ~26px of terminal height recovered |

Nothing changes while the keyboard is closed, on any platform. Nothing changes anywhere the inset is already 0.

The `var()` fallback is load-bearing rather than defensive: `useViewportResize`'s teardown calls `removeProperty` rather than setting `0px`, and an unresolvable `var()` with no fallback makes the whole declaration invalid at computed-value time — which would drop the padding entirely rather than fall back to it.

The `8px` floor keeps the value sane when the subtraction goes negative.

### Testing

- `SystemKeyboardToolbar.test.ts`: its two existing padding assertions still hold, plus one new one locking the subtraction. 18/18 green.
- `vue-tsc --noEmit` clean, `prettier --check` clean.
- Full frontend suite: 1308 passed, 15 failed. **All 15 are `src/test/OverlayDragItem.test.ts` and are pre-existing on `dev`** — reproduced on a clean checkout of `dev` at `8b644d9` with none of this change present, same 15. Nothing here touches that file.

### What is not proven here, stated plainly

The mechanism above is derived from the CSS and from `useViewportResize`'s own writes, and the arithmetic is checked in the test. What I verified **on a physical iPhone** was a fork-local variant that flattens the padding in both keyboard states — a different expression, chosen there for an unrelated reason. This exact expression has not been run on a device. It is a strict no-op with the keyboard down, so the risk is bounded to the open-keyboard case, but I would rather say so than let the testing section imply more than it should.
