### PR TITLE
release: v0.24.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1615,7 +1615,7 @@ dependencies = [
 
 [[package]]
 name = "dinotty-desktop"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
@@ -1654,7 +1654,7 @@ dependencies = [
 
 [[package]]
 name = "dinotty-server"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "arboard",
  "axum 0.7.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["src-tauri"]
 
 [workspace.package]
-version = "0.24.0"
+version = "0.24.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/xichan96/dinotty"

--- a/frontend/src/composables/useTerminal.ts
+++ b/frontend/src/composables/useTerminal.ts
@@ -36,6 +36,7 @@ import {
   type MobileTerminalModifiers,
 } from '../utils/terminalInput'
 import { createTerminalWheel, type TerminalWheel } from './useTerminalWheel'
+import { attachImeHeuristic } from '../utils/imeAnchor'
 import { setupTerminalDrop } from './useTerminalDrop'
 import { createTerminalOverlay } from './useTerminalOverlay'
 import { t } from './useI18n'
@@ -146,6 +147,9 @@ export class TerminalInstance {
   private _suppressTitleChange = false
   private _touchCleanup: (() => void) | null = null
   private _compositionCleanup: (() => void) | null = null
+  // Pins the IME textarea/composition-view to Ink's inverse caret cell while
+  // composing (Windows ConPTY cursor drift). Detached in destroy().
+  private _imeAnchorDetach: { detach(): void } | null = null
   private _resizeObserver: ResizeObserver | null = null
   private _themeUnsub: (() => void) | null = null
   private _textUnsub: (() => void) | null = null
@@ -320,6 +324,11 @@ export class TerminalInstance {
     this.xterm.loadAddon(this.fitAddon)
 
     this.xterm.open(wrapper)
+
+    // Anchor the IME preedit/candidate window to Ink's fake caret (a lone
+    // inverse cell) instead of the hardware cursor, which Claude Code on
+    // Windows ConPTY leaves at the right edge of the status row (#276).
+    this._imeAnchorDetach = attachImeHeuristic(this.xterm)
 
     // Ctrl+Shift+C/V: Linux-style copy/paste (macOS uses Cmd+C/V natively)
     const xt = this.xterm
@@ -1034,6 +1043,8 @@ export class TerminalInstance {
     this._wheel = null
     this._touchCleanup?.()
     this._compositionCleanup?.()
+    this._imeAnchorDetach?.detach()
+    this._imeAnchorDetach = null
     this._clearIme229()
     this._inputTextarea = null
     this._dropCleanup?.()

--- a/frontend/src/utils/__tests__/imeAnchor.spec.ts
+++ b/frontend/src/utils/__tests__/imeAnchor.spec.ts
@@ -1,0 +1,328 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { Terminal } from '@xterm/xterm'
+import {
+  attachImeHeuristic,
+  computeCellSize,
+  findInverseCell,
+  resolveImeAnchor,
+} from '../imeAnchor'
+
+type CellMark = 'inv' | 'norm'
+
+// Pure scan tests use a fake buffer; the real IBuffer is structurally
+// compatible with this shape (see ImeBufferScan in imeAnchor.ts).
+function fakeLine(cells: CellMark[]) {
+  return {
+    length: cells.length,
+    getCell(x: number) {
+      const c = cells[x]
+      if (c === undefined) return undefined
+      return { isInverse: () => (c === 'inv' ? 1 : 0) }
+    },
+  }
+}
+
+function fakeBuffer(lines: CellMark[][], viewportY = 0) {
+  const rows = lines.map(fakeLine)
+  return {
+    viewportY,
+    getLine: (y: number) => rows[y],
+  }
+}
+
+describe('findInverseCell (scan order and isolation)', () => {
+  it('returns the lone inverse cell with viewport-relative row', () => {
+    const buf = fakeBuffer(
+      [
+        ['norm', 'norm', 'norm'],
+        ['norm', 'inv', 'norm'],
+        ['norm', 'norm', 'norm'],
+      ],
+      1
+    )
+    // Absolute buffer row 1 is viewport row 0 when viewportY = 1.
+    expect(findInverseCell(buf, 3)).toEqual({ col: 1, row: 0 })
+  })
+
+  it('scans bottom-up: the lowest inverse cell wins', () => {
+    const buf = fakeBuffer([
+      ['inv', 'norm', 'norm'],
+      ['norm', 'norm', 'norm'],
+      ['norm', 'inv', 'norm'],
+    ])
+    expect(findInverseCell(buf, 3)).toEqual({ col: 1, row: 2 })
+  })
+
+  it('scans right-to-left: the rightmost inverse cell wins on a row', () => {
+    const buf = fakeBuffer([['norm', 'inv', 'norm', 'inv', 'norm']])
+    expect(findInverseCell(buf, 1)).toEqual({ col: 3, row: 0 })
+  })
+
+  it('skips a cell whose BOTH neighbours are inverse (selection bar)', () => {
+    // Row of three inverse cells = highlight row; the middle must be skipped,
+    // and the isolated cell on the row above is the real caret.
+    const buf = fakeBuffer([
+      ['norm', 'norm', 'inv', 'norm', 'norm'],
+      ['inv', 'inv', 'inv', 'inv', 'inv'],
+    ])
+    expect(findInverseCell(buf, 2)).toEqual({ col: 2, row: 0 })
+  })
+
+  it('skips a run at the line edge (non-isolated), returning null', () => {
+    // A caret must be a LONE inverse cell: a run of two (or more) inverse cells
+    // at the edge is a highlight/selection run, so no anchor from this row.
+    const buf = fakeBuffer([['norm', 'inv', 'inv']])
+    expect(findInverseCell(buf, 1)).toBeNull()
+  })
+
+  it('keeps a caret at column 0 (no left neighbour, normal right neighbour)', () => {
+    const buf = fakeBuffer([['inv', 'norm', 'norm']])
+    expect(findInverseCell(buf, 1)).toEqual({ col: 0, row: 0 })
+  })
+
+  it('returns null when nothing is inverse', () => {
+    const buf = fakeBuffer([
+      ['norm', 'norm', 'norm'],
+      ['norm', 'norm', 'norm'],
+    ])
+    expect(findInverseCell(buf, 2)).toBeNull()
+  })
+
+  it('respects requireIsolatedCell=false', () => {
+    const buf = fakeBuffer([['inv', 'inv', 'inv']])
+    expect(findInverseCell(buf, 1, false)).toEqual({ col: 2, row: 0 })
+  })
+})
+
+describe('resolveImeAnchor (heuristic vs hardware fallback)', () => {
+  it('reports heuristic with the inverse-cell coords when found', () => {
+    expect(resolveImeAnchor({ col: 3, row: 1 }, { col: 9, row: 2 })).toEqual({
+      source: 'heuristic',
+      col: 3,
+      row: 1,
+    })
+  })
+
+  it('falls back to the hardware cursor when no inverse cell exists', () => {
+    expect(resolveImeAnchor(null, { col: 9, row: 2 })).toEqual({
+      source: 'hardware',
+      col: 9,
+      row: 2,
+    })
+  })
+})
+
+describe('computeCellSize (render-service cell vs rect fallback)', () => {
+  it('prefers the render-service CSS cell size (letter_spacing/line_height correct)', () => {
+    const screen = { getBoundingClientRect: () => ({ width: 900, height: 300 }) }
+    expect(computeCellSize(screen, 120, 30, { width: 8.5, height: 24 })).toEqual({ w: 8.5, h: 24 })
+  })
+
+  it('falls back to rect/cols division when the render cell is missing', () => {
+    const screen = { getBoundingClientRect: () => ({ width: 900, height: 300 }) }
+    expect(computeCellSize(screen, 120, 30)).toEqual({ w: 7.5, h: 10 })
+  })
+
+  it('guards against a zero render cell', () => {
+    const screen = { getBoundingClientRect: () => ({ width: 900, height: 300 }) }
+    expect(computeCellSize(screen, 120, 30, { width: 0, height: 0 })).toEqual({ w: 7.5, h: 10 })
+  })
+})
+
+// ── DOM integration ──────────────────────────────────────────────
+
+function makeDom() {
+  document.body.innerHTML = ''
+  const root = document.createElement('div')
+  root.className = 'xterm'
+  root.innerHTML = [
+    '<div class="xterm-screen"></div>',
+    '<div class="xterm-helpers">',
+    '  <textarea class="xterm-helper-textarea"></textarea>',
+    '  <div class="composition-view"></div>',
+    '</div>',
+  ].join('')
+  document.body.appendChild(root)
+  const textarea = root.querySelector('.xterm-helper-textarea') as HTMLTextAreaElement
+  const compositionView = root.querySelector('.composition-view') as HTMLElement
+  return { root, textarea, compositionView }
+}
+
+function setup(opts: {
+  lines: CellMark[][]
+  rows?: number
+  cols?: number
+  viewportY?: number
+  cursorX?: number
+  cursorY?: number
+  cellW?: number
+  cellH?: number
+}) {
+  const dom = makeDom()
+  const rows = opts.rows ?? 3
+  const cols = opts.cols ?? 10
+  const lines = opts.lines.map(fakeLine)
+  let renderCb: (() => void) | null = null
+  const buffer = {
+    viewportY: opts.viewportY ?? 0,
+    cursorX: opts.cursorX ?? 0,
+    cursorY: opts.cursorY ?? 0,
+    getLine: (y: number) => lines[y],
+  }
+  const terminal = {
+    element: dom.root,
+    cols,
+    rows,
+    buffer: { active: buffer },
+    onRender(cb: () => void) {
+      renderCb = cb
+      return {
+        dispose() {
+          renderCb = null
+        },
+      }
+    },
+    _core: {
+      _renderService: {
+        dimensions: {
+          css: { cell: { width: opts.cellW ?? 8, height: opts.cellH ?? 20 } },
+        },
+      },
+    },
+  }
+  return {
+    ...dom,
+    terminal,
+    buffer,
+    setLine: (y: number, cells: CellMark[]) => {
+      lines[y] = fakeLine(cells)
+    },
+    fireRender: () => renderCb?.(),
+  }
+}
+
+const tick = () => new Promise((r) => setTimeout(r, 0))
+
+describe('attachImeHeuristic (DOM integration)', () => {
+  it('pins textarea + composition-view to the inverse cell with !important', () => {
+    const { terminal, textarea, compositionView, buffer } = setup({
+      lines: [
+        ['norm', 'norm', 'norm'],
+        ['norm', 'norm', 'inv', 'norm'],
+        ['norm', 'norm', 'norm'],
+      ],
+      cellW: 8,
+      cellH: 20,
+    })
+    const onAnchor = vi.fn()
+    attachImeHeuristic(terminal as unknown as Terminal, { onAnchor })
+    textarea.dispatchEvent(new Event('compositionstart'))
+
+    // col=2 -> left 16px, row=1 -> top 20px (viewport-relative)
+    expect(textarea.style.getPropertyValue('left')).toBe('16px')
+    expect(textarea.style.getPropertyPriority('left')).toBe('important')
+    expect(textarea.style.getPropertyValue('top')).toBe('20px')
+    expect(textarea.style.getPropertyPriority('top')).toBe('important')
+    expect(compositionView.style.getPropertyValue('left')).toBe('16px')
+    expect(compositionView.style.getPropertyValue('top')).toBe('20px')
+    expect(onAnchor).toHaveBeenCalledWith({ source: 'heuristic', col: 2, row: 1 })
+    expect(buffer.cursorX).not.toBe(2) // sanity: cursor was somewhere else
+  })
+
+  it('re-applies the pin when xterm overwrites the style during composition', async () => {
+    const { terminal, textarea } = setup({
+      lines: [['norm', 'inv', 'norm', 'norm']],
+      cellW: 10,
+      cellH: 20,
+    })
+    attachImeHeuristic(terminal as unknown as Terminal)
+    textarea.dispatchEvent(new Event('compositionstart'))
+    expect(textarea.style.getPropertyValue('left')).toBe('10px')
+
+    textarea.style.left = '0px' // simulate xterm's recursive setTimeout write
+    await tick()
+    expect(textarea.style.getPropertyValue('left')).toBe('10px')
+    expect(textarea.style.getPropertyPriority('left')).toBe('important')
+  })
+
+  it('falls back to the hardware cursor (no style pin) when no inverse cell exists', () => {
+    const { terminal, textarea, compositionView } = setup({
+      lines: [
+        ['norm', 'norm', 'norm'],
+        ['norm', 'norm', 'norm'],
+        ['norm', 'norm', 'norm'],
+      ],
+      cursorX: 7,
+      cursorY: 2,
+    })
+    const onAnchor = vi.fn()
+    attachImeHeuristic(terminal as unknown as Terminal, { onAnchor })
+    textarea.dispatchEvent(new Event('compositionstart'))
+
+    expect(onAnchor).toHaveBeenCalledWith({ source: 'hardware', col: 7, row: 2 })
+    expect(textarea.style.getPropertyValue('left')).toBe('')
+    expect(compositionView.style.getPropertyValue('top')).toBe('')
+  })
+
+  it('follows the caret on render (IME partial commit) but keeps the last pin if it transiently disappears', () => {
+    const { terminal, textarea, setLine, fireRender } = setup({
+      lines: [
+        ['norm', 'norm', 'norm'],
+        ['norm', 'norm', 'norm', 'norm', 'norm', 'inv', 'norm'],
+        ['norm', 'norm', 'norm'],
+      ],
+      cellW: 8,
+      cellH: 20,
+    })
+    attachImeHeuristic(terminal as unknown as Terminal)
+    textarea.dispatchEvent(new Event('compositionstart'))
+    expect(textarea.style.getPropertyValue('left')).toBe('40px') // col 5
+
+    // Ink redraws the caret one cell right mid-composition.
+    setLine(1, ['norm', 'norm', 'norm', 'norm', 'norm', 'norm', 'inv', 'norm'])
+    fireRender()
+    expect(textarea.style.getPropertyValue('left')).toBe('48px') // col 6
+
+    // Transient clear-then-redraw: no inverse cell this tick -> keep last pin.
+    setLine(1, ['norm', 'norm', 'norm', 'norm', 'norm', 'norm', 'norm', 'norm'])
+    fireRender()
+    expect(textarea.style.getPropertyValue('left')).toBe('48px')
+  })
+
+  it('stops re-pinning after compositionend', async () => {
+    const { terminal, textarea } = setup({
+      lines: [['norm', 'inv', 'norm', 'norm']],
+      cellW: 10,
+      cellH: 20,
+    })
+    attachImeHeuristic(terminal as unknown as Terminal)
+    textarea.dispatchEvent(new Event('compositionstart'))
+    expect(textarea.style.getPropertyValue('left')).toBe('10px')
+
+    textarea.dispatchEvent(new Event('compositionend'))
+    textarea.style.left = '5px'
+    await tick()
+    expect(textarea.style.getPropertyValue('left')).toBe('5px')
+  })
+
+  it('detach removes listeners, observers, and the render subscription', () => {
+    const { terminal, textarea, fireRender } = setup({
+      lines: [['norm', 'inv', 'norm', 'norm']],
+      cellW: 10,
+      cellH: 20,
+    })
+    const attached = attachImeHeuristic(terminal as unknown as Terminal)
+    textarea.dispatchEvent(new Event('compositionstart'))
+    expect(textarea.style.getPropertyValue('left')).toBe('10px')
+
+    attached.detach()
+    // Listener removed: a fresh compositionstart must not re-pin.
+    textarea.style.removeProperty('left')
+    textarea.dispatchEvent(new Event('compositionstart'))
+    expect(textarea.style.getPropertyValue('left')).toBe('')
+
+    // Render subscription disposed: firing a render must not re-pin.
+    fireRender()
+    expect(textarea.style.getPropertyValue('left')).toBe('')
+  })
+})

--- a/frontend/src/utils/imeAnchor.ts
+++ b/frontend/src/utils/imeAnchor.ts
@@ -1,0 +1,265 @@
+import type { Terminal } from '@xterm/xterm'
+
+// IME anchor heuristic ported from
+// https://github.com/msdshsk/xterm-ime-anchor (MIT).
+//
+// Problem: Ink-based TUIs (Claude Code, inkchat, …) don't cursor-park at the
+// input field after rendering, so the terminal's hardware cursor — and
+// therefore xterm.js's IME anchor — ends up at the wrong place (on Windows
+// ConPTY, typically the right edge / end of a status row). The preedit and
+// candidate window then anchor at the right edge and the UI appears to shift
+// left as the composed text grows.
+//
+// Observation: every Ink <TextInput> draws its caret as a single inverse-video
+// space (SGR 7 + ' ' + SGR 27) on the input row. That inverse cell reliably
+// marks the visual input position regardless of the hardware cursor.
+//
+// xterm.js's CompositionHelper owns TWO DOM elements that both need to be at
+// "where the user expects IME to appear":
+//   1. `.xterm-helper-textarea` — the hidden input that receives IME events.
+//      The browser anchors the IME candidate panel to this element.
+//   2. `.composition-view` — a visible <div> that xterm.js renders the preedit
+//      INTO, positioned absolutely inside `.xterm-helpers`.
+//
+// xterm's internal updateCompositionElements() writes style.left/top on both
+// elements every ~0 ms via setTimeout recursion while composing, always based
+// on buffer.x/y (the hardware cursor). We therefore:
+//   a) compute the anchor on compositionstart,
+//   b) pin both elements' left/top to that anchor with !important, and
+//   c) observe the style attribute of each and re-pin when xterm overwrites.
+//
+// Fall-through: if no inverse cell is in the visible viewport, we do nothing
+// and let xterm.js keep its default hardware-cursor anchor (correct for normal
+// shells, because shells naturally cursor-park after their prompt).
+
+export type ImeAnchor = {
+  source: 'heuristic' | 'hardware'
+  col: number
+  row: number
+}
+
+export type AttachOptions = {
+  onAnchor?: (a: ImeAnchor) => void
+  // If the inverse cell we're about to anchor on is adjacent to ANOTHER inverse
+  // cell, we've latched onto a highlight/selection run rather than an Ink caret
+  // (caret = one lone inverse cell). Default: true. The original xterm-ime-anchor
+  // checked `leftInv && rightInv` here, but in a right-to-left scan that is
+  // unreachable — the first inverse cell found always has a non-inverse right
+  // neighbour — so the selection-run skip never fired. Skipping on EITHER
+  // neighbour makes the run-skip actually work.
+  requireIsolatedCell?: boolean
+}
+
+export type Detached = { detach(): void }
+
+// Minimal structural slice of xterm's IBufferLine/IBuffer. The real xterm
+// types satisfy these, and a fake does too — so the pure scan below is
+// unit-testable without spinning up a terminal.
+export interface ImeBufferLineLike {
+  length: number
+  getCell(x: number): { isInverse(): number } | undefined
+}
+
+export interface ImeBufferScan {
+  viewportY: number
+  getLine(y: number): ImeBufferLineLike | undefined
+}
+
+// Scan the visible buffer for the lone inverse cell that marks an Ink caret.
+// Right-to-left, bottom-up: trailing caret indicators win over earlier
+// decorative inverse runs. Returns viewport-relative coordinates.
+export function findInverseCell(
+  buffer: ImeBufferScan,
+  rows: number,
+  requireIsolatedCell = true
+): { col: number; row: number } | null {
+  const startY = buffer.viewportY
+  for (let y = startY + rows - 1; y >= startY; y--) {
+    const line = buffer.getLine(y)
+    if (!line) continue
+    for (let x = line.length - 1; x >= 0; x--) {
+      const cell = line.getCell(x)
+      if (!cell || !cell.isInverse()) continue
+
+      if (requireIsolatedCell) {
+        const left = x > 0 ? line.getCell(x - 1) : null
+        const right = x + 1 < line.length ? line.getCell(x + 1) : null
+        const leftInv = !!left && !!left.isInverse()
+        const rightInv = !!right && !!right.isInverse()
+        // Not a lone caret -> highlight/selection run. Skip.
+        if (leftInv || rightInv) continue
+      }
+
+      return { col: x, row: y - startY }
+    }
+  }
+  return null
+}
+
+export function resolveImeAnchor(
+  hit: { col: number; row: number } | null,
+  hardwareCursor: { col: number; row: number }
+): ImeAnchor {
+  if (!hit) return { source: 'hardware', col: hardwareCursor.col, row: hardwareCursor.row }
+  return { source: 'heuristic', col: hit.col, row: hit.row }
+}
+
+export function computeCellSize(
+  screen: { getBoundingClientRect(): { width: number; height: number } },
+  cols: number,
+  rows: number,
+  renderCell?: { width: number; height: number }
+): { w: number; h: number } {
+  // Prefer the render service's CSS cell size — it accounts for
+  // letter_spacing/line_height, which a plain rect/cols division does not.
+  if (renderCell && renderCell.width > 0 && renderCell.height > 0) {
+    return { w: renderCell.width, h: renderCell.height }
+  }
+  const rect = screen.getBoundingClientRect()
+  return {
+    w: rect.width / Math.max(cols, 1),
+    h: rect.height / Math.max(rows, 1),
+  }
+}
+
+function renderCellSize(terminal: Terminal): { width: number; height: number } | null {
+  try {
+    const core = (
+      terminal as {
+        _core?: {
+          _renderService?: { dimensions?: { css?: { cell?: { width?: number; height?: number } } } }
+        }
+      }
+    )._core
+    const cell = core?._renderService?.dimensions?.css?.cell
+    if (cell && (cell.width ?? 0) > 0 && (cell.height ?? 0) > 0) {
+      return { width: cell.width as number, height: cell.height as number }
+    }
+  } catch {
+    /* fall through to rect-based estimate */
+  }
+  return null
+}
+
+export function attachImeHeuristic(terminal: Terminal, options: AttachOptions = {}): Detached {
+  const { onAnchor, requireIsolatedCell = true } = options
+
+  const root = terminal.element
+  if (!root) return { detach() {} }
+
+  // xterm.js stable DOM structure (since 4.x):
+  //   .xterm
+  //     .xterm-screen
+  //       .xterm-helpers
+  //         .xterm-helper-textarea   (hidden input for IME capture)
+  //         .composition-view        (visible div for preedit text)
+  const textarea = root.querySelector('.xterm-helper-textarea') as HTMLTextAreaElement | null
+  const screen = root.querySelector('.xterm-screen') as HTMLElement | null
+  const compositionView = root.querySelector('.composition-view') as HTMLElement | null
+
+  if (!textarea || !screen || !compositionView) {
+    return { detach() {} }
+  }
+
+  let composing = false
+  let pinned: { left: string; top: string } | null = null
+  let renderDisposable: { dispose(): void } | null = null
+
+  // A single MutationObserver routed at both elements — we re-apply whenever
+  // xterm's recursive setTimeout writes the hardware-cursor coordinates back.
+  const reapply = (el: HTMLElement) => {
+    if (!composing || !pinned) return
+    if (el.style.left !== pinned.left || el.style.top !== pinned.top) {
+      el.style.setProperty('left', pinned.left, 'important')
+      el.style.setProperty('top', pinned.top, 'important')
+    }
+  }
+  const moTa = new MutationObserver(() => reapply(textarea))
+  const moCv = new MutationObserver(() => reapply(compositionView))
+
+  const cellSize = () => {
+    const rc = renderCellSize(terminal)
+    return computeCellSize(screen, terminal.cols, terminal.rows, rc ?? undefined)
+  }
+
+  // Re-scan the buffer and update the pin. Called on compositionstart AND on
+  // every render while composing. The latter is required for IME partial
+  // commit: when the user keeps typing mid-conversion, the browser emits a
+  // compositionend+compositionstart pair; Ink hasn't redrawn yet at that
+  // instant (the just-committed text is still in flight to the PTY), so the
+  // caret's inverse cell is at the OLD position. A couple of render ticks
+  // later Ink redraws with the new caret — this handler follows it.
+  function recomputeAndPin() {
+    if (!composing) return
+
+    const hit = findInverseCell(terminal.buffer.active, terminal.rows, requireIsolatedCell)
+    if (!hit) {
+      // Don't reset `pinned` here: the buffer state between partial-commit
+      // render cycles can transiently lose the inverse cell (Ink sometimes
+      // clears-then-redraws). Keep the last known anchor until composition
+      // ends or a new inverse cell is found.
+      return
+    }
+
+    const { w, h } = cellSize()
+    const left = `${Math.round(hit.col * w)}px`
+    const top = `${Math.round(hit.row * h)}px`
+    if (pinned && pinned.left === left && pinned.top === top) return
+
+    pinned = { left, top }
+    textarea!.style.setProperty('left', left, 'important')
+    textarea!.style.setProperty('top', top, 'important')
+    compositionView!.style.setProperty('left', left, 'important')
+    compositionView!.style.setProperty('top', top, 'important')
+
+    onAnchor?.({ source: 'heuristic', col: hit.col, row: hit.row })
+  }
+
+  function onCompositionStart() {
+    composing = true
+
+    // Initial scan. If no inverse cell is present right now, fall through
+    // to xterm's hardware-cursor anchor (correct for normal shells).
+    const hit = findInverseCell(terminal.buffer.active, terminal.rows, requireIsolatedCell)
+    if (!hit) {
+      pinned = null
+      onAnchor?.({
+        source: 'hardware',
+        col: terminal.buffer.active.cursorX,
+        row: terminal.buffer.active.cursorY,
+      })
+    } else {
+      recomputeAndPin()
+    }
+
+    // Follow subsequent renders — catches the partial-commit case where Ink
+    // redraws its caret mid-composition.
+    renderDisposable = terminal.onRender(() => recomputeAndPin())
+  }
+
+  function onCompositionEnd() {
+    composing = false
+    pinned = null
+    renderDisposable?.dispose()
+    renderDisposable = null
+    // Let xterm.js take its natural position back on the next cursor tick.
+  }
+
+  textarea.addEventListener('compositionstart', onCompositionStart)
+  textarea.addEventListener('compositionend', onCompositionEnd)
+  moTa.observe(textarea, { attributes: true, attributeFilter: ['style'] })
+  moCv.observe(compositionView, { attributes: true, attributeFilter: ['style'] })
+
+  return {
+    detach() {
+      composing = false
+      pinned = null
+      renderDisposable?.dispose()
+      renderDisposable = null
+      textarea.removeEventListener('compositionstart', onCompositionStart)
+      textarea.removeEventListener('compositionend', onCompositionEnd)
+      moTa.disconnect()
+      moCv.disconnect()
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- fix(ime): anchor IME preedit to Ink's inverse caret (#276) — Windows 上中文输入法 preedit/候选窗锚到右侧边缘、画面左移
- chore: bump version to v0.24.1

## Test plan
- 前端全量 vitest 1374 通过(含 19 个 imeAnchor 用例)
- vue-tsc --noEmit、cargo check、eslint、prettier 全绿
- Windows 真机验证留给用户(worktree 为 macOS)