### PR TITLE
fix(desktop): register plugin workspace routes in embedded server

### DIFF
--- a/src-tauri/src/embedded_server/router.rs
+++ b/src-tauri/src/embedded_server/router.rs
@@ -169,6 +169,15 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/plugins/:id/events/subscribe", post(plugin::subscribe))
         .route("/api/plugins/:id/events/unsubscribe", post(plugin::unsubscribe))
         .route("/api/plugins/events/has-subscriber", get(plugin::has_subscriber))
+
+        .route("/api/plugins/:id/workspace/readDir", get(plugin::plugin_workspace_read_dir))
+        .route("/api/plugins/:id/workspace/readFile", get(plugin::plugin_workspace_read_file))
+        .route("/api/plugins/:id/workspace/file", put(plugin::plugin_workspace_put_file))
+        .route("/api/plugins/:id/workspace/stat", get(plugin::plugin_workspace_stat))
+        .route("/api/plugins/:id/workspace/mkdir", post(plugin::plugin_workspace_mkdir))
+        .route("/api/plugins/:id/workspace/delete", delete(plugin::plugin_workspace_delete))
+        .route("/api/plugins/:id/workspace/rename", post(plugin::plugin_workspace_rename))
+        .route("/api/plugins/:id/workspace/move", post(plugin::plugin_workspace_move))
         .route("/api/plugins/:id/*path", get(plugin::plugin_asset))
         // Sessions extended API (run/send/read/events) + Token management + MCP
         // - dual-track auth via sessions_token_middleware


### PR DESCRIPTION
## 问题

桌面 APP 里插件调用 `ctx.workspace.*`（readFile / writeFile / stat 等）一律 405，而同样的操作对源码运行的独立服务器正常。

## 根因

0b66466d 为插件新增 workspace 文件 API 时，只把 `/api/plugins/:id/workspace/*` 路由注册到了独立服务器 `src/main.rs`，未改 src-tauri。桌面 APP 的 REST 由 `src-tauri/src/embedded_server/router.rs` 自建，请求落到老的通配资产路由 `GET /api/plugins/:id/*path` 上，非 GET 方法即 405。该缺口在源码里，重建 APP 也无法解决。

## 修复

在 embedded router 中注册 8 条 workspace 路由（readDir / readFile / file / stat / mkdir / delete / rename / move），与 `src/main.rs:560-567` 镜像。handler 本就在共享 crate `dinotty-server` 的 `plugin::workspace` 模块中（桌面 crate 为 path 依赖），纯接线、无新逻辑。

watch WS 路由（`/ws/plugins/:id/workspace/watch`）暂未加：需要 ConnectInfo / FileWatcherState 额外接线，且当前无插件使用。

## 验证

- `cargo check -p dinotty-desktop` 通过，`cargo tauri build --bundles app` 构建成功
