### PR TITLE
fix(mobile): stop reserving the bottom safe-area inset in the system keyboard toolbar

### DIFF
--- a/frontend/src/styles/mobile-keyboard.css
+++ b/frontend/src/styles/mobile-keyboard.css
@@ -590,15 +590,13 @@
   flex-direction: column;
   box-sizing: border-box;
   gap: 4px;
-  /* The bottom inset is reserved only while it is actually exposed. This toolbar is fixed to
-   * the keyboard edge, so once the keyboard is up it covers the home indicator and reserving
-   * its inset costs terminal height for space nothing can occupy. --sys-kb-height is the
-   * measured occlusion, 0px whenever nothing occludes, so with the keyboard down the
-   * expression is identical to max(8px, env(safe-area-inset-bottom)). The var() fallback
-   * matters because useViewportResize's teardown removes the property rather than zeroing it. */
-  padding: 5px max(5px, env(safe-area-inset-right))
-    max(8px, calc(env(safe-area-inset-bottom, 0px) - var(--sys-kb-height, 0px)))
-    max(5px, env(safe-area-inset-left));
+  /* The bottom inset is deliberately not reserved. In persistent toolbar mode with the
+   * keyboard down this bar docks at the screen bottom, and useKeyboardBand publishes its
+   * measured border-box height as --mkb-height, which the app root subtracts from the
+   * terminal viewport - so the inset is charged to terminal height for the whole session,
+   * not just while the bar is in use. An 8px floor keeps the controls off the very edge.
+   * The left/right insets stay: they cost no vertical space. */
+  padding: 5px max(5px, env(safe-area-inset-right)) 8px max(5px, env(safe-area-inset-left));
   border-top: 1px solid color-mix(in srgb, var(--border), white 7%);
   background: color-mix(in srgb, var(--bg-surface), black 4%);
   box-shadow: 0 -8px 28px rgba(0, 0, 0, 0.22);

--- a/frontend/src/test/SystemKeyboardToolbar.test.ts
+++ b/frontend/src/test/SystemKeyboardToolbar.test.ts
@@ -84,9 +84,14 @@ describe('SystemKeyboardToolbar', () => {
     const toolbarPadding = toolbarRule.match(/padding:\s*([^;]+);/s)?.[1] ?? ''
     expect(toolbarRule).toMatch(/position:\s*fixed/)
     expect(toolbarRule).toMatch(/bottom:\s*var\(--system-toolbar-bottom,\s*0px\)/)
-    expect(toolbarPadding).toContain('8px')
-    // The bottom inset is deliberately absent: the toolbar's border-box height is subtracted
-    // from the terminal viewport, so reserving it would cost terminal height in every session.
+    // Pin all four shorthand values. `toContain('8px')` alone is too weak: it still passes
+    // if the bottom value regresses to 0 while 8px turns up in some other position. The
+    // bottom inset is deliberately absent - the toolbar's border-box height is subtracted
+    // from the terminal viewport, so reserving it would cost terminal height in every
+    // session.
+    expect(toolbarPadding.replace(/\s+/g, ' ').trim()).toBe(
+      '5px max(5px, env(safe-area-inset-right)) 8px max(5px, env(safe-area-inset-left))'
+    )
     expect(toolbarPadding).not.toContain('safe-area-inset-bottom')
     expect(toolbarPadding).not.toContain('--sys-kb-height')
     // The frozen toolbar must not own geometry: the host owns both the height

--- a/frontend/src/test/SystemKeyboardToolbar.test.ts
+++ b/frontend/src/test/SystemKeyboardToolbar.test.ts
@@ -85,9 +85,10 @@ describe('SystemKeyboardToolbar', () => {
     expect(toolbarRule).toMatch(/position:\s*fixed/)
     expect(toolbarRule).toMatch(/bottom:\s*var\(--system-toolbar-bottom,\s*0px\)/)
     expect(toolbarPadding).toContain('8px')
-    expect(toolbarPadding).toContain('safe-area-inset-bottom')
-    // Reserving the inset under an open keyboard costs height for covered space.
-    expect(toolbarPadding).toContain('--sys-kb-height')
+    // The bottom inset is deliberately absent: the toolbar's border-box height is subtracted
+    // from the terminal viewport, so reserving it would cost terminal height in every session.
+    expect(toolbarPadding).not.toContain('safe-area-inset-bottom')
+    expect(toolbarPadding).not.toContain('--sys-kb-height')
     // The frozen toolbar must not own geometry: the host owns both the height
     // band (--mkb-height via useKeyboardBand 'auto') and passes the terminal
     // IME focus into the viewport composable that writes the bottom offset.


### PR DESCRIPTION
Follow-up to #275, which dropped the bottom safe-area reservation *while the
keyboard is open*. This drops the other half: the reservation while it is closed.

### What happens today

`#system-mobile-kb` reserves its bottom padding as:

    max(8px, calc(env(safe-area-inset-bottom, 0px) - var(--sys-kb-height, 0px)))

Keyboard open — `--sys-kb-height` exceeds the inset, so this collapses to `8px`.
That is #275 working as intended.

Keyboard closed — `--sys-kb-height` is `0px`, so the expression is
`max(8px, env(safe-area-inset-bottom))`, i.e. 34px on current iPhones.

### Why the closed-keyboard case costs terminal height

The toolbar's padding is not free space. `useAppKeyboard` runs `useKeyboardBand`
with `desiredHeight: 'auto'` and `hostRef` pointing at the toolbar, so the band
measures the toolbar's **border-box** height — padding included — and writes it to
`--mkb-height` (`useKeyboardBand.ts:31`). `#app-root` subtracts it (`App.vue:794`):

    100% - max(0px, var(--mkb-height, 0px) - var(--kb-overlap, 0px)) - var(--sys-kb-height, 0px)

In `system_toolbar_mode: 'persistent_mobile'` the toolbar stays visible with the
keyboard down (`useAppCore.ts:138`), so those 34px are charged to the terminal
viewport for the whole session — not only while the bar is in use. On a 812pt-tall
iPhone that is 26px of terminal permanently spent on padding beneath a bar nobody
is touching.

(In the default toolbar mode the bar unmounts when the keyboard closes, so
`--mkb-height` is 0 and the reservation costs nothing. This change only affects
persistent mode.)

### The change

Flat `8px` — what the expression already collapses to whenever the keyboard is open:

    padding: 5px max(5px, env(safe-area-inset-right)) 8px max(5px, env(safe-area-inset-left));

Left/right insets unchanged; they cost no vertical space.

### The trade-off, stated plainly

This does bring the toolbar's bottom row closer to the home indicator. The lowest
interactive elements are the page dots (`.system-kb-page-dots`, real `<button>`s),
which end up roughly 8px above the screen edge instead of roughly 42px.

We have been running the flat value in a fork and checked it on an iPhone with the
app installed to the home screen: the dots stayed comfortable to hit and the
reduced clearance was not a problem in use. That is one device and one pair of
hands, so it is evidence rather than proof — if you would rather keep the
clearance, a "no" here is entirely reasonable and I will not push back.

`SystemKeyboardToolbar.test.ts` is updated to assert the inset is absent rather
than present.

### CI note

The 15 failing tests in `src/test/OverlayDragItem.test.ts` are present on `dev`
before this change; nothing in this PR touches that file.
