### PR TITLE
chore: bump version to v0.25.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1615,7 +1615,7 @@ dependencies = [
 
 [[package]]
 name = "dinotty-desktop"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
@@ -1654,7 +1654,7 @@ dependencies = [
 
 [[package]]
 name = "dinotty-server"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "arboard",
  "axum 0.7.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["src-tauri"]
 
 [workspace.package]
-version = "0.24.3"
+version = "0.25.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/xichan96/dinotty"


### PR DESCRIPTION
## Summary
- 版本号 v0.24.3 → v0.25.0（自 v0.24.3 含多个 feat，MINOR）
- 同步 Cargo.lock（dinotty-server / dinotty-desktop）

## 本次发布主要变更（#287 / #288）
- feat(plugin): 插件支持 floating window / split pane 两种打开方式，per-plugin open_modes 偏好
- feat(settings): per-plugin open_modes 偏好项
- style(settings): 插件偏好项收纳到卡片齿轮，工具栏/打开方式偏好调整
- perf(bootstrap): 懒加载 i18n 表与重面板；prefetch Monaco chunk
- refactor(overview/settings): 移动端工作区列表横向 chip、settings icon-only tabs
- style(test): plugin_prefs rustfmt（#288，CI 修复）

## Test plan
- [x] dev backend CI（fmt / clippy / tests）green
- [x] frontend build green